### PR TITLE
Hashing investigation

### DIFF
--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -104,7 +104,7 @@ class GenerateFiles(ComputationStep):
         {'name': 'disable_summarise_exposure', 'flag':'-S', 'default': False, 'type': str2bool, 'const':True, 'nargs':'?', 'help': 'Disables creation of an exposure summary report'},
         {'name': 'group_id_cols',              'flag':'-G', 'nargs':'+',                         'help': 'Columns from loc file to set group_id', 'default': GROUP_ID_COLS},
         {'name': 'lookup_multiprocessing',     'type': str2bool, 'const': False, 'nargs':'?',  'default': False, 'help': 'Flag to enable/disable lookup multiprocessing'},
-        {"name": "hashed_group_id",            "type": str2bool, "const": False, 'nargs':'?',  "default": False, "help": "Hashes the group_id in the items.bin"},
+        {"name": "hashed_group_id",            "type": str2bool, "const": True, 'nargs':'?',  "default": True, "help": "Hashes the group_id in the items.bin"},
 
         # Manager only options (pass data directy instead of filepaths)
         {'name': 'lookup_config'},

--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -104,7 +104,7 @@ class GenerateFiles(ComputationStep):
         {'name': 'disable_summarise_exposure', 'flag':'-S', 'default': False, 'type': str2bool, 'const':True, 'nargs':'?', 'help': 'Disables creation of an exposure summary report'},
         {'name': 'group_id_cols',              'flag':'-G', 'nargs':'+',                         'help': 'Columns from loc file to set group_id', 'default': GROUP_ID_COLS},
         {'name': 'lookup_multiprocessing',     'type': str2bool, 'const': False, 'nargs':'?',  'default': False, 'help': 'Flag to enable/disable lookup multiprocessing'},
-        {"name": "hashed_group_id",            "type": str2bool, "const": True, 'nargs':'?',  "default": True, "help": "Hashes the group_id in the items.bin"},
+        {"name": "hashed_group_id",            "type": str2bool, "const": False, 'nargs':'?',  "default": False, "help": "Hashes the group_id in the items.bin"},
 
         # Manager only options (pass data directy instead of filepaths)
         {'name': 'lookup_config'},

--- a/oasislmf/preparation/gul_inputs.py
+++ b/oasislmf/preparation/gul_inputs.py
@@ -333,7 +333,10 @@ def get_gul_input_items(
 
     # this block gets fired if the hash_group_ids is True
     else:
-        gul_inputs_df["group_id"] = (pd.util.hash_pandas_object(gul_inputs_df[group_id_cols]).to_numpy() >> 33)
+        para_chain = gul_inputs_df.drop_duplicates(subset=group_id_cols).reset_index(drop=True)
+        para_chain["group_id"] = pd.util.hash_pandas_object(para_chain[group_id_cols])
+        para_chain = para_chain[group_id_cols + ["group_id"]]
+        gul_inputs_df = pd.merge(gul_inputs_df, para_chain, how='left', left_on=group_id_cols, right_on=group_id_cols)
 
     gul_inputs_df['group_id'] = gul_inputs_df['group_id'].astype('uint32')
 

--- a/oasislmf/preparation/gul_inputs.py
+++ b/oasislmf/preparation/gul_inputs.py
@@ -279,7 +279,7 @@ def get_gul_input_items(
 
     # Concatenate chunks. Sort by index to preserve item_id order in generated outputs compared
     # to original code.
-    gul_inputs_df = pd.concat(gul_inputs_reformatted_chunks).sort_index().reset_index()
+    gul_inputs_df = pd.concat(gul_inputs_reformatted_chunks).sort_index().reset_index(drop=True, inplace=True)
     # Set default values and data types for BI coverage boolean, TIV, deductibles and limit
     dtypes = {
         **{t: 'uint8' for t in term_cols_ints + terms_ints},
@@ -333,10 +333,7 @@ def get_gul_input_items(
 
     # this block gets fired if the hash_group_ids is True
     else:
-        para_chain = gul_inputs_df.drop_duplicates(subset=group_id_cols).reset_index(drop=True)
-        para_chain["group_id"] = pd.util.hash_pandas_object(para_chain[group_id_cols])
-        para_chain = para_chain[group_id_cols + ["group_id"]]
-        gul_inputs_df = pd.merge(gul_inputs_df, para_chain, how='left', left_on=group_id_cols, right_on=group_id_cols)
+        gul_inputs_df["group_id"] = pd.util.hash_pandas_object(gul_inputs_df[group_id_cols])
 
     gul_inputs_df['group_id'] = gul_inputs_df['group_id'].astype('uint32')
 

--- a/oasislmf/preparation/gul_inputs.py
+++ b/oasislmf/preparation/gul_inputs.py
@@ -333,7 +333,7 @@ def get_gul_input_items(
 
     # this block gets fired if the hash_group_ids is True
     else:
-        gul_inputs_df["group_id"] = pd.util.hash_pandas_object(gul_inputs_df[group_id_cols])
+        gul_inputs_df["group_id"] = (pd.util.hash_pandas_object(gul_inputs_df[group_id_cols], index=False).to_numpy() >> 33)
 
     gul_inputs_df['group_id'] = gul_inputs_df['group_id'].astype('uint32')
 


### PR DESCRIPTION
This PR solves a bug for which the group_ids produced through hashing (with `hashed_group_id=True`) were different even if they should have been identical given the input parameters of the hashing function were identical.
This PR ensures that group_ids are are equal if the input parameters of the hashing function are identical.
