### PR TITLE
Implement multiplicative method for total loss computation and new `alloc_rule=3`

### DIFF
--- a/oasislmf/pytools/gul/core.py
+++ b/oasislmf/pytools/gul/core.py
@@ -127,17 +127,13 @@ def split_tiv_multiplicative(gulitems, tiv):
         gulitems (numpy.array[oasis_float]): array containing losses of all items.
         tiv (oasis_float): total insured value.
     """
-    # gulitems are in tiv units, so it's faster to use a `scale` factor rather than
-    # computing ratios for all gulitems
     Ngulitems = gulitems.shape[0]
-    scale = tiv**Ngulitems
     total_loss = 1.
     for i in range(Ngulitems):
-        total_loss *= tiv - gulitems[i]
+        total_loss *= 1. - gulitems[i] / tiv
 
-    total_loss = scale - total_loss
-    total_loss *= tiv / scale
-
+    total_loss = 1. - total_loss
+    total_loss *= tiv
     if total_loss > 0.:
         # back-allocate proportionally in any case (i.e., not only if total_loss > tiv)
         f = tiv / total_loss

--- a/oasislmf/pytools/gul/core.py
+++ b/oasislmf/pytools/gul/core.py
@@ -128,15 +128,17 @@ def split_tiv_multiplicative(gulitems, tiv):
         tiv (oasis_float): total insured value.
     """
     Ngulitems = gulitems.shape[0]
-    total_loss = 1.
+    undamaged_value = 1.
+    sum_loss = 0.
     for i in range(Ngulitems):
-        total_loss *= 1. - gulitems[i] / tiv
+        undamaged_value *= 1. - gulitems[i] / tiv
+        sum_loss += gulitems[i]
 
-    total_loss = 1. - total_loss
-    total_loss *= tiv
-    if total_loss > 0.:
+    multiplicative_loss = tiv * (1. - undamaged_value)
+
+    if sum_loss > 0.:
         # back-allocate proportionally in any case (i.e., not only if total_loss > tiv)
-        f = tiv / total_loss
+        f = multiplicative_loss / sum_loss
 
         for j in range(Ngulitems):
             # editing in-place the np array

--- a/oasislmf/pytools/gul/core.py
+++ b/oasislmf/pytools/gul/core.py
@@ -97,14 +97,14 @@ def setmaxloss(losses):
 
 
 @njit(cache=True, fastmath=True)
-def split_tiv(gulitems, tiv):
+def split_tiv_classic(gulitems, tiv):
     """Split the total insured value (TIV). If the total loss of all the items
     in `gulitems` exceeds the total insured value, re-scale the losses in the
     same proportion to the losses.
 
     Args:
         gulitems (numpy.array[oasis_float]): array containing losses of all items.
-        tiv (oasis_float): total insured value,
+        tiv (oasis_float): total insured value.
     """
     total_loss = np.sum(gulitems)
 
@@ -114,6 +114,32 @@ def split_tiv(gulitems, tiv):
         for j in range(gulitems.shape[0]):
             # editing in-place the np array
             gulitems[j] *= f
+
+
+@njit(cache=True, fastmath=True)
+def split_tiv_multiplicative(gulitems, tiv):
+    """Split the total insured value (TIV). If the total loss of all the items
+    in `gulitems` exceeds the total insured value, re-scale the losses in the
+    same proportion to the losses.
+
+    Args:
+        gulitems (numpy.array[oasis_float]): array containing losses of all items.
+        tiv (oasis_float): total insured value.
+    TODO: update docstring
+    """
+    total_loss = 1.
+    for i in range(len(gulitems.shape[0])):
+        total_loss *= 1. - gulitems[i] / tiv
+
+    total_loss = 1. - total_loss
+    total_loss *= tiv
+
+    # if total_loss > tiv:
+    f = tiv / total_loss
+
+    for j in range(gulitems.shape[0]):
+        # editing in-place the np array
+        gulitems[j] *= f
 
 
 @njit(cache=True, fastmath=True)

--- a/oasislmf/pytools/gul/manager.py
+++ b/oasislmf/pytools/gul/manager.py
@@ -146,7 +146,6 @@ def run(run_dir, ignore_file_type, sample_size, loss_threshold, alloc_rule, debu
     input_path = os.path.join(run_dir, 'input')
     ignore_file_type = set(ignore_file_type)
 
-
     damage_bins = get_damage_bins(static_path)
 
     # read coverages from file
@@ -160,7 +159,6 @@ def run(run_dir, ignore_file_type, sample_size, loss_threshold, alloc_rule, debu
             f'Peril specific run: ({peril_filter}), {len(valid_area_peril_id)} AreaPerilID included out of {len(keys_df)}')
     else:
         valid_area_peril_id = None
-
 
     # init the structure for computation
     # coverages are numbered from 1, therefore we skip element 0 in `coverages`
@@ -273,7 +271,7 @@ def compute_event_losses(event_id, coverages, coverage_ids, items_data,
         buff_size (int): size in bytes of the output buffer.
         int32_mv (numpy.ndarray): int32 view of the memoryview where the output is buffered.
         cursor (int): index of int32_mv where to start writing.
-        
+
     Returns:
         int, int, int: updated value of cursor, updated value of cursor_bytes, last last_processed_coverage_ids_idx
     """
@@ -382,7 +380,6 @@ def write_losses(event_id, sample_size, loss_threshold, losses, item_ids, alloc_
     if alloc_rule == 2:
         losses[1:] = setmaxloss(losses[1:])
 
-    # split tiv has to be executed after setmaxloss, if alloc_rule==2.
     if tiv > 0:
         # check whether the sum of losses-per-sample exceeds TIV
         # if so, split TIV in proportion to the losses

--- a/oasislmf/pytools/gul/manager.py
+++ b/oasislmf/pytools/gul/manager.py
@@ -392,8 +392,7 @@ def write_losses(event_id, sample_size, loss_threshold, losses, item_ids, alloc_
             for sample_i in range(1, losses.shape[0]):
                 split_tiv_classic(losses[sample_i], tiv)
 
-        else:
-            # alloc_rule == 3
+        elif alloc_rule == 3:
             # check whether the sum of losses-per-sample exceeds TIV
             # if so, split TIV in proportion to the losses
             for sample_i in range(1, losses.shape[0]):

--- a/oasislmf/pytools/gul/manager.py
+++ b/oasislmf/pytools/gul/manager.py
@@ -379,23 +379,22 @@ def write_losses(event_id, sample_size, loss_threshold, losses, item_ids, alloc_
     Returns:
         int: updated values of cursor
     """
-    # note that Nsamples = sample_size + NUM_IDX
-
     if alloc_rule == 2:
         losses[1:] = setmaxloss(losses[1:])
 
     # split tiv has to be executed after setmaxloss, if alloc_rule==2.
     if tiv > 0:
+        # check whether the sum of losses-per-sample exceeds TIV
+        # if so, split TIV in proportion to the losses
+
         if alloc_rule in [1, 2]:
-            # check whether the sum of losses-per-sample exceeds TIV
-            # if so, split TIV in proportion to the losses
-            for sample_i in range(1, losses.shape[0]):
+            # loop over all positive sidx samples
+            for sample_i in range(1, losses.shape[0] - 5):
                 split_tiv_classic(losses[sample_i], tiv)
 
         elif alloc_rule == 3:
-            # check whether the sum of losses-per-sample exceeds TIV
-            # if so, split TIV in proportion to the losses
-            for sample_i in range(1, losses.shape[0]):
+            # loop over all positive sidx samples
+            for sample_i in range(1, losses.shape[0] - 5):
                 split_tiv_multiplicative(losses[sample_i], tiv)
 
     # output the losses for all the items

--- a/oasislmf/pytools/gul/manager.py
+++ b/oasislmf/pytools/gul/manager.py
@@ -25,7 +25,7 @@ from oasislmf.pytools.gul.io import (
     write_sample_rec, read_getmodel_stream
 )
 from oasislmf.pytools.gul.random import get_random_generator
-from oasislmf.pytools.gul.core import split_tiv, get_gul, setmaxloss, compute_mean_loss
+from oasislmf.pytools.gul.core import split_tiv_classic, split_tiv_multiplicative, get_gul, setmaxloss, compute_mean_loss
 from oasislmf.pytools.gul.utils import append_to_dict_value, binary_search
 
 
@@ -385,11 +385,19 @@ def write_losses(event_id, sample_size, loss_threshold, losses, item_ids, alloc_
         losses[1:] = setmaxloss(losses[1:])
 
     # split tiv has to be executed after setmaxloss, if alloc_rule==2.
-    if alloc_rule >= 1 and tiv > 0:
-        # check whether the sum of losses-per-sample exceeds TIV
-        # if so, split TIV in proportion to the losses
-        for sample_i in range(1, losses.shape[0]):
-            split_tiv(losses[sample_i], tiv)
+    if tiv > 0:
+        if alloc_rule in [1, 2]:
+            # check whether the sum of losses-per-sample exceeds TIV
+            # if so, split TIV in proportion to the losses
+            for sample_i in range(1, losses.shape[0]):
+                split_tiv_classic(losses[sample_i], tiv)
+
+        else:
+            # alloc_rule == 3
+            # check whether the sum of losses-per-sample exceeds TIV
+            # if so, split TIV in proportion to the losses
+            for sample_i in range(1, losses.shape[0]):
+                split_tiv_multiplicative(losses[sample_i], tiv)
 
     # output the losses for all the items
     for item_j in range(item_ids.shape[0]):

--- a/oasislmf/pytools/gul/manager.py
+++ b/oasislmf/pytools/gul/manager.py
@@ -389,12 +389,12 @@ def write_losses(event_id, sample_size, loss_threshold, losses, item_ids, alloc_
 
         if alloc_rule in [1, 2]:
             # loop over all positive sidx samples
-            for sample_i in range(1, losses.shape[0] - 5):
+            for sample_i in range(1, losses.shape[0]):
                 split_tiv_classic(losses[sample_i], tiv)
 
         elif alloc_rule == 3:
             # loop over all positive sidx samples
-            for sample_i in range(1, losses.shape[0] - 5):
+            for sample_i in range(1, losses.shape[0]):
                 split_tiv_multiplicative(losses[sample_i], tiv)
 
     # output the losses for all the items

--- a/oasislmf/pytools/gul/manager.py
+++ b/oasislmf/pytools/gul/manager.py
@@ -209,8 +209,8 @@ def run(run_dir, ignore_file_type, sample_size, loss_threshold, alloc_rule, debu
         # set the random generator function
         generate_rndm = get_random_generator(random_generator)
 
-        if alloc_rule not in [0, 1, 2]:
-            raise ValueError(f"Expect alloc_rule to be 0 or 1 or 2, got {alloc_rule}")
+        if alloc_rule not in [0, 1, 2, 3]:
+            raise ValueError(f"Expect alloc_rule to be 0, 1, 2, or 3, got {alloc_rule}")
 
         cursor = 0
         cursor_bytes = 0

--- a/tests/pytools/gul/test_core.py
+++ b/tests/pytools/gul/test_core.py
@@ -32,8 +32,24 @@ class TestGulpyCore(TestCase):
         np.testing.assert_array_almost_equal(gulitems_orig * tiv / np.sum(gulitems_orig), gulitems, decimal=1e-14)
 
     def test_split_tiv_multiplicative(self) -> None:
-        # WIP
-        pass
+        Ngulitems = 10
+        tiv = 1e3
+
+        # test 1: all gulitems are zeros, should remain all zeros
+        gulitems_orig = np.zeros(Ngulitems)
+        gulitems = gulitems_orig.copy()
+        split_tiv_multiplicative(gulitems, tiv)
+        np.testing.assert_array_equal(np.zeros(Ngulitems), gulitems)
+
+        # # test 2: sum(gulitems) < tiv, gulitems losses should remain unchanged
+        gulitems_orig = np.array([40., 60., 100., 20., 120., 188., 300., 80., 30., 50.])
+        assert np.sum(gulitems_orig) < tiv
+        gulitems = gulitems_orig.copy()
+        split_tiv_multiplicative(gulitems, tiv)
+
+        total_loss = tiv * (1. - np.prod(1 - gulitems_orig / tiv))
+        expected_gulitems = gulitems_orig * (tiv / total_loss)
+        np.testing.assert_array_almost_equal(expected_gulitems, gulitems, decimal=1e-14)
 
 
 if __name__ == "__main__":

--- a/tests/pytools/gul/test_core.py
+++ b/tests/pytools/gul/test_core.py
@@ -41,12 +41,11 @@ class TestGulpyCore(TestCase):
         split_tiv_multiplicative(gulitems, tiv)
         np.testing.assert_array_equal(np.zeros(Ngulitems), gulitems)
 
-        # # test 2: sum(gulitems) < tiv, gulitems losses should remain unchanged
+        # test 2: sum(gulitems) < tiv, gulitems losses should remain unchanged
         gulitems_orig = np.array([40., 60., 100., 20., 120., 188., 300., 80., 30., 50.])
         assert np.sum(gulitems_orig) < tiv
         gulitems = gulitems_orig.copy()
         split_tiv_multiplicative(gulitems, tiv)
-
         total_loss = tiv * (1. - np.prod(1 - gulitems_orig / tiv))
         expected_gulitems = gulitems_orig * (tiv / total_loss)
         np.testing.assert_array_almost_equal(expected_gulitems, gulitems, decimal=1e-14)

--- a/tests/pytools/gul/test_core.py
+++ b/tests/pytools/gul/test_core.py
@@ -46,8 +46,8 @@ class TestGulpyCore(TestCase):
         assert np.sum(gulitems_orig) < tiv
         gulitems = gulitems_orig.copy()
         split_tiv_multiplicative(gulitems, tiv)
-        total_loss = tiv * (1. - np.prod(1 - gulitems_orig / tiv))
-        expected_gulitems = gulitems_orig * (tiv / total_loss)
+        multiplicative_loss = tiv * (1. - np.prod(1. - gulitems_orig / tiv))
+        expected_gulitems = gulitems_orig * (multiplicative_loss / np.sum(gulitems_orig))
         np.testing.assert_array_almost_equal(expected_gulitems, gulitems, decimal=1e-14)
 
 

--- a/tests/pytools/gul/test_core.py
+++ b/tests/pytools/gul/test_core.py
@@ -4,7 +4,7 @@ This file tests gul/core.py functionality
 from unittest import main, TestCase
 import numpy as np
 
-from oasislmf.pytools.gul.core import split_tiv_classic
+from oasislmf.pytools.gul.core import split_tiv_classic, split_tiv_multiplicative
 
 
 class TestGulpyCore(TestCase):
@@ -31,7 +31,7 @@ class TestGulpyCore(TestCase):
         split_tiv_classic(gulitems, tiv)
         np.testing.assert_array_almost_equal(gulitems_orig * tiv / np.sum(gulitems_orig), gulitems, decimal=1e-14)
 
-    def test_split_tiv_fractional(self) -> None:
+    def test_split_tiv_multiplicative(self) -> None:
         # WIP
         pass
 

--- a/tests/pytools/gul/test_core.py
+++ b/tests/pytools/gul/test_core.py
@@ -1,0 +1,40 @@
+"""
+This file tests gul/core.py functionality
+"""
+from unittest import main, TestCase
+import numpy as np
+
+from oasislmf.pytools.gul.core import split_tiv_classic
+
+
+class TestGulpyCore(TestCase):
+
+    def setUp(self) -> None:
+        pass
+
+    def tearDown(self) -> None:
+        pass
+
+    def test_split_tiv_classic(self) -> None:
+        Ngulitems = 100
+        tiv = 1e3
+
+        # test 1: sum(gulitems) < tiv, no split should be executed
+        gulitems_orig = np.ones(Ngulitems) * tiv / Ngulitems - 1e-3
+        gulitems = gulitems_orig.copy()
+        split_tiv_classic(gulitems, tiv)
+        np.testing.assert_array_equal(gulitems_orig, gulitems)
+
+        # test 2: sum(gulitems) > tiv, split should be executed
+        gulitems_orig = np.ones(Ngulitems) * tiv / Ngulitems + 1e-3
+        gulitems = gulitems_orig.copy()
+        split_tiv_classic(gulitems, tiv)
+        np.testing.assert_array_almost_equal(gulitems_orig * tiv / np.sum(gulitems_orig), gulitems, decimal=1e-14)
+
+    def test_split_tiv_fractional(self) -> None:
+        # WIP
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/pytools/gul/test_gulpy.py
+++ b/tests/pytools/gul/test_gulpy.py
@@ -1,9 +1,0 @@
-import numpy as np
-from numpy.testing import assert_array_almost_equal
-
-from oasislmf.pytools.gul.manager import run
-
-
-def test_a0():
-
-    pass


### PR DESCRIPTION
This PR implements a new way of computing the total losses using multiplicative expression for sub-peril losses and, respectively, a new alloc_rule value: 3.

This PR tracks implementation of this feature in gulpy. Details are in https://github.com/OasisLMF/ktools/issues/118

Fix #1099 

TODO:

- [x] check that gulpy produces same results as before for alloc_rule = 0, 1, 2.

<!--start_release_notes-->
### Release notes feature title
This PR implements a new formula for computing the total losses using multiplicative expression for sub-peril losses.
This implementation is accessible using the new alloc_rule = 3, i.e. with:
```bash
gulpy -a3 ...
```
After computing total losses using the new formula, back-allocation in proportion to the losses is applied to the sub-peril losses, similarly to the back-allocation applied with `alloc_rule=1`.

More details are in https://github.com/OasisLMF/ktools/issues/118
<!--end_release_notes-->
