### PR TITLE
Always create a correlations.bin, if missing model_settings file is b…

### DIFF
--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -234,14 +234,10 @@ class GenerateFiles(ComputationStep):
             group_id_cols=group_id_cols,
             hashed_group_id=self.hashed_group_id,
         )
-
-        if self.model_settings_json is not None:
-            correlation_input_items = get_correlation_input_items(
-                model_settings_path=self.model_settings_json,
-                gul_inputs_df=gul_inputs_df
-            )
-        else:
-            correlation_input_items = None
+        correlation_input_items = get_correlation_input_items(
+            model_settings_path=self.model_settings_json,
+            gul_inputs_df=gul_inputs_df
+        )
 
         # If not in det. loss gen. scenario, write exposure summary file
         if summarise_exposure:

--- a/oasislmf/preparation/correlations.py
+++ b/oasislmf/preparation/correlations.py
@@ -43,8 +43,11 @@ def get_correlation_input_items(model_settings_path: str, gul_inputs_df: pd.Data
 
     Returns: (pd.DataFrame) the mapped data of correlations
     """
-    model_settings_raw_data: dict = get_model_settings(model_settings_fp=model_settings_path)
-    correlation_map_df = map_data(data=model_settings_raw_data)
+    if model_settings_path == None:
+        correlation_map_df = None
+    else:
+        model_settings_raw_data: dict = get_model_settings(model_settings_fp=model_settings_path)
+        correlation_map_df = map_data(data=model_settings_raw_data)
 
     if correlation_map_df is not None:
         gul_inputs_df = gul_inputs_df.merge(correlation_map_df, left_on='peril_id', right_on='id').reset_index()


### PR DESCRIPTION
### Fix for running the MDK without a model_settings file
* The file generation step always creates a `correlation.csv` file, when no model_settings file is given, the file is empty. 
<!--end_release_notes-->

Tests conducted:

- [x] when model_settings file is given and no correlations are defined -> correlations.bin and correlations.csv should be created empty
- [x] when model_settings file is given and correlations are defined  but not applied to perils -> correlations.bin and correlations.csv should be created empty
- [x] when model_settings file is given and correlations are defined and applied to perils -> correlations.bin and correlations.csv should be created and populated as expected