### PR TITLE
Fix/678 logger

### DIFF
--- a/oasislmf/__init__.py
+++ b/oasislmf/__init__.py
@@ -11,7 +11,9 @@ import logging
 from logging import NullHandler
 
 logger = logging.getLogger(__name__)
-logger.addHandler(NullHandler())
+handler = NullHandler()
+handler.name='oasislmf'
+logger.addHandler(handler)
 
 
 class MyLoader(Loader):

--- a/oasislmf/cli/command.py
+++ b/oasislmf/cli/command.py
@@ -72,15 +72,20 @@ class OasisBaseCommand(BaseCommand):
                 log_level = logging.INFO
                 log_format = '%(message)s'
 
-            logging.basicConfig(stream=sys.stdout, level=log_level, format=log_format)
-            self._logger = logging.getLogger()
+            logger = logging.getLogger('oasislmf')
+            ch = logging.StreamHandler(stream=sys.stdout)
+            ch.setFormatter(logging.Formatter(log_format))
+            logger.addHandler(ch)
+            logger.setLevel(log_level)
+            self._logger = logger
+
 
     @property
     def logger(self):
         if self._logger:
             return self._logger
 
-        return logging.getLogger()
+        return logging.getLogger('oasislmf')
 
 
 class OasisComputationCommand(OasisBaseCommand):

--- a/oasislmf/cli/command.py
+++ b/oasislmf/cli/command.py
@@ -73,7 +73,13 @@ class OasisBaseCommand(BaseCommand):
                 log_format = '%(message)s'
 
             logger = logging.getLogger('oasislmf')
+            for handler in list(logger.handlers):
+                if handler.name == 'oasislmf':
+                    logger.removeHandler(handler)
+                    break
+
             ch = logging.StreamHandler(stream=sys.stdout)
+            ch.name = 'oasislmf'
             ch.setFormatter(logging.Formatter(log_format))
             logger.addHandler(ch)
             logger.setLevel(log_level)

--- a/oasislmf/computation/base.py
+++ b/oasislmf/computation/base.py
@@ -36,7 +36,7 @@ class ComputationStep:
          - check path existence (pre_exist)
          - create necessary directories (is_dir, is_path)
         """
-        self.logger = logging.getLogger()
+        self.logger = logging.getLogger(__name__)
         self.kwargs = kwargs
         self.logger.debug(f"{self.__class__.__name__}: " + json.dumps(self.kwargs, indent=4))
 

--- a/oasislmf/execution/bash.py
+++ b/oasislmf/execution/bash.py
@@ -10,7 +10,7 @@ import re
 import shutil
 import string
 from functools import partial
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 from collections import Counter
 

--- a/oasislmf/execution/conf.py
+++ b/oasislmf/execution/conf.py
@@ -47,7 +47,7 @@ def create_analysis_settings_json(directory):
     """
     if not os.path.exists(directory):
         error_message = "Directory does not exist: {}".format(directory)
-        logging.getLogger().error(error_message)
+        logging.getLogger(__name__).error(error_message)
         raise OasisException(error_message)
 
     general_settings_file = os.path.join(directory, GENERAL_SETTINGS_FILE)
@@ -58,7 +58,7 @@ def create_analysis_settings_json(directory):
     for file in [general_settings_file, model_settings_file, gul_summaries_file, il_summaries_file]:
         if not os.path.exists(file):
             error_message = "File does not exist: {}".format(directory)
-            logging.getLogger().error(error_message)
+            logging.getLogger(__name__).error(error_message)
             raise OasisException(error_message)
 
     general_settings = dict()
@@ -81,6 +81,6 @@ def create_analysis_settings_json(directory):
     analysis_settings['gul_summaries'] = gul_summaries
     analysis_settings['il_summaries'] = il_summaries
     output_json = json.dumps(analysis_settings)
-    logging.getLogger().info("Analysis settings json: {}".format(output_json))
+    logging.getLogger(__name__).info("Analysis settings json: {}".format(output_json))
 
     return output_json

--- a/oasislmf/platform_api/client.py
+++ b/oasislmf/platform_api/client.py
@@ -31,7 +31,7 @@ class ApiEndpoint(object):
     End points.
     """
     def __init__(self, session, url_endpoint, logger=None):
-        self.logger = logger or logging.getLogger()
+        self.logger = logger or logging.getLogger(__name__)
         self.session = session
         self.url_endpoint = url_endpoint
 
@@ -61,7 +61,7 @@ class JsonEndpoint(object):
     Used for JSON data End points.
     """
     def __init__(self, session, url_endpoint, url_resource, logger=None):
-        self.logger = logger or logging.getLogger()
+        self.logger = logger or logging.getLogger(__name__)
         self.session = session
         self.url_endpoint = url_endpoint
         self.url_resource = url_resource
@@ -107,7 +107,7 @@ class FileEndpoint(object):
     File Resources Endpoint for Upload / Downloading
     """
     def __init__(self, session, url_endpoint, url_resource, logger=None):
-        self.logger = logger or logging.getLogger()
+        self.logger = logger or logging.getLogger(__name__)
 
         self.session = session
         self.url_endpoint = url_endpoint
@@ -374,7 +374,7 @@ class API_analyses(ApiEndpoint):
 
 class APIClient(object):
     def __init__(self, api_url='http://localhost:8000', api_ver='V1', username='admin', password='password', timeout=25, logger=None, **kwargs):
-        self.logger = logger or logging.getLogger()
+        self.logger = logger or logging.getLogger(__name__)
 
         self.api = APISession(api_url, username, password, timeout, **kwargs)
         self.models = API_models(self.api, '{}{}/models/'.format(self.api.url_base, api_ver))

--- a/oasislmf/platform_api/session.py
+++ b/oasislmf/platform_api/session.py
@@ -19,7 +19,7 @@ from ..utils.exceptions import OasisException
 class APISession(Session):
     def __init__(self, api_url, username, password, timeout=25, retries=5, retry_delay=1, request_interval=0.02, logger=None, **kwargs):
         super(APISession, self).__init__(**kwargs)
-        self.logger = logger or logging.getLogger()
+        self.logger = logger or logging.getLogger(__name__)
 
         # Extended class vars
         self.tkn_access = None

--- a/oasislmf/preparation/reinsurance_layer.py
+++ b/oasislmf/preparation/reinsurance_layer.py
@@ -189,7 +189,7 @@ class ReinsuranceLayer(object):
         gulsummaryxref_df=pd.DataFrame(), logger=None
     ):
 
-        self.logger = logger or logging.getLogger()
+        self.logger = logger or logging.getLogger(__name__)
         self.name = name
 
         self.coverages_df = coverages_df

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -322,7 +322,7 @@ def analysis_settings_compatibility(analysis_settings_data):
     }
     obsolete_keys = set(compatibility_profile) & set(analysis_settings_data)
     if obsolete_keys:
-        logger = logging.getLogger()
+        logger = logging.getLogger(__name__)
         logger.warning('WARNING: Deprecated key(s) in analysis_settings JSON')
         for key in obsolete_keys:
             # warn user

--- a/oasislmf/utils/inputs.py
+++ b/oasislmf/utils/inputs.py
@@ -19,7 +19,7 @@ from argparse import ArgumentTypeError
 def update_config(config_data, config_map=get_config_profile()):
         config = config_data.copy()
         obsolete_keys = set(config) & set(config_map)
-        logger = logging.getLogger()
+        logger = logging.getLogger(__name__)
 
         if obsolete_keys:
             logger.warning('Deprecated key(s) in MDK config:')
@@ -54,7 +54,7 @@ class InputValues(object):
 
     """
     def __init__(self, args, update_keys=True):
-        self.logger = logging.getLogger()
+        self.logger = logging.getLogger(__name__)
         self.args = args
         self.config = {}
         self.config_fp = self.get('config', is_path=True)

--- a/oasislmf/utils/log.py
+++ b/oasislmf/utils/log.py
@@ -43,8 +43,8 @@ def set_rotating_logger(
         backupCount=max_backups
     )
 
-    logging.getLogger().setLevel(log_level)
-    logging.getLogger().addHandler(handler)
+    logging.getLogger('oasislmf').setLevel(log_level)
+    logging.getLogger('oasislmf').addHandler(handler)
     formatter = logging.Formatter(
         "%(asctime)s - %(levelname)s - %(message)s")
 
@@ -67,8 +67,8 @@ def read_log_config(config_parser):
     handler = RotatingFileHandler(
         log_file, maxBytes=log_max_size_in_bytes,
         backupCount=log_backup_count)
-    logging.getLogger().setLevel(log_level)
-    logging.getLogger().addHandler(handler)
+    logging.getLogger('oasislmf').setLevel(log_level)
+    logging.getLogger('oasislmf').addHandler(handler)
     formatter = logging.Formatter(
         "%(asctime)s - %(levelname)s - %(message)s")
     handler.setFormatter(formatter)
@@ -78,7 +78,7 @@ def oasis_log(*args, **kwargs):
     """
     Decorator that logs the entry, exit and execution time.
     """
-    logger = logging.getLogger()
+    logger = logging.getLogger('oasislmf')
 
     def actual_oasis_log(func):
         @wraps(func)

--- a/oasislmf/utils/log.py
+++ b/oasislmf/utils/log.py
@@ -37,12 +37,17 @@ def set_rotating_logger(
     if not os.path.exists(log_dir):
         os.makedirs(log_dir)
 
+    logger = logging.getLogger('oasislmf')
+    for handler in list(logger.handlers):
+        if handler.name == 'oasislmf':
+            logger.removeHandler(handler)
+            break
     handler = RotatingFileHandler(
         _log_fp,
         maxBytes=max_file_size,
         backupCount=max_backups
     )
-
+    handler.name='oasislmf'
     logging.getLogger('oasislmf').setLevel(log_level)
     logging.getLogger('oasislmf').addHandler(handler)
     formatter = logging.Formatter(
@@ -64,9 +69,15 @@ def read_log_config(config_parser):
     if not os.path.exists(log_dir):
         os.makedirs(log_dir)
 
+    logger = logging.getLogger('oasislmf')
+    for handler in list(logger.handlers):
+        if handler.name == 'oasislmf':
+            logger.removeHandler(handler)
+            break
     handler = RotatingFileHandler(
         log_file, maxBytes=log_max_size_in_bytes,
         backupCount=log_backup_count)
+    handler.name = 'oasislmf'
     logging.getLogger('oasislmf').setLevel(log_level)
     logging.getLogger('oasislmf').addHandler(handler)
     formatter = logging.Formatter(

--- a/oasislmf/validation/model_data.py
+++ b/oasislmf/validation/model_data.py
@@ -38,7 +38,7 @@ def csv_validity_test(model_data_fp):
     :raises OasisException: if one of the tests fail
     """
 
-    logger = logging.getLogger()
+    logger = logging.getLogger(__name__)
     logger.setLevel(logging.INFO)
 
     model_data_dir = os.path.abspath(model_data_fp)

--- a/tests/utils/test_log.py
+++ b/tests/utils/test_log.py
@@ -116,7 +116,7 @@ class ReadLogConfig(TestCase):
                 'LOG_BACKUP_COUNT': 10,
             })
 
-            logger = logging.getLogger()
+            logger = logging.getLogger('oasislmf')
 
             self.assertEqual(level, logger.level)
 
@@ -137,7 +137,7 @@ class SetRotatingLogger(TestCase):
         with patch('logging.root', logging.RootLogger(logging.NOTSET)):
             set_rotating_logger(log_file_path=log_file_path, log_level=level, max_file_size=100, max_backups=10)
 
-            logger = logging.getLogger()
+            logger = logging.getLogger('oasislmf')
 
             self.assertEqual(level, logger.level)
 


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!--start_release_notes-->
### Fix set logger configuration for oasislmf only
When setting logger, OasisLmf was actually changing the log configuration of all the module by calling logging.getLogger() instead of logging.getLogger('oasislmf')
<!--end_release_notes-->
