### PR TITLE
Add output type check to the start of generate losses

### DIFF
--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -256,7 +256,7 @@ class GenerateLossesDir(GenerateLossesBase):
         il_missing = True if analysis_settings.get('il_output', False) and not il else False
         ri_missing = True if analysis_settings.get('ri_output', False) and not ri else False
         if il_missing or ri_missing:
-            missing_input_files = "{} are enabled analysis_settings without the generated input files. The 'generate-oasis-files' step should be rerun with account/reinsurance files.".format(["IL"*il_missing, "RI"*ri_missing])
+            missing_input_files = "{} are enabled in the analysis_settings without the generated input files. The 'generate-oasis-files' step should be rerun with account/reinsurance files.".format(["IL"*il_missing, "RI"*ri_missing])
             if self.check_missing_inputs:
                 raise OasisException(missing_input_files)
             else:

--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -209,6 +209,7 @@ class GenerateLossesDir(GenerateLossesBase):
         {'name': 'fmpy',                   'default': True, 'type': str2bool, 'const':True, 'nargs':'?', 'help': 'use fmcalc python version instead of c++ version'},
         {'name': 'ktools_alloc_rule_il',   'default': KTOOLS_ALLOC_IL_DEFAULT,  'type':int, 'help': 'Set the fmcalc allocation rule used in direct insured loss'},
         {'name': 'ktools_alloc_rule_ri',   'default': KTOOLS_ALLOC_RI_DEFAULT,  'type':int, 'help': 'Set the fmcalc allocation rule used in reinsurance'},
+        {'name': 'check_missing_inputs',   'default': False, 'type': str2bool, 'const':True, 'nargs':'?', 'help': 'Fail an analysis run if IL/RI is requested without the required generated files.'},
 
         # Manager only options (pass data directy instead of filepaths)
         {'name': 'verbose',              'default': KTOOLS_DEBUG},
@@ -238,6 +239,7 @@ class GenerateLossesDir(GenerateLossesBase):
 
     def run(self):
         model_run_fp = self._get_output_dir()
+        analysis_settings = get_analysis_settings(self.analysis_settings_json)
         il = all(p in os.listdir(self.oasis_files_dir) for p in [
             'fm_policytc.csv',
             'fm_profile.csv',
@@ -250,9 +252,19 @@ class GenerateLossesDir(GenerateLossesBase):
         ]
         ri = any(ri_dirs)
 
+        # Check for missing input files and either warn user or raise exception
+        il_missing = True if analysis_settings.get('il_output', False) and not il else False
+        ri_missing = True if analysis_settings.get('ri_output', False) and not ri else False
+        if il_missing or ri_missing:
+            missing_input_files = "{} are enabled analysis_settings without the generated input files. The 'generate-oasis-files' step should be rerun with account/reinsurance files.".format(["IL"*il_missing, "RI"*ri_missing])
+            if self.check_missing_inputs:
+                raise OasisException(missing_input_files)
+            else:
+                warnings.warn(missing_input_files)
+
+
         gul_item_stream = (not self.ktools_legacy_stream)
         self.logger.info('\nPreparing loss Generation (GUL=True, IL={}, RIL={})'.format(il, ri))
-        analysis_settings = get_analysis_settings(self.analysis_settings_json)
 
         runtypes = ['gul'] + ['il'] * il + ['ri'] * ri
         self.__check_for_parquet_output(analysis_settings, runtypes)

--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -253,8 +253,8 @@ class GenerateLossesDir(GenerateLossesBase):
         ri = any(ri_dirs)
 
         # Check for missing input files and either warn user or raise exception
-        il_missing = True if analysis_settings.get('il_output', False) and not il else False
-        ri_missing = True if analysis_settings.get('ri_output', False) and not ri else False
+        il_missing = analysis_settings.get('il_output', False) and not il
+        ri_missing = analysis_settings.get('ri_output', False) and not ri
         if il_missing or ri_missing:
             missing_input_files = "{} are enabled in the analysis_settings without the generated input files. The 'generate-oasis-files' step should be rerun with account/reinsurance files.".format(["IL"*il_missing, "RI"*ri_missing])
             if self.check_missing_inputs:


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!--start_release_notes-->
### Added option to fail loss generation if input files are missing 
If the `--check-missing-inputs` option is set, a loss analysis will fail if either `IL` or `RI` is set in the analysis_settings but the oasis files are missing (the input generation was run without acc / ri OED files).  

If not set the MDK will still warn when this happens, but not fail. 


## Warning message
```
UserWarning: ['IL', 'RI'] are enabled analysis_settings without the generated input files. The 'generate-oasis-files' step should be rerun with account/reinsurance files.
```


## Exception example
```
$ oasislmf model run --check-missing-inputs

Stating oasislmf command - RunModel
RUNNING: oasislmf.manager.interface
Processing arguments - Creating Oasis Files

Generating Oasis files (GUL=True, IL=False, RIL=False)
RUNNING: oasislmf.lookup.factory.generate_key_files
COMPLETED: oasislmf.lookup.factory.generate_key_files in 0.1s
  ...
RUNNING: oasislmf.preparation.summaries.write_mapping_file

Oasis files generated: {
    "items": "/home/sam/repos/models/piwind/runs/losses-20220909083601/input/items.csv",
    "coverages": "/home/sam/repos/models/piwind/runs/losses-20220909083601/input/coverages.csv"
}

['IL', 'RI'] are enabled analysis_settings without the generated input files. The 'generate-oasis-files' step should be rerun with account/reinsurance files.

$ echo $?
1
```

<!--end_release_notes-->
