### PR TITLE
Add support for GUL alloc rule 3

### DIFF
--- a/oasislmf/utils/defaults.py
+++ b/oasislmf/utils/defaults.py
@@ -336,10 +336,11 @@ KTOOLS_FIFO_RELATIVE = False
 KTOOLS_DISABLE_ERR_GUARD = False
 KTOOLS_GUL_LEGACY_STREAM = False
 # ktools gul alloc rules:
+# 3 = total loss using multiplicative method
 # 2 = total loss is maximum subperil loss
 # 1 = default with back allocation
 # 0 = default without back allocation
-KTOOLS_ALLOC_GUL_MAX = 2
+KTOOLS_ALLOC_GUL_MAX = 3
 KTOOLS_ALLOC_FM_MAX = 3
 KTOOLS_ALLOC_GUL_DEFAULT = 0
 KTOOLS_ALLOC_IL_DEFAULT = 2


### PR DESCRIPTION
<!--start_release_notes-->
### Add support for GUL alloc rule 3
Since ktools v3.9.3, the new GUL alloc rule 3 was introduced to calculate the total peril loss using the multiplicative method (please see ktools issue https://github.com/OasisLMF/ktools/issues/118 for more details). The check for the GUL alloc rule range has been updated to reflect this new alloc rule.
<!--end_release_notes-->
