### PR TITLE
Remove check for IL + RI files from the run model cmd

### DIFF
--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -164,17 +164,6 @@ class GenerateFiles(ComputationStep):
 
         il = bool(exposure_data.account)
         ri = exposure_data.ri_info and exposure_data.ri_scope and il
-
-        # Send warning if RI files are in args without IL
-        if any([self.oed_info_csv, self.oed_scope_csv]) and not ri:
-            self.logger.warn(
-                'RI option indicated by provision of some RI related assets, but other assets are missing. '
-                'To generate RI inputs you need to provide all of the assets required to generate direct '
-                'Oasis files (GUL + FM input files) plus all of the following assets: '
-                '  * reinsurance info file'
-                '  * reinsurance scope file'
-            )
-
         self.logger.info('\nGenerating Oasis files (GUL=True, IL={}, RIL={})'.format(il, ri))
         summarise_exposure = not self.disable_summarise_exposure
 

--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -164,6 +164,17 @@ class GenerateFiles(ComputationStep):
 
         il = bool(exposure_data.account)
         ri = exposure_data.ri_info and exposure_data.ri_scope and il
+
+        # Send warning if RI files are in args without IL
+        if any([self.oed_info_csv, self.oed_scope_csv]) and not ri:
+            self.logger.warn(
+                'RI option indicated by provision of some RI related assets, but other assets are missing. '
+                'To generate RI inputs you need to provide all of the assets required to generate direct '
+                'Oasis files (GUL + FM input files) plus all of the following assets: '
+                '  * reinsurance info file'
+                '  * reinsurance scope file'
+            )
+
         self.logger.info('\nGenerating Oasis files (GUL=True, IL={}, RIL={})'.format(il, ri))
         summarise_exposure = not self.disable_summarise_exposure
 

--- a/oasislmf/computation/run/model.py
+++ b/oasislmf/computation/run/model.py
@@ -70,6 +70,19 @@ class RunModel(ComputationStep):
         if self.model_settings_json:
             get_model_settings(self.model_settings_json)
 
+        # Check input exposure
+        required_ri_paths = [self.oed_info_csv, self.oed_scope_csv]
+        il = True if self.oed_accounts_csv else False
+        ri = all(required_ri_paths) and il
+        if any(required_ri_paths) and not ri:
+            raise OasisException(
+                'RI option indicated by provision of some RI related assets, but other assets are missing. '
+                'To generate RI inputs you need to provide all of the assets required to generate direct '
+                'Oasis files (GUL + FM input files) plus all of the following assets: '
+                '    reinsurance info. file path, '
+                '    reinsurance scope file path.'
+            )
+
         self.kwargs['exposure_data'] = get_exposure_data(self, add_internal_col=True)
 
         # Run chain

--- a/oasislmf/computation/run/model.py
+++ b/oasislmf/computation/run/model.py
@@ -11,7 +11,6 @@ from ..generate.files import GenerateFiles
 from ..generate.losses import GenerateLosses
 from ..hooks.pre_analysis import ExposurePreAnalysis
 
-from ...utils.exceptions import OasisException
 from ...utils.data import (
     get_analysis_settings,
     get_model_settings, get_exposure_data,
@@ -69,19 +68,6 @@ class RunModel(ComputationStep):
         get_analysis_settings(self.analysis_settings_json)
         if self.model_settings_json:
             get_model_settings(self.model_settings_json)
-
-        # Check input exposure
-        required_ri_paths = [self.oed_info_csv, self.oed_scope_csv]
-        il = True if self.oed_accounts_csv else False
-        ri = all(required_ri_paths) and il
-        if any(required_ri_paths) and not ri:
-            raise OasisException(
-                'RI option indicated by provision of some RI related assets, but other assets are missing. '
-                'To generate RI inputs you need to provide all of the assets required to generate direct '
-                'Oasis files (GUL + FM input files) plus all of the following assets: '
-                '    reinsurance info. file path, '
-                '    reinsurance scope file path.'
-            )
 
         self.kwargs['exposure_data'] = get_exposure_data(self, add_internal_col=True)
 

--- a/oasislmf/computation/run/model.py
+++ b/oasislmf/computation/run/model.py
@@ -70,19 +70,6 @@ class RunModel(ComputationStep):
         if self.model_settings_json:
             get_model_settings(self.model_settings_json)
 
-        # Check input exposure
-        required_ri_paths = [self.oed_info_csv, self.oed_scope_csv]
-        il = True if self.oed_accounts_csv else False
-        ri = all(required_ri_paths) and il
-        if any(required_ri_paths) and not ri:
-            raise OasisException(
-                'RI option indicated by provision of some RI related assets, but other assets are missing. '
-                'To generate RI inputs you need to provide all of the assets required to generate direct '
-                'Oasis files (GUL + FM input files) plus all of the following assets: '
-                '    reinsurance info. file path, '
-                '    reinsurance scope file path.'
-            )
-
         self.kwargs['exposure_data'] = get_exposure_data(self, add_internal_col=True)
 
         # Run chain

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -980,6 +980,7 @@ def get_exposure_data(computation_step, add_internal_col=False):
     except OdsException as ods_error:
         raise OasisException("Failed to load OED exposure files", ods_error)
 
+
 def reduce_df(df, cols=None):
     """
     A method to select columns in a dataframe

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -45,6 +45,7 @@ import logging
 from datetime import datetime
 
 from ods_tools.oed import OedExposure
+from ods_tools.oed.common import OdsException
 
 try:
     from json import JSONDecodeError
@@ -950,32 +951,34 @@ def prepare_reinsurance_df(ri_info, ri_scope):
 
 
 def get_exposure_data(computation_step, add_internal_col=False):
-    if 'exposure_data' in computation_step.kwargs:
-        exposure_data = computation_step.kwargs['exposure_data']
-    else:
-        if Path(computation_step.oasis_files_dir, OedExposure.DEFAULT_EXPOSURE_CONFIG_NAME).is_file():
-            exposure_data = OedExposure.from_config(Path(computation_step.oasis_files_dir, OedExposure.DEFAULT_EXPOSURE_CONFIG_NAME))
-        elif hasattr(computation_step, 'get_exposure_data_config'):  # if computation step input specify ExposureData config
-            exposure_data = OedExposure(**computation_step.get_exposure_data_config())
-        else:  # ExposureData info was not created, oed input file must have default name (location, account, ...)
-            exposure_data = OedExposure.from_dir(
-                computation_step.oasis_files_dir,
-                oed_schema_info=getattr(computation_step, 'oed_schema_info', None),
-                currency_conversion=getattr(computation_step, 'currency_conversion_json', None),
-                reporting_currency=getattr(computation_step, 'reporting_currency', None),
-                check_oed=computation_step.check_oed,
-                use_field=True)
+    try:
+        if 'exposure_data' in computation_step.kwargs:
+            exposure_data = computation_step.kwargs['exposure_data']
+        else:
+            if Path(computation_step.oasis_files_dir, OedExposure.DEFAULT_EXPOSURE_CONFIG_NAME).is_file():
+                exposure_data = OedExposure.from_config(Path(computation_step.oasis_files_dir, OedExposure.DEFAULT_EXPOSURE_CONFIG_NAME))
+            elif hasattr(computation_step, 'get_exposure_data_config'):  # if computation step input specify ExposureData config
+                exposure_data = OedExposure(**computation_step.get_exposure_data_config())
+            else:  # ExposureData info was not created, oed input file must have default name (location, account, ...)
+                exposure_data = OedExposure.from_dir(
+                    computation_step.oasis_files_dir,
+                    oed_schema_info=getattr(computation_step, 'oed_schema_info', None),
+                    currency_conversion=getattr(computation_step, 'currency_conversion_json', None),
+                    reporting_currency=getattr(computation_step, 'reporting_currency', None),
+                    check_oed=computation_step.check_oed,
+                    use_field=True)
 
-        if add_internal_col:
-            if exposure_data.location:
-                exposure_data.location.dataframe = prepare_location_df(exposure_data.location.dataframe)
-            if exposure_data.account:
-                exposure_data.account.dataframe = prepare_account_df(exposure_data.account.dataframe)
-            if exposure_data.ri_info and exposure_data.ri_scope:
-                exposure_data.ri_info.dataframe, exposure_data.ri_scope.dataframe = prepare_reinsurance_df(exposure_data.ri_info.dataframe,
-                                                                                                           exposure_data.ri_scope.dataframe)
-    return exposure_data
-
+            if add_internal_col:
+                if exposure_data.location:
+                    exposure_data.location.dataframe = prepare_location_df(exposure_data.location.dataframe)
+                if exposure_data.account:
+                    exposure_data.account.dataframe = prepare_account_df(exposure_data.account.dataframe)
+                if exposure_data.ri_info and exposure_data.ri_scope:
+                    exposure_data.ri_info.dataframe, exposure_data.ri_scope.dataframe = prepare_reinsurance_df(exposure_data.ri_info.dataframe,
+                                                                                                               exposure_data.ri_scope.dataframe)
+        return exposure_data
+    except OdsException as ods_error:
+        raise OasisException("Failed to load OED exposure files", ods_error)
 
 def reduce_df(df, cols=None):
     """


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!--start_release_notes-->
### Remove redundant IL+RI check
With the addition of https://github.com/OasisLMF/OasisLMF/pull/1112  there are two input file checks, one which can be toggled on/off via the flag ` --check-missing-inputs`  and another which is hard coded in the `oasislmf run model` command. 

Removed the check from `oasislmf run model` which is a 'compound' command of [`generate-files` + `generate-losses`]

<!--end_release_notes-->
