### PR TITLE
Fix/package install error

### DIFF
--- a/oasislmf/__init__.py
+++ b/oasislmf/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.26.4'
+__version__ = '1.26.3'
 
 import sys
 import os

--- a/oasislmf/__init__.py
+++ b/oasislmf/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.26.2'
+__version__ = '1.26.4'
 
 import sys
 import os

--- a/requirements-package.in
+++ b/requirements-package.in
@@ -16,4 +16,4 @@ shutilwhich
 tabulate>=0.8.2
 tblib
 tqdm
-numpy<1.22,>=1.18
+numpy<1.23,>=1.18

--- a/requirements-package.in
+++ b/requirements-package.in
@@ -7,13 +7,14 @@ jsonschema
 msgpack
 numba>=0.55.1
 numexpr
+numpy<1.23,>=1.18
 ods-tools>=2.3.2
 pandas>=1.0.3,!=1.1.0,!=1.1.1
 pytz
-requests>=2.20.0
 requests-toolbelt
+requests>=2.20.0
+scipy
 shutilwhich
 tabulate>=0.8.2
 tblib
 tqdm
-numpy<1.23,>=1.18


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!--start_release_notes-->
### Fix Package requirements 

#### Add Scipy to required packages 
From https://github.com/OasisLMF/OasisLMF/pull/1069 the package `scipy` is used without being included in `requirements-package.in` 

https://github.com/OasisLMF/OasisLMF/blob/e0b0639c23c97c81847e29db7eef023f5137184f/requirements-package.in#L1-L19

https://github.com/OasisLMF/OasisLMF/blob/e0b0639c23c97c81847e29db7eef023f5137184f/oasislmf/pytools/gul/random.py#L9

#### Update Numpy maximum version

Platform docker builds fail due to the pinned numpy version, this was fixed in version `1.26.3` but that change didn't get merged back into develop from the branches diverging. 

Issue fixed with this PR instead of a merge back from `backports/1.26.x`. 

```
numpy==1.22.4 and oasislmf[extra]==<develop> because these package versions have conflicting dependencies.
The conflict is caused by:
    The user requested numpy==1.22.4
    fastparquet 0.8.0 depends on numpy>=1.18
    numba 0.55.2 depends on numpy<1.23 and >=1.18
    numexpr 2.8.1 depends on numpy>=1.13.3
    pandas 1.5.1 depends on numpy>=1.20.3; python_version < "3.10"
    pyarrow 8.0.0 depends on numpy>=1.16.6
    scikit-learn 1.1.2 depends on numpy>=1.17.3
    scipy 1.9.3 depends on numpy<1.26.0 and >=1.18.5
    oasislmf[extra] depends on numpy<1.22 and >=1.18
```

<!--end_release_notes-->
