### PR TITLE
[gulpy] bugfix: use the correct itemsize when creating `int32_mv`

### DIFF
--- a/oasislmf/pytools/gul/common.py
+++ b/oasislmf/pytools/gul/common.py
@@ -13,7 +13,6 @@ gul_header = np.int32(1 | 2 << 24).tobytes()
 
 PIPE_CAPACITY = 65536  # bytes
 GETMODEL_STREAM_BUFF_SIZE = 2 * PIPE_CAPACITY
-GULPY_STREAM_BUFF_SIZE_WRITE = PIPE_CAPACITY
 
 items_data_type = nb.from_dtype(np.dtype([('item_id', np.int32),
                                           ('damagecdf_i', np.int32),

--- a/oasislmf/pytools/gul/manager.py
+++ b/oasislmf/pytools/gul/manager.py
@@ -19,8 +19,8 @@ from oasislmf.pytools.getmodel.manager import get_damage_bins, Item
 from oasislmf.pytools.getmodel.common import oasis_float, Keys, Correlation
 
 from oasislmf.pytools.gul.common import (
-    MEAN_IDX, STD_DEV_IDX, TIV_IDX, CHANCE_OF_LOSS_IDX, MAX_LOSS_IDX, NUM_IDX,
-    ITEM_MAP_KEY_TYPE, ITEM_MAP_VALUE_TYPE, GULPY_STREAM_BUFF_SIZE_WRITE,
+    MEAN_IDX, PIPE_CAPACITY, STD_DEV_IDX, TIV_IDX, CHANCE_OF_LOSS_IDX, MAX_LOSS_IDX, NUM_IDX,
+    ITEM_MAP_KEY_TYPE, ITEM_MAP_VALUE_TYPE,
     gulSampleslevelRec_size, gulSampleslevelHeader_size, coverage_type, gul_header,
 )
 from oasislmf.pytools.gul.io import (
@@ -206,9 +206,6 @@ def run(run_dir, ignore_file_type, sample_size, loss_threshold, alloc_rule, debu
         stream_out.write(gul_header)
         stream_out.write(np.int32(sample_size).tobytes())
 
-        # number of bytes to read at a given time.
-        number_size = max(gulSampleslevelHeader_size, gulSampleslevelRec_size)
-
         # set the random generator function
         generate_rndm = get_random_generator(random_generator)
 
@@ -298,14 +295,14 @@ def run(run_dir, ignore_file_type, sample_size, loss_threshold, alloc_rule, debu
             last_processed_coverage_ids_idx = 0
 
             # adjust buff size so that the buffer fits the longest coverage
-            buff_size = GULPY_STREAM_BUFF_SIZE_WRITE
+            buff_size = PIPE_CAPACITY
             max_bytes_per_coverage = np.max(coverages['cur_items']) * max_bytes_per_item
             while buff_size < max_bytes_per_coverage:
                 buff_size *= 2
 
-            # define the raw memory view, the int32 view of it, and their respective cursors
+            # define the raw memory view and its int32 view
             mv_write = memoryview(bytearray(buff_size))
-            int32_mv_write = np.ndarray(buff_size // number_size, buffer=mv_write, dtype='i4')
+            int32_mv_write = np.ndarray(buff_size // 4, buffer=mv_write, dtype='i4')
 
             while last_processed_coverage_ids_idx < compute_i:
                 cursor, cursor_bytes, last_processed_coverage_ids_idx = compute_event_losses(
@@ -316,8 +313,12 @@ def run(run_dir, ignore_file_type, sample_size, loss_threshold, alloc_rule, debu
                     max_bytes_per_item, buff_size, int32_mv_write, cursor
                 )
 
-                select([], select_stream_list, select_stream_list)
-                stream_out.write(mv_write[:cursor_bytes])
+                # write the losses to the output stream
+                write_start = 0
+                while write_start < cursor_bytes:
+                    select([], select_stream_list, select_stream_list)
+                    write_start += stream_out.write(mv_write[write_start:cursor_bytes])
+
                 cursor = 0
 
             logger.info(f"event {event_id} DONE")


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->
This PR is a quick bug fix to solve an issue with the `int32_mv` ndarray that covers the memory view  used to store the gul losses before streaming them out.
Before this PR, `int32_mv` was correctly initialised as `i4` dtype (`int32`), but with a wrong number of elements.
This was causing a wrong output of `gulpy` (losses all zero for entire items) for large number of samples, without throwing an error.
 
<!--start_release_notes-->
### gulpy bugfix
This PR solves Issue #1141 where a bug that was causing a wrong output of `gulpy` (losses all zero for entire items) for large number of samples, without throwing an error.
 
<!--end_release_notes-->
