### PR TITLE
Try to omit /opt/ folder

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,9 @@ skipsdist = true
 
 [coverage:run]
 parallel = true
-omit = tests/fm/test_fmpy.py
+omit = 
+    tests/fm/test_fmpy.py
+    /opt/*
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!--start_release_notes-->
### Filter '/opt/*' from code coverage 
* Tox incorrectly reports a lower coverage due to duplicated test files from the package install dir. 
<!--end_release_notes-->
