### PR TITLE
Add `--copy-model-data` optional flag to `oasislmf model run`

### DIFF
--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -205,6 +205,7 @@ class GenerateLossesDir(GenerateLossesBase):
         {'name': 'user_data_dir', 'flag': '-D', 'is_path': True, 'pre_exist': False,
             'help': 'Directory containing additional model data files which varies between analysis runs'},
         {'name': 'model_data_dir', 'flag': '-d', 'is_path': True, 'pre_exist': True, 'help': 'Model data directory path'},
+        {'name': 'copy_model_data', 'default': False, 'type': str2bool, 'help': 'Copy model data instead of creating symbolic links to it.'},
         {'name': 'model_run_dir', 'flag': '-r', 'is_path': True, 'pre_exist': False, 'help': 'Model run directory path'},
         {'name': 'model_package_dir', 'flag': '-p', 'is_path': True, 'pre_exist': False, 'help': 'Path containing model specific package'},
         {'name': 'ktools_legacy_stream', 'type': str2bool, 'const': True, 'nargs': '?', 'default': KTOOLS_GUL_LEGACY_STREAM,
@@ -280,7 +281,8 @@ class GenerateLossesDir(GenerateLossesBase):
             self.model_data_dir,
             self.analysis_settings_json,
             user_data_dir=self.user_data_dir,
-            ri=ri
+            ri=ri,
+            copy_model_data=self.copy_model_data,
         )
 
         generate_summaryxref_files(

--- a/oasislmf/execution/bin.py
+++ b/oasislmf/execution/bin.py
@@ -48,6 +48,7 @@ def prepare_run_directory(
     inputs_archive=None,
     user_data_dir=None,
     ri=False,
+    copy_model_data=False,
 ):
     """
     Ensures that the model run directory has the correct folder structure in
@@ -156,7 +157,7 @@ def prepare_run_directory(
             for sourcefile in glob.glob(os.path.join(model_data_fp, '*')):
                 destfile = os.path.join(model_data_dst_fp, os.path.basename(sourcefile))
 
-                if os.name == 'nt':
+                if os.name == 'nt' or copy_model_data:
                     shutil.copy(sourcefile, destfile)
                 else:
                     os.symlink(sourcefile, destfile)


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->
This PR Fixes #1150 by introducing an optional flag `--copy-model-data` to copy the model data to the `runs/losses-xxx/static` directory instead of creating symbolic links to individual files.
 
<!--start_release_notes-->
### Introducing `oasislmf model run --copy_model_data` flag
This PR Fixes #1150 by introducing an optional flag `--copy-model-data` to copy the model data to the `runs/losses-xxx/static` directory instead of creating symbolic links to individual files. By default the flag is `False`, which reproduces current default behaviour of creating symbolic links to the model data.

<!--end_release_notes-->
