### PR TITLE
Don't write temp files during test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ wheels/
 .installed.cfg
 *.egg
 
+# pip-tools generated files
+requirements.txt
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
@@ -52,6 +55,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache
 validation/runs
+tmp/
 
 # Translations
 *.mo

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ python_classes =
 [flake8]
 exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,.ropeproject,.hypothesis
 max-line-length = 150
-ignore = E501,402
+ignore = E501,E402
 
 [coverage:run]
 branch = true

--- a/tests/model_execution/test_bash.py
+++ b/tests/model_execution/test_bash.py
@@ -7,7 +7,9 @@ import shutil
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
 
-from oasislmf.model_execution.bash import genbash, create_bash_outputs, create_bash_analysis, bash_wrapper, bash_params
+from oasislmf.execution.bash import (bash_params, bash_wrapper,
+                                     create_bash_analysis, create_bash_outputs,
+                                     genbash)
 from oasislmf.utils import diff
 
 TEST_DIRECTORY = os.path.dirname(__file__)
@@ -882,6 +884,7 @@ class Genbash(TestCase):
 class Genbash_GulItemStream(Genbash):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         # test dirs
         cls.KPARSE_INPUT_FOLDER = os.path.join(TEST_DIRECTORY, "kparse_input")
         cls.KPARSE_OUTPUT_FOLDER = os.path.join(TEST_DIRECTORY, "itm_kparse_output")
@@ -904,6 +907,7 @@ class Genbash_GulItemStream(Genbash):
 class Genbash_ErrorGuard(Genbash):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         # test dirs
         cls.KPARSE_INPUT_FOLDER = os.path.join(TEST_DIRECTORY, "kparse_input")
         cls.KPARSE_OUTPUT_FOLDER = os.path.join(TEST_DIRECTORY, "err_kparse_output")
@@ -926,6 +930,7 @@ class Genbash_ErrorGuard(Genbash):
 class Genbash_TempDir(Genbash):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         # test dirs
         cls.KPARSE_INPUT_FOLDER = os.path.join(TEST_DIRECTORY, "kparse_input")
         cls.KPARSE_OUTPUT_FOLDER = os.path.join(TEST_DIRECTORY, "tmp_kparse_output")
@@ -948,6 +953,7 @@ class Genbash_TempDir(Genbash):
 class Genbash_FullCorrItemStream(Genbash):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         # test dirs
         cls.KPARSE_INPUT_FOLDER = os.path.join(TEST_DIRECTORY, "fc_kparse_input")
         cls.KPARSE_OUTPUT_FOLDER = os.path.join(TEST_DIRECTORY, "itm_fc_kparse_output")
@@ -970,6 +976,7 @@ class Genbash_FullCorrItemStream(Genbash):
 class Genbash_FullCorrErrorGuard(Genbash):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         # test dirs
         cls.KPARSE_INPUT_FOLDER = os.path.join(TEST_DIRECTORY, "fc_kparse_input")
         cls.KPARSE_OUTPUT_FOLDER = os.path.join(TEST_DIRECTORY, "err_fc_kparse_output")
@@ -992,6 +999,7 @@ class Genbash_FullCorrErrorGuard(Genbash):
 class Genbash_FullCorrTempDir(Genbash):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         # test dirs
         cls.KPARSE_INPUT_FOLDER = os.path.join(TEST_DIRECTORY, "fc_kparse_input")
         cls.KPARSE_OUTPUT_FOLDER = os.path.join(TEST_DIRECTORY, "tmp_fc_kparse_output")
@@ -1014,6 +1022,7 @@ class Genbash_FullCorrTempDir(Genbash):
 class Genbash_LoadBanlancerFmpy(Genbash):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         # test dirs
         cls.KPARSE_INPUT_FOLDER = os.path.join(TEST_DIRECTORY, "kparse_input")
         cls.KPARSE_OUTPUT_FOLDER = os.path.join(TEST_DIRECTORY, "lb_kparse_output")
@@ -1040,6 +1049,7 @@ class Genbash_LoadBanlancerFmpy(Genbash):
 class Genbash_EventShuffle(Genbash):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         # test dirs
         cls.KPARSE_INPUT_FOLDER = os.path.join(TEST_DIRECTORY, "kparse_input")
         cls.KPARSE_OUTPUT_FOLDER = os.path.join(TEST_DIRECTORY, "eve_kparse_output")

--- a/tests/model_preparation/test_reinsurance.py
+++ b/tests/model_preparation/test_reinsurance.py
@@ -1,28 +1,20 @@
 import os
+import shutil
 import subprocess
 import time
 import unittest
-import hypothesis
-
-from tempfile import TemporaryDirectory
 from collections import OrderedDict
+from tempfile import TemporaryDirectory
 
-import pandas as pd
+import hypothesis
 import numpy as np
-
+import pandas as pd
 from pandas.util.testing import assert_frame_equal
-
 from parameterized import parameterized
 
-from oasislmf.model_preparation import (
-    oed,
-    reinsurance_layer,
-)
-
 from oasislmf.model_execution import bin
+from oasislmf.model_preparation import oed, reinsurance_layer
 from oasislmf.utils.data import get_dataframe, set_dataframe_column_dtypes
-
-import shutil
 
 
 class TestReinsurance(unittest.TestCase):
@@ -3054,10 +3046,6 @@ class TestReinsurance(unittest.TestCase):
             xref_descriptions_df,
             ri_info_df,
             ri_scope_df)
-
-        ri_inputs[0].ri_inputs.fm_policytc.to_csv('/tmp/fm_policytc.csv', index=False)
-        ri_inputs[0].ri_inputs.fm_programme.to_csv('/tmp/fm_programme.csv', index=False)
-        ri_inputs[0].ri_inputs.fm_profile.to_csv('/tmp/fm_profile.csv', index=False)
 
         expected_ri_inputs = [
             reinsurance_layer.RiInputs(


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!--start_release_notes-->
### Oasislmf Testing fixes 
* test_reinsurance.py  - removed unused debugging files 
* test_bash.py - fix for running individual tests
* flake8 - Newer versions of flake8 only recognise codes that match this pattern (single letter, three digits)
<!--end_release_notes-->
