### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       ktools_branch:
-        description: 'If set, build ktools from scratch and use output to build package: [BranchName]'
+        description: "If set, build ktools from scratch and use output to build package: [BranchName]"
         required: false
         default: "develop"
 
@@ -22,11 +22,11 @@ jobs:
     strategy:
       matrix:
         cfg:
-        - { python-version: '3.7', pkg-version: ""}
-        - { python-version: '3.8', pkg-version: ""}
-        - { python-version: '3.9', pkg-version: ""}
-        - { python-version: '3.10', pkg-version: ""}
-        - { python-version: '3.10', pkg-version: 'numba==0.55.1' }
+          - { python-version: "3.7", pkg-version: "" }
+          - { python-version: "3.8", pkg-version: "" }
+          - { python-version: "3.9", pkg-version: "" }
+          - { python-version: "3.10", pkg-version: "" }
+          - { python-version: "3.11", pkg-version: "" }
 
     steps:
       - uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ python_classes =
 [flake8]
 exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,.ropeproject,.hypothesis
 max-line-length = 150
-ignore = E501,402
+ignore = E501,E402
 
 [coverage:run]
 branch = true


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->
In this PR we add Python 3.11 to the matrix of tests in `unittest.yml`, and we drop the specific test for python=3.10 and numba=0.55.1, which we introduced when numba 0.55.2 was released to ensure that we were testing the two most recent numba versions.
Since v0.55.2, `numba` has had 4 more releases and is now at v0.55.6, with no issues being reported across our tests, so we drop the specific test for numba 0.55.1.
This PR fixes  #1162 

<!--start_release_notes-->
### Add support for Python 3.11
This PR extends `oasislmf` support to Python version 3.11.

<!--end_release_notes-->
