### PR TITLE
Add support for codecov.io

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -73,5 +73,5 @@ jobs:
       - name: Run tox
         run: tox -e py
       - name: Upload coverage to Codecov
-        if: matrix.cfg.upload-cov == true && contains(fromJson('["pull_request", "master", "develop"]'), github.event_name)
+        if: matrix.cfg.upload-cov == true
         uses: codecov/codecov-action@v3

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -73,5 +73,5 @@ jobs:
       - name: Run tox
         run: tox -e py
       - name: Upload coverage to Codecov
-        if: ${{ matrix.cfg.upload-cov == true }}
+        if: matrix.cfg.upload-cov == true && contains(fromJson('["pull_request", "master", "develop"]'), github.event_name)
         uses: codecov/codecov-action@v3

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       ktools_branch:
-        description: 'Build Ktools before tests: [git ref]'
+        description: "Build Ktools before tests: [git ref]"
         required: false
         default: "develop"
 
@@ -34,10 +34,10 @@ jobs:
     strategy:
       matrix:
         cfg:
-        - { python-version: '3.7', pkg-version: ""}
-        - { python-version: '3.8', pkg-version: ""}
-        - { python-version: '3.9', pkg-version: ""}
-        - { python-version: '3.10', pkg-version: ""}
+          - { python-version: "3.7", pkg-version: "", upload-cov: false }
+          - { python-version: "3.8", pkg-version: "", upload-cov: false }
+          - { python-version: "3.9", pkg-version: "", upload-cov: false }
+          - { python-version: "3.10", pkg-version: "", upload-cov: true }
 
     steps:
       - uses: actions/checkout@v3
@@ -72,3 +72,6 @@ jobs:
           pip install -r requirements.txt
       - name: Run tox
         run: tox -e py
+      - name: Upload coverage to Codecov
+        if: ${{ matrix.cfg.upload-cov == true }}
+        uses: codecov/codecov-action@v3

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,33 @@
+# codecov.io configuration
+
+# reference for this yml config file:
+#   https://docs.codecov.com/docs/codecovyml-reference
+
+# to check whether codecov.yml is valid, run this command:
+#   curl -X POST --data-binary @codecov.yml https://codecov.io/validate
+
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        threshold: 3%
+        # Allow the coverage to drop by X%, and posting a success status.
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach, diff, flags, files, footer"
+  behavior: default

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,8 @@ python_classes =
 
 [flake8]
 exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,.ropeproject,.hypothesis
-ignore = E501
+max-line-length = 150
+ignore = E501,E402
 
 [coverage:run]
 branch = true


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->
This PR Fix #1169 by adding to the CI workflow the capability to upload code coverage reports to codecov.io to have a better graphical visualization of current coverage, and how code coverage changes with any new PR.

We cannot add a badge to the README right now because the codecov.io dashboard doesn't show any data (we need to merge this PR to master for that). A coverage badge can be added to the README after this PR is merged, in a future PR.
