### PR TITLE
[ci] fix coverage run to produce coverage.xml

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -75,3 +75,5 @@ jobs:
       - name: Upload coverage to Codecov
         if: matrix.cfg.upload-cov == true
         uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.xml

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ omit =
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
-commands = pytest -p no:flaky --ignore=fm_testing_tool --ignore=validation --cov-config=tox.ini --cov=oasislmf {posargs}
+commands = pytest -p no:flaky --ignore=fm_testing_tool --ignore=validation --cov-config=tox.ini --cov=oasislmf --cov-report=xml --cov-report=term {posargs}
 #$commands = pytest -p no:flaky --ignore=fm_testing_tool --ignore=validation --cov-config=tox.ini --cov=oasislmf {posargs} --doctest-modules
 setenv =
     COV_CORE_SOURCE={toxinidir}/oasislmf


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->
This PR fixes a bug in the way we were running coverage through tox, which was causing tox not to produce the `coverage.xml` report to be uploaded to codecov.io.
