### PR TITLE
Set pip-compile to backtracking and trim unused requirments

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -60,13 +60,17 @@ jobs:
           python -m pip install --upgrade pip
           pip install pip-tools
 
+      - name: Set pip resolver flag
+        if: matrix.cfg.python-version == 3.7
+        run: |
+          echo "PIP_RESOLVER=--resolver=backtracking" >> $GITHUB_ENV
       - name: Pip Compile
         run: |
           rm -f requirements.txt
           if [ -z "${{ matrix.cfg.pkg-version }}" ]; then
-            pip-compile requirements.in -o requirements.txt --resolver=backtracking
+            pip-compile requirements.in -o requirements.txt ${PIP_RESOLVER}
           else
-            pip-compile --upgrade-package "${{ matrix.cfg.pkg-version }}" requirements.in -o requirements.txt --resolver=backtracking
+            pip-compile --upgrade-package "${{ matrix.cfg.pkg-version }}" requirements.in -o requirements.txt ${PIP_RESOLVER}
           fi
           pip install -r requirements.txt
       - name: Run tox

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -19,7 +19,6 @@ on:
       ktools_branch:
         description: "Build Ktools before tests: [git ref]"
         required: false
-        default: "develop"
 
 jobs:
   build:
@@ -65,9 +64,9 @@ jobs:
         run: |
           rm -f requirements.txt
           if [ -z "${{ matrix.cfg.pkg-version }}" ]; then
-            pip-compile requirements.in -o requirements.txt
+            pip-compile requirements.in -o requirements.txt --resolver=backtracking
           else
-            pip-compile --upgrade-package "${{ matrix.cfg.pkg-version }}" requirements.in -o requirements.txt
+            pip-compile --upgrade-package "${{ matrix.cfg.pkg-version }}" requirements.in -o requirements.txt --resolver=backtracking
           fi
           pip install -r requirements.txt
       - name: Run tox

--- a/requirements.in
+++ b/requirements.in
@@ -3,18 +3,11 @@
 
 configparser>=3.5.0
 coverage
-discover
-flake8
-freezegun
-future
 hypothesis
-ipdb
 mock
 parameterized
 pip-tools>=2.0.2
-virtualenv<=20.16.2
 pytest
 pytest-cov
 pytest-ignore-flaky
-responses
 tox


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!--start_release_notes-->
### Fix CI bug with pip compile 
* There are several excess packages in `requirements.in` which are not needed for CI testing, these have been removed. 
* Set pip-compile to use backtracking when running with python3.7. 
* Tweaked the default in the manual trigger for `unittest.yml`,  it now won't build ktools unless a branch is given as input.
<!--end_release_notes-->
