### PR TITLE
Use `scikit-learn` in requirements instead of deprecated `sklearn`

### DIFF
--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -749,7 +749,7 @@ class GenerateLossesDeterministic(ComputationStep):
         guls_fp = os.path.join(output_dir, "raw_guls.csv")
         guls.to_csv(guls_fp, index=False)
 
-        #il_stream_type = 2 if self.fmpy else 1
+        # il_stream_type = 2 if self.fmpy else 1
         ils_fp = os.path.join(output_dir, 'raw_ils.csv')
 
         # Create IL fmpy financial structures

--- a/oasislmf/lookup/builtin.py
+++ b/oasislmf/lookup/builtin.py
@@ -351,7 +351,7 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
 
         if nearest_neighbor_min_distance > 0:
             if BallTree is None:
-                raise OasisException(f"sklearn modules are needed for rtree with nearest_neighbor_min_distance, {OPT_INSTALL_MESSAGE}")
+                raise OasisException(f"scikit-learn modules are needed for rtree with nearest_neighbor_min_distance, {OPT_INSTALL_MESSAGE}")
             gdf_area_peril['center'] = gdf_area_peril.centroid
             base_geometry_name = gdf_area_peril.geometry.name
 

--- a/oasislmf/pytools/fm/stream.py
+++ b/oasislmf/pytools/fm/stream.py
@@ -28,7 +28,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-#gul_header = np.int32(1 << 24).tobytes()
+# gul_header = np.int32(1 << 24).tobytes()
 fm_header = np.int32(1 | 2 << 24).tobytes()
 
 
@@ -215,7 +215,7 @@ def load_event(event_agg, sidx_loss, event_id, nodes_array, losses, loss_indexes
             output_id = output_array[node['output_ids'] + layer]
             if output_id:  # if output is not in xref output_id is 0
                 loss_index = loss_indexes[node['ba'] + layer]
-                #print(computes[compute_i], output_id, loss_index, losses[loss_index])
+                # print(computes[compute_i], output_id, loss_index, losses[loss_index])
                 while cursor < nb_values:
                     if i_index == 0:
                         event_agg[cursor]['event_id'], event_agg[cursor]['agg_id'] = event_id, output_id

--- a/optional-package.in
+++ b/optional-package.in
@@ -1,6 +1,6 @@
 shapely>=1.3.0
 geopandas>=0.8.0
-sklearn
+scikit-learn
 pyarrow>=3.0.0
 rtree>=0.8.3
 cookiecutter>=1.6.0

--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,7 @@ class InstallKtoolsMixin(object):
                 OS = None
 
         # ENV OVERRIDE TO install a localy copy of ktools
-        #TAR_DIR = os.path.abspath(os.getenv('KTOOLS_TAR_FILE_DIR', ''))
+        # TAR_DIR = os.path.abspath(os.getenv('KTOOLS_TAR_FILE_DIR', ''))
 
         if os.getenv('KTOOLS_TAR_FILE_DIR', None):
             TAR_OVERRIDE = os.path.join(os.path.abspath(os.getenv('KTOOLS_TAR_FILE_DIR')), '{}_{}.tar.gz'.format(OS, ARCH))

--- a/tests/model_execution/test_bash.py
+++ b/tests/model_execution/test_bash.py
@@ -138,7 +138,7 @@ class Genbash(TestCase):
         )
 
         # debug
-        #print(json.dumps(params, indent=4))
+        # print(json.dumps(params, indent=4))
 
         fifo_tmp_dir = params['fifo_tmp_dir']
         for process_id in range(num_partitions):

--- a/tests/model_preparation/test_summaries.py
+++ b/tests/model_preparation/test_summaries.py
@@ -152,12 +152,12 @@ class TestSummaries(TestCase):
 
         # Check number of not-modelled
         # WARNING: current assumption is that all cov types must be covered to be modelled
-        #moddeled = 0
-        #moddeld_loc_ids = gul_inputs[gul_inputs['status'] == 'success'].loc_id.unique()
+        # moddeled = 0
+        # moddeld_loc_ids = gul_inputs[gul_inputs['status'] == 'success'].loc_id.unique()
         # for loc_id in moddeld_loc_ids:
         #    if len(gul_inputs[gul_inputs.loc_id == loc_id].coverage_type_id.unique()) == 4:
         #        moddeled+=1
-        #self.assertEqual(len(loc_df) - moddeled, exp_summary['total']['not-modelled']['number_of_locations'])
+        # self.assertEqual(len(loc_df) - moddeled, exp_summary['total']['not-modelled']['number_of_locations'])
 
     @given(st.data())
     @settings(max_examples=10, deadline=None)


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->
This PR Fixes #1187  an error that is now being raised during `pip-compile` that causes CI to fail with:
```bash
  × python setup.py egg_info did not run successfully.
    │ exit code: 1
    ╰─> [18 lines of output]
        The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
        rather than 'sklearn' for pip commands.
        
        Here is how to fix this error in the main use cases:
        - use 'pip install scikit-learn' rather than 'pip install sklearn'
        - replace 'sklearn' by 'scikit-learn' in your pip requirements files
          (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
        - if the 'sklearn' package is used by one of your dependencies,
          it would be great if you take some time to track which package uses
          'sklearn' instead of 'scikit-learn' and report it to their issue tracker
        - as a last resort, set the environment variable
          SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error
        
        More information is available at
        https://github.com/scikit-learn/sklearn-pypi-package
        
        If the previous advice does not cover your use case, feel free to report it at
        https://github.com/scikit-learn/sklearn-pypi-package/issues/new
        [end of output]
```

The PR also implements a handful more PEP8 fixes, that popped up with `autopep8` v2.0.1 being released on 15th Dec 2022.

