### PR TITLE
Collect coverage in numba jit compiled functions

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -36,6 +36,7 @@ jobs:
           - { python-version: "3.7", pkg-version: "", upload-cov: false }
           - { python-version: "3.8", pkg-version: "", upload-cov: false }
           - { python-version: "3.9", pkg-version: "", upload-cov: false }
+          - { python-version: "3.10", pkg-version: "", upload-cov: false }
           - { python-version: "3.10", pkg-version: "", upload-cov: true }
 
     steps:
@@ -63,6 +64,10 @@ jobs:
         if: matrix.cfg.python-version == 3.7
         run: |
           echo "PIP_RESOLVER=--resolver=backtracking" >> $GITHUB_ENV
+      - name: Disable numba jit compilation when coverage is gathered
+        if: matrix.cfg.upload-cov == true
+        run: |
+          echo "NUMBA_DISABLE_JIT=1" >> $GITHUB_ENV
       - name: Pip Compile
         run: |
           rm -f requirements.txt


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->
This PR Fixes #  by introducing a specific test run to collect coverage information. In that run, numba jit compilation is disabled so that coverage can collect information on the lines hit by the tests. 

As documented here: https://community.codecov.com/t/numba-jitted-methods-are-not-captured-by-codecov/2649 coverage doesn't collect coverage from jit compiled functions, which results in a possibly considerable underestimate of our code coverage.

<!--start_release_notes-->
### Release notes feature title
... Release notes description / summary
... Any text between these two tags will be automatically pulled into the platform release notes
<!--end_release_notes-->
