### PR TITLE
use io.open for footprint bin instead of os.open to take advantage of…

### DIFF
--- a/oasislmf/pytools/getmodel/footprint.py
+++ b/oasislmf/pytools/getmodel/footprint.py
@@ -175,11 +175,8 @@ class FootprintBin(Footprint):
     footprint_filenames = [footprint_filename, footprint_index_filename]
 
     def __enter__(self):
-        self.footprint = self.stack.enter_context(
-            mmap.mmap(os.open(os.path.join(self.static_path, footprint_filename), flags=os.O_RDONLY),
-                      length=0, access=mmap.ACCESS_READ
-                      )
-        )
+        footprint_file = self.stack.enter_context(open(os.path.join(self.static_path, footprint_filename), 'rb'))
+        self.footprint = mmap.mmap(footprint_file.fileno(), length=0, access=mmap.ACCESS_READ)
         footprint_header = np.frombuffer(bytearray(self.footprint[:FootprintHeader.size]), dtype=FootprintHeader)
         self.num_intensity_bins = int(footprint_header['num_intensity_bins'])
         self.has_intensity_uncertainty = int(footprint_header['has_intensity_uncertainty'] & intensityMask)
@@ -227,8 +224,8 @@ class FootprintBinZ(Footprint):
     footprint_filenames = [zfootprint_filename, zfootprint_index_filename]
 
     def __enter__(self):
-        self.zfootprint = self.stack.enter_context(mmap.mmap(os.open(os.path.join(self.static_path, zfootprint_filename), flags=os.O_RDONLY),
-                                                             length=0, access=mmap.ACCESS_READ))
+        zfootprint_file = self.stack.enter_context(open(os.path.join(self.static_path, zfootprint_filename), 'rb'))
+        self.zfootprint = mmap.mmap(zfootprint_file.fileno(), length=0, access=mmap.ACCESS_READ)
 
         footprint_header = np.frombuffer(bytearray(self.zfootprint[:FootprintHeader.size]), dtype=FootprintHeader)
         self.num_intensity_bins = int(footprint_header['num_intensity_bins'])


### PR DESCRIPTION
… automatic closure

<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### fix Footprint open file leakage in `gulmc` and `getmodel`
Closure of `footprint.bin` and `footprint.bin.z` file was not handled properly in `oasislmf/pytools/getmodel/footprint.py`.
This code is used in both `gulmc` and `getmodel` and was keeping the file open until the process finished.
<!--end_release_notes-->
