### PR TITLE
add option to have custom oed schema

### DIFF
--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -102,6 +102,7 @@ class GenerateFiles(ComputationStep):
         {'name': 'profile_loc_json', 'flag': '-e', 'is_path': True, 'pre_exist': True, 'help': 'Source (OED) exposure profile JSON path'},
         {'name': 'profile_acc_json', 'flag': '-b', 'is_path': True, 'pre_exist': True, 'help': 'Source (OED) accounts profile JSON path'},
         {'name': 'profile_fm_agg_json', 'flag': '-g', 'is_path': True, 'pre_exist': True, 'help': 'FM (OED) aggregation profile path'},
+        {'name': 'oed_schema_info', 'is_path': True, 'pre_exist': True, 'help': 'path to custom oed_schema'},
         {'name': 'currency_conversion_json', 'is_path': True, 'pre_exist': True, 'help': 'settings to perform currency conversion of oed files'},
         {'name': 'reporting_currency', 'help': 'currency to use in the results reported'},
         {'name': 'oed_location_csv', 'flag': '-x', 'is_path': True, 'pre_exist': True, 'help': 'Source location CSV file path'},
@@ -140,6 +141,7 @@ class GenerateFiles(ComputationStep):
             'account': self.oed_accounts_csv,
             'ri_info': self.oed_info_csv,
             'ri_scope': self.oed_scope_csv,
+            'oed_schema_info': self.oed_schema_info,
             'currency_conversion': self.currency_conversion_json,
             'check_oed': self.check_oed,
             'use_field': True

--- a/oasislmf/computation/generate/keys.py
+++ b/oasislmf/computation/generate/keys.py
@@ -18,6 +18,7 @@ class KeyComputationStep(ComputationStep):
     def get_exposure_data_config(self):
         return {
             'location': self.oed_location_csv,
+            'oed_schema_info': self.oed_schema_info,
             'check_oed': self.check_oed,
             'use_field': True
         }
@@ -59,6 +60,7 @@ class GenerateKeys(KeyComputationStep):
 
     step_params = [
         {'name': 'oed_location_csv', 'flag': '-x', 'is_path': True, 'pre_exist': True, 'help': 'Source location CSV file path'},
+        {'name': 'oed_schema_info', 'is_path': True, 'pre_exist': True, 'help': 'path to custom oed_schema'},
         {'name': 'check_oed', 'type': str2bool, 'const': True, 'nargs': '?', 'default': True, 'help': 'if True check input oed files'},
         {'name': 'keys_data_csv', 'flag': '-k', 'is_path': True, 'pre_exist': False, 'help': 'Generated keys CSV output path'},
         {'name': 'keys_errors_csv', 'flag': '-e', 'is_path': True, 'pre_exist': False, 'help': 'Generated keys errors CSV output path'},
@@ -138,6 +140,7 @@ class GenerateKeys(KeyComputationStep):
 class GenerateKeysDeterministic(KeyComputationStep):
     step_params = [
         {'name': 'oed_location_csv', 'flag': '-x', 'is_path': True, 'pre_exist': True, 'help': 'Source location CSV file path'},
+        {'name': 'oed_schema_info', 'is_path': True, 'pre_exist': True, 'help': 'path to custom oed_schema'},
         {'name': 'check_oed', 'type': str2bool, 'const': True, 'nargs': '?', 'default': True, 'help': 'if True check input oed files'},
         {'name': 'keys_data_csv', 'flag': '-k', 'is_path': True, 'pre_exist': False, 'help': 'Generated keys CSV output path'},
         {'name': 'num_subperils', 'flag': '-p', 'default': 1, 'type': int,

--- a/oasislmf/computation/hooks/pre_analysis.py
+++ b/oasislmf/computation/hooks/pre_analysis.py
@@ -34,6 +34,7 @@ class ExposurePreAnalysis(ComputationStep):
                     'help': 'Name of the class to use for the exposure_pre_analysis'},
                    {'name': 'exposure_pre_analysis_setting_json', 'is_path': True, 'pre_exist': True,
                     'help': 'Exposure Pre-Analysis config JSON file path'},
+                   {'name': 'oed_schema_info', 'is_path': True, 'pre_exist': True, 'help': 'path to custom oed_schema'},
                    {'name': 'oed_location_csv', 'is_path': True, 'pre_exist': True, 'help': 'Source location CSV file path'},
                    {'name': 'oed_accounts_csv', 'is_path': True, 'pre_exist': True, 'help': 'Source accounts CSV file path'},
                    {'name': 'oed_info_csv', 'is_path': True, 'pre_exist': True, 'help': 'Reinsurance info. CSV file path'},
@@ -51,6 +52,7 @@ class ExposurePreAnalysis(ComputationStep):
             'account': self.oed_accounts_csv,
             'ri_info': self.oed_info_csv,
             'ri_scope': self.oed_scope_csv,
+            'oed_schema_info': self.oed_schema_info,
             'check_oed': self.check_oed,
             'use_field': True
         }

--- a/oasislmf/computation/run/exposure.py
+++ b/oasislmf/computation/run/exposure.py
@@ -44,6 +44,7 @@ class RunExposure(ComputationStep):
         {'name': 'check_oed', 'type': str2bool, 'const': True, 'nargs': '?', 'default': True, 'help': 'if True check input oed files'},
         {'name': 'output_file', 'flag': '-f', 'is_path': True, 'pre_exist': False, 'help': '', 'type': str},
         {'name': 'loss_factor', 'flag': '-l', 'type': float, 'nargs': '+', 'help': '', 'default': [1.0]},
+        {'name': 'oed_schema_info', 'is_path': True, 'pre_exist': True, 'help': 'path to custom oed_schema'},
         {'name': 'currency_conversion_json', 'is_path': True, 'pre_exist': True, 'help': 'settings to perform currency conversion of oed files'},
         {'name': 'reporting_currency', 'help': 'currency to use in the results reported'},
         {'name': 'ktools_alloc_rule_il', 'flag': '-a', 'default': KTOOLS_ALLOC_IL_DEFAULT, 'type': int,

--- a/oasislmf/computation/run/model.py
+++ b/oasislmf/computation/run/model.py
@@ -45,6 +45,7 @@ class RunModel(ComputationStep):
             'account': self.oed_accounts_csv,
             'ri_info': self.oed_info_csv,
             'ri_scope': self.oed_scope_csv,
+            'oed_schema_info': self.oed_schema_info,
             'currency_conversion': self.currency_conversion_json,
             'check_oed': self.check_oed,
             'use_field': True

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -926,6 +926,7 @@ def get_exposure_data(computation_step, add_internal_col=False):
         else:  # ExposureData info was not created, oed input file must have default name (location, account, ...)
             exposure_data = OedExposure.from_dir(
                 computation_step.oasis_files_dir,
+                oed_schema_info=getattr(computation_step, 'oed_schema_info', None),
                 currency_conversion=getattr(computation_step, 'currency_conversion_json', None),
                 reporting_currency=getattr(computation_step, 'reporting_currency', None),
                 check_oed=computation_step.check_oed,


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### add option oed_schema_info to specify custom oed schmea
ods_tools provide the ability to specify your own oed schmea instead of using the default one.
This option can be use for example to change default value or add new columns or code.
To create your own oed_schema from the original one.

1. copy [OpenExposureData_Spec.xlsx](https://github.com/OasisLMF/ODS_OpenExposureData/blob/develop/OpenExposureData/Docs/OpenExposureData_Spec.xlsx).
2. do your modification
3. convert it to oed json schema using the script in [extract_spec.py](https://github.com/OasisLMF/ODS_OpenExposureData/blob/develop/docker/extract_spec.py)
`python  path_to/extract_spec.py json --source-excel-path path_to/OpenExposureData_Spec.xlsx --output-json-path path_to/custom_oed_schema.json`

then add the path to the config or option when calling oasislmf using the name oed_schema_info.
example in the config for oasislmf model:
"oed_schema_info": "path_to/custom_oed_schema.json",




<!--end_release_notes-->
