### PR TITLE
Fix expecteted output with Extra TIV cols from ods-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `oasislmf` Python package, loosely called the *model development kit (MDK)* 
 ## Releases and maintenance
 Releases are published on a monthly cadence which tracks our team's development cycle. The planned fixes, enhancements and features can be seen on the [project development board](https://github.com/orgs/OasisLMF/projects/37) before each release.
 
-> Note: From April 2022 and on the oasis release cycle is changing, the monthly published versions are switching to become 'pre-release' builds and the Long term support releases (currently 1.15.x and 1.23.x) will be the new 'standard oasis releases' for production use.
+> Note:  From April 2022 and on the oasis release cycle is changing, the monthly published versions are switching to become 'pre-release' builds and the Long term support releases (currently 1.15.x and 1.23.x) will be the new 'standard oasis releases' for production use.
 
 In practice, this is a shift in release labels which should better align with the intended use cases. Monthly builds are viewed as intermediate releases for testing new features, while the standard releases (marked by an increase in the minor version number 1.27.0 -> 1.28.0)
 are stable builds.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `oasislmf` Python package, loosely called the *model development kit (MDK)* 
 ## Releases and maintenance
 Releases are published on a monthly cadence which tracks our team's development cycle. The planned fixes, enhancements and features can be seen on the [project development board](https://github.com/orgs/OasisLMF/projects/37) before each release.
 
-> Note:  From April 2022 and on the oasis release cycle is changing, the monthly published versions are switching to become 'pre-release' builds and the Long term support releases (currently 1.15.x and 1.23.x) will be the new 'standard oasis releases' for production use.
+> Note: From April 2022 and on the oasis release cycle is changing, the monthly published versions are switching to become 'pre-release' builds and the Long term support releases (currently 1.15.x and 1.23.x) will be the new 'standard oasis releases' for production use.
 
 In practice, this is a shift in release labels which should better align with the intended use cases. Monthly builds are viewed as intermediate releases for testing new features, while the standard releases (marked by an increase in the minor version number 1.27.0 -> 1.28.0)
 are stable builds.

--- a/tests/model_preparation/test_exposure_pre_analysis.py
+++ b/tests/model_preparation/test_exposure_pre_analysis.py
@@ -15,12 +15,12 @@ input_oed_location = """PortNumber,AccNumber,LocNumber,BuildingTIV
 1,A11111,10002082050,5
 """
 
-output_oed_location = """PortNumber,AccNumber,LocNumber,BuildingTIV,loc_id,loc_idx
-1,A11111,10002082046,2.0,1,0
-1,A11111,10002082047,4.0,2,1
-1,A11111,10002082048,6.0,3,2
-1,A11111,10002082049,8.0,4,3
-1,A11111,10002082050,10.0,5,4
+output_oed_location = """PortNumber,AccNumber,LocNumber,BuildingTIV,ContentsTIV,BITIV,loc_id,loc_idx
+1,A11111,10002082046,2.0,0.0,0.0,1,0
+1,A11111,10002082047,4.0,0.0,0.0,2,1
+1,A11111,10002082048,6.0,0.0,0.0,3,2
+1,A11111,10002082049,8.0,0.0,0.0,4,3
+1,A11111,10002082050,10.0,0.0,0.0,5,4
 """
 
 


### PR DESCRIPTION
<!--start_release_notes-->
### Fix Unit tests for ods-tools>=3.0.2 
With this change to ods-tools https://github.com/OasisLMF/ODS_OpenExposureData/pull/133 missing required columns 
which allow blanks are added to processed location files. This causes the tests in `tests/model_preparation/test_exposure_pre_analysis.py` to fail. 

Fixed by added the extra TIV columns to expected output.  See [Github actions](https://github.com/OasisLMF/ODS_OpenExposureData/actions/runs/4245616602/jobs/7381380103) for example error 
<!--end_release_notes-->
