### PR TITLE
updated exposure run error message for clarity

### DIFF
--- a/oasislmf/computation/run/exposure.py
+++ b/oasislmf/computation/run/exposure.py
@@ -96,8 +96,8 @@ class RunExposure(ComputationStep):
         exposure_data = get_exposure_data(self, add_internal_col=True)
         if not exposure_data.location or not exposure_data.account:
             raise OasisException(
-                f'No location/exposure found in source directory "{src_dir}" - '
-                'a file named `location.*` is expected'
+                f'Location and/or account missing in source directory "{src_dir}" - '
+                'files named `location.*` and `account.*` are expected'
             )
         il = bool(exposure_data.account)
         ril = all([exposure_data.ri_info, exposure_data.ri_scope, il])


### PR DESCRIPTION
fixed #1233 


<!--start_release_notes-->
Expanded error message in oasislmf exposure run for missing/misspelled account file names. Previously the error message suggested the location file was missing, which is misleading 
<!--end_release_notes-->
