### PR TITLE
Release/1.27.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,17 @@
 OasisLMF Changelog
 ==================
 
+`1.27.2`_
+ ---------
+* [#1220](https://github.com/OasisLMF/OasisLMF/pull/1220) - Fix mapping of `vuln_idx` to `vuln_i` and implement `eff_vuln_cdf` as a dynamic array to work with large footprints
+* [#1130](https://github.com/OasisLMF/OasisLMF/pull/1130) - Remove check for IL + RI files from the run model cmd
+* [#1232](https://github.com/OasisLMF/OasisLMF/pull/1232) - Moved Settings JSON validation to ods-tools
+* [#1233](https://github.com/OasisLMF/OasisLMF/pull/1234) - oasislmf exposure run reports missing location file when account missing
+* [#141](https://github.com/OasisLMF/OasisLMF/pull/1235) - Implement account level financial structures
+* [#1236](https://github.com/OasisLMF/OasisLMF/pull/1236) - Switch changelog builder from "build" repo to "OasisPlatform"
+* [#1156, #1180, #1151](https://github.com/OasisLMF/OasisLMF/pull/1181) - [gulmc] implement hazard correlation
+.. _`1.27.2`:  https://github.com/OasisLMF/OasisLMF/compare/1.27.1...1.27.2
+
 `1.27.1`_
  ---------
 * [#1218](https://github.com/OasisLMF/OasisLMF/pull/1218) - Fix missing default collumn for RI

--- a/oasislmf/__init__.py
+++ b/oasislmf/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.27.1'
+__version__ = '1.27.2'
 
 import sys
 from importlib.abc import MetaPathFinder, Loader

--- a/requirements-package.in
+++ b/requirements-package.in
@@ -7,7 +7,7 @@ msgpack
 numba>=0.55.1
 numexpr
 numpy<1.23,>=1.18
-ods-tools>=3.0.0
+ods-tools>=3.0.4
 pandas>=1.0.3,!=1.1.0,!=1.1.1
 pytz
 requests-toolbelt

--- a/tests/model_preparation/test_exposure_pre_analysis.py
+++ b/tests/model_preparation/test_exposure_pre_analysis.py
@@ -15,12 +15,12 @@ input_oed_location = """PortNumber,AccNumber,LocNumber,BuildingTIV
 1,A11111,10002082050,5
 """
 
-output_oed_location = """PortNumber,AccNumber,LocNumber,BuildingTIV,loc_id,loc_idx
-1,A11111,10002082046,2.0,1,0
-1,A11111,10002082047,4.0,2,1
-1,A11111,10002082048,6.0,3,2
-1,A11111,10002082049,8.0,4,3
-1,A11111,10002082050,10.0,5,4
+output_oed_location = """PortNumber,AccNumber,LocNumber,BuildingTIV,ContentsTIV,BITIV,loc_id,loc_idx
+1,A11111,10002082046,2.0,0.0,0.0,1,0
+1,A11111,10002082047,4.0,0.0,0.0,2,1
+1,A11111,10002082048,6.0,0.0,0.0,3,2
+1,A11111,10002082049,8.0,0.0,0.0,4,3
+1,A11111,10002082050,10.0,0.0,0.0,5,4
 """
 
 


### PR DESCRIPTION
## OasisLMF Changelog - [1.27.2](https://github.com/OasisLMF/OasisLMF/compare/1.27.1...1.27.2)
* [#1220](https://github.com/OasisLMF/OasisLMF/pull/1220) - Fix mapping of `vuln_idx` to `vuln_i` and implement `eff_vuln_cdf` as a dynamic array to work with large footprints
* [#1130](https://github.com/OasisLMF/OasisLMF/pull/1130) - Remove check for IL + RI files from the run model cmd
* [#1232](https://github.com/OasisLMF/OasisLMF/pull/1232) - Moved Settings JSON validation to ods-tools
* [#1233](https://github.com/OasisLMF/OasisLMF/pull/1234) - oasislmf exposure run reports missing location file when account missing
* [#141](https://github.com/OasisLMF/OasisLMF/pull/1235) - Implement account level financial structures
* [#1236](https://github.com/OasisLMF/OasisLMF/pull/1236) - Switch changelog builder from "build" repo to "OasisPlatform"
* [#1156, #1180, #1151](https://github.com/OasisLMF/OasisLMF/pull/1181) - [gulmc] implement hazard correlation
