### PR TITLE
Use console entrypoint to define and install `oasislmf` binary

### DIFF
--- a/bin/oasislmf
+++ b/bin/oasislmf
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-import sys
-
-from oasislmf.cli import RootCmd
-
-if __name__ == '__main__':
-    sys.exit(RootCmd().run())

--- a/oasislmf/cli/root.py
+++ b/oasislmf/cli/root.py
@@ -1,18 +1,19 @@
-from ..utils.exceptions import OasisException
+import sys
 
+from ..utils.exceptions import OasisException
 from .admin import AdminCmd
+from .api import ApiCmd
+from .command import OasisBaseCommand
 from .config import ConfigCmd
 from .exposure import ExposureCmd
 from .model import ModelCmd
-from .command import OasisBaseCommand
 from .test import TestCmd
 from .version import VersionCmd
-from .api import ApiCmd
 
 
 class RootCmd(OasisBaseCommand):
     """
-    Tool for manageing oasislmf models
+    Tool for managing oasislmf models.
     """
     sub_commands = {
         'admin': AdminCmd,
@@ -46,3 +47,8 @@ class RootCmd(OasisBaseCommand):
             else:
                 self.logger.error(str(e))
             return 1
+
+
+def main():
+    """CLI entrypoint for running the whole RootCmd"""
+    sys.exit(RootCmd().run())

--- a/oasislmf/cli/root.py
+++ b/oasislmf/cli/root.py
@@ -1,14 +1,14 @@
 import sys
 
-from ..utils.exceptions import OasisException
-from .admin import AdminCmd
-from .api import ApiCmd
-from .command import OasisBaseCommand
-from .config import ConfigCmd
-from .exposure import ExposureCmd
-from .model import ModelCmd
-from .test import TestCmd
-from .version import VersionCmd
+from oasislmf.cli.admin import AdminCmd
+from oasislmf.cli.api import ApiCmd
+from oasislmf.cli.command import OasisBaseCommand
+from oasislmf.cli.config import ConfigCmd
+from oasislmf.cli.exposure import ExposureCmd
+from oasislmf.cli.model import ModelCmd
+from oasislmf.cli.test import TestCmd
+from oasislmf.cli.version import VersionCmd
+from oasislmf.utils.exceptions import OasisException
 
 
 class RootCmd(OasisBaseCommand):
@@ -52,3 +52,7 @@ class RootCmd(OasisBaseCommand):
 def main():
     """CLI entrypoint for running the whole RootCmd"""
     sys.exit(RootCmd().run())
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -367,7 +367,7 @@ setup(
     exclude_package_data={
         '': ['__pycache__', '*.py[co]'],
     },
-    scripts=['bin/oasislmf', 'bin/completer_oasislmf', 'bin/ktools_monitor.sh'],
+    scripts=['bin/completer_oasislmf', 'bin/ktools_monitor.sh'],
     entry_points={
         'console_scripts': [
             'complex_itemtobin=oasislmf.execution.complex_items_to_bin:main',
@@ -382,6 +382,7 @@ setup(
             'gulpy=oasislmf.pytools.gulpy:main',
             'load_balancer=oasislmf.execution.load_balancer:main',
             'modelpy=oasislmf.pytools.modelpy:main',
+            'oasislmf=oasislmf.cli.root:main',
             "servedata=oasislmf.pytools.data_layer.footprint_layer:main",
             'vulntoparquet=oasislmf.pytools.getmodel.vulnerability:main',
         ]


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->
Following the approach we use for all executables in `oasislmf/pytools` (e.g., `fmpy`, `gulmc`, etc.), we now define a console entrypoint for the main executable `oasislmf`.

This simplifies the current implementation that relies on ad-hoc script (an extension-less python script named `oasislmf`) and ad-hoc installation in setup.py. This is not necessary and using a console entrypoint is simpler and more natural.

The changes proposed in this PR are also really useful for debugging the whole MDK. To debug `oasislmf model run`, it is now sufficient to execute `oasislmf.cli.root.py:main()` with a debugger.

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->
