### PR TITLE
bugfix for pandas 2.0.0

### DIFF
--- a/oasislmf/lookup/builtin.py
+++ b/oasislmf/lookup/builtin.py
@@ -13,6 +13,7 @@ import pandas as pd
 
 try:  # needed for rtree
     from shapely.geometry import Point
+
     # Hide numerous warnings similar to:
     # > ...lib64/python3.8/site-packages/geopandas/_compat.py:112: UserWarning: The Shapely GEOS
     # > version (3.8.0-CAPI-1.13.1 ) is incompatible with the GEOS version PyGEOS was compiled with
@@ -31,15 +32,14 @@ try:  # needed for rtree
 except ImportError:
     Point = gdp = None
 
+import itertools
 import math
 import re
-import itertools
 
-from ..utils.exceptions import OasisException
-from ..utils.status import OASIS_KEYS_STATUS, OASIS_UNKNOWN_ID
-from ..utils.peril import PERILS, PERIL_GROUPS
-
-from .base import AbstractBasicKeyLookup, MultiprocLookupMixin
+from oasislmf.lookup.base import AbstractBasicKeyLookup, MultiprocLookupMixin
+from oasislmf.utils.exceptions import OasisException
+from oasislmf.utils.peril import PERIL_GROUPS, PERILS
+from oasislmf.utils.status import OASIS_KEYS_STATUS, OASIS_UNKNOWN_ID
 
 OPT_INSTALL_MESSAGE = "install oasislmf with extra packages by running 'pip install oasislmf[extra]'"
 
@@ -207,7 +207,7 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
                            if useful_col.lower() in lower_case_column_map}
 
         locations = locations.rename(columns=useful_cols_map)
-        locations = locations[locations.columns & useful_cols].drop_duplicates()
+        locations = locations[list(useful_cols.intersection(locations.columns))].drop_duplicates()
 
         # set default status and message
         locations['status'] = OASIS_KEYS_STATUS['success']['id']


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->
We introduce a minor fix to get `oasislmf` to work with `pandas 2.0.0`, which was released in April 2023.
This PR Fix #1251.

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Make oasislmf compatible with pandas 2.0.0
We introduce a minor fix to get `oasislmf` to work with `pandas 2.0.0`, which was released in April 2023.


<!--end_release_notes-->
