### PR TITLE
Fix summary levels file

### DIFF
--- a/oasislmf/preparation/summaries.py
+++ b/oasislmf/preparation/summaries.py
@@ -253,17 +253,17 @@ def write_summary_levels(exposure_df, accounts_df, exposure_data, target_dir):
 
     # GUL perspective (loc columns only)
     l_col_list = exposure_df.replace(0, np.nan).dropna(how='any', axis=1).columns.to_list()
-    l_col_info = {k: v for k, v in exposure_data.get_input_fields('Loc').items()}
-    gul_avail = {k: l_col_info[k]["Type & Description"] if k in l_col_info else desc_non_oed
+    l_col_info = exposure_data.get_input_fields('Loc')
+    gul_avail = {k: l_col_info[k.lower()]["Type & Description"] if k.lower() in l_col_info else desc_non_oed
                  for k in set([c for c in l_col_list]).difference(int_excluded_cols)}
 
     # IL perspective (join of acc + loc col with no dups)
     il_avail = {}
     if accounts_df is not None:
         a_col_list = accounts_df.loc[:, ~accounts_df.isnull().all()].columns.to_list()
-        a_col_info = {k: v for k, v in exposure_data.get_input_fields('Acc').items()}
+        a_col_info = exposure_data.get_input_fields('Acc')
         a_avail = set([c for c in a_col_list])
-        il_avail = {k: a_col_info[k]["Type & Description"] if k in a_col_info else desc_non_oed
+        il_avail = {k: a_col_info[k.lower()]["Type & Description"] if k.lower() in a_col_info else desc_non_oed
                     for k in a_avail.difference(gul_avail.keys())}
 
     # Write JSON


### PR DESCRIPTION
<!--start_release_notes-->
### Fixed summary levels file not detecting OED fields 
Fix for issue https://github.com/OasisLMF/OasisLMF/issues/1241 
<!--end_release_notes-->


#### Example PiWind Output after fix 
```
{
    "GUL": {
        "available": {
            "AccCurrency": "Account currency",
            "AccNumber": "Account number",
            "BuildingID": "Unique building identification number",
            "BuildingTIV": "Building Total Insured Value",
            "ConstructionCode": "OED construction code",
            "CountryCode": "Country code (based on ISO3166 alpha-2 codes)",
            "IsTenant": "Whether property is occupied by a tenant or not",
            "Latitude": "Latitude in degrees (-90.0 to +90.0)",
            "LayerAttachment": "Policy layer attachment point (always treated as amount)",
            "LayerLimit": "Policy layer limit (always treated as amount)",
            "LayerNumber": "Layer number",
            "LayerParticipation": "Insurance company share of the policy layer. Values between 0 to 1 (e.g. 12% entered as 0.12)",
            "LocCurrency": "Location currency",
            "LocNumber": "Location number",
            "LocPerilsCovered": "Location perils covered",
            "Longitude": "Longitude in degrees (-180.0 to +180.0)",
            "OEDVersion": "The OED schema version of the file - 'major, minor, patch' format i.e. (2.0.0)",
            "OccupancyCode": "OED occupancy code",
            "PolExpiryDate": "Policy expiry date - in ISO 8601 format: YYYY-MM-DD",
            "PolInceptionDate": "Policy inception date - in ISO 8601 format: YYYY-MM-DD",
            "PolNumber": "Policy layer number",
            "PolPerilsCovered": "Policy perils covered",
            "PortNumber": "Portfolio number",
            "PostalCode": "Postcode: the highest resolution postcode most often used. (e.g. 5 digit zip for the US).",
            "StreetAddress": "Street address including house number ",
            "acc_idx": "Not an OED field",
            "coverage_id": "Oasis coverage identifier",
            "coverage_type_id": "Oasis coverage type",
            "layer_id": "Not an OED field",
            "peril_id": "OED peril code"
        }
    },
    "IL": {
        "available": {
            "AccCurrency": "Account currency",
            "AccNumber": "Account number",
            "BuildingID": "Unique building identification number",
            "BuildingTIV": "Building Total Insured Value",
            "ConstructionCode": "OED construction code",                                                                                                                                                                                                                                                                                                                                                                                  
            "CountryCode": "Country code (based on ISO3166 alpha-2 codes)",
            "IsTenant": "Whether property is occupied by a tenant or not",
            "Latitude": "Latitude in degrees (-90.0 to +90.0)",
            "LayerAttachment": "Policy layer attachment point (always treated as amount)",
            "LayerLimit": "Policy layer limit (always treated as amount)",
            "LayerNumber": "Layer number",
            "LayerParticipation": "Insurance company share of the policy layer. Values between 0 to 1 (e.g. 12% entered as 0.12)",
            "LocCurrency": "Location currency",
            "LocNumber": "Location number",
            "LocPerilsCovered": "Location perils covered",
            "Longitude": "Longitude in degrees (-180.0 to +180.0)",
            "OEDVersion": "The OED schema version of the file - 'major, minor, patch' format i.e. (2.0.0)",
            "OccupancyCode": "OED occupancy code",
            "PolExpiryDate": "Policy expiry date - in ISO 8601 format: YYYY-MM-DD",
            "PolInceptionDate": "Policy inception date - in ISO 8601 format: YYYY-MM-DD",
            "PolNumber": "Policy layer number",
            "PolPerilsCovered": "Policy perils covered",
            "PortNumber": "Portfolio number",
            "PostalCode": "Postcode: the highest resolution postcode most often used. (e.g. 5 digit zip for the US).",
            "StreetAddress": "Street address including house number ",
            "acc_idx": "Not an OED field",
            "coverage_id": "Oasis coverage identifier",
            "coverage_type_id": "Oasis coverage type",
            "layer_id": "Not an OED field",
            "peril_id": "OED peril code"
        }
    }
}
```