### PR TITLE
specify dtype for useful summary column reading

### DIFF
--- a/oasislmf/preparation/summaries.py
+++ b/oasislmf/preparation/summaries.py
@@ -38,6 +38,20 @@ from ..utils.log import oasis_log
 from ..utils.path import as_path
 from ..utils.status import OASIS_KEYS_STATUS, OASIS_KEYS_STATUS_MODELLED
 
+MAP_SUMMARY_DTYPES = {
+    'loc_id': 'int',
+    SOURCE_IDX['loc']: 'int',
+    SOURCE_IDX['acc']: 'int',
+    'item_id': 'int',
+    'layer_id': 'int',
+    'coverage_id': 'int',
+    'peril_id': 'category',
+    'agg_id': 'int',
+    'output_id': 'int',
+    'coverage_type_id': 'int',
+    'tiv': 'float'
+}
+
 
 def get_useful_summary_cols(oed_hierarchy):
     return [
@@ -448,7 +462,6 @@ def get_summary_xref_df(map_df, exposure_df, accounts_df, summaries_info_dict, s
     :return summary_desc: dictionary of dataFrames listing what summary_ids map to
     :rtype: dictionary
     """
-
     summaryxref_df = pd.DataFrame()
     summary_desc = {}
 
@@ -550,8 +563,12 @@ def generate_summaryxref_files(location_df, account_df, model_run_fp, analysis_s
         il_map_fp = os.path.join(model_run_fp, 'input', SUMMARY_MAPPING['fm_map_fn'])
         il_map_df = get_dataframe(
             src_fp=il_map_fp,
-            empty_data_error_msg='No summary map file found.'
+            lowercase_cols=False,
+            col_dtypes=MAP_SUMMARY_DTYPES,
+            empty_data_error_msg='No summary map file found.',
         )
+        il_map_df = il_map_df[list(set(il_map_df).intersection(MAP_SUMMARY_DTYPES))]
+
         if gul_summaries:
             gul_map_df = il_map_df
             gul_map_df['item_id'] = gul_map_df['agg_id']
@@ -560,7 +577,11 @@ def generate_summaryxref_files(location_df, account_df, model_run_fp, analysis_s
         gul_map_fp = os.path.join(model_run_fp, 'input', SUMMARY_MAPPING['gul_map_fn'])
         gul_map_df = get_dataframe(
             src_fp=gul_map_fp,
-            empty_data_error_msg='No summary map file found.')
+            lowercase_cols=False,
+            col_dtypes=MAP_SUMMARY_DTYPES,
+            empty_data_error_msg='No summary map file found.',
+        )
+        gul_map_df = gul_map_df[list(set(gul_map_df).intersection(MAP_SUMMARY_DTYPES))]
 
     if gul_summaries:
         # Load GUL summary map
@@ -585,8 +606,11 @@ def generate_summaryxref_files(location_df, account_df, model_run_fp, analysis_s
         il_map_fp = os.path.join(model_run_fp, 'input', SUMMARY_MAPPING['fm_map_fn'])
         il_map_df = get_dataframe(
             src_fp=il_map_fp,
-            empty_data_error_msg='No summary map file found.'
+            lowercase_cols=False,
+            col_dtypes=MAP_SUMMARY_DTYPES,
+            empty_data_error_msg='No summary map file found.',
         )
+        il_map_df = il_map_df[list(set(il_map_df).intersection(MAP_SUMMARY_DTYPES))]
 
         il_summaryxref_df, il_summary_desc = get_summary_xref_df(
             il_map_df,
@@ -608,13 +632,15 @@ def generate_summaryxref_files(location_df, account_df, model_run_fp, analysis_s
         summary_ri_fp = os.path.join(
             model_run_fp, os.path.basename(ri_layers[max_layer]['directory']))
 
-        ri_summaryxref_df = pd.DataFrame()
         if ('il_summaries' not in analysis_settings) or (not il_summaries):
             il_map_fp = os.path.join(model_run_fp, 'input', SUMMARY_MAPPING['fm_map_fn'])
             il_map_df = get_dataframe(
                 src_fp=il_map_fp,
-                empty_data_error_msg='No summary map file found.'
+                lowercase_cols=False,
+                col_dtypes=MAP_SUMMARY_DTYPES,
+                empty_data_error_msg='No summary map file found.',
             )
+            il_map_df = il_map_df[list(set(il_map_df).intersection(MAP_SUMMARY_DTYPES))]
 
         ri_summaryxref_df, ri_summary_desc = get_summary_xref_df(
             il_map_df,


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### specify dtype for useful summary column reading
During the loss computation preparation step, we read the summaries files using a simple pandas.read_csv.
This change provide the read with the dtype of each needed columns improving read speed and avoiding potential wrong data type issues.
We also remove the case lowering of the column name as the column are expected to have the proper case in the files and we need them to match properly with the other files.
<!--end_release_notes-->
