### PR TITLE
Update numpy pin

### DIFF
--- a/requirements-package.in
+++ b/requirements-package.in
@@ -6,7 +6,7 @@ fastparquet>=0.3.1
 msgpack
 numba>=0.55.1
 numexpr
-numpy>=1.18
+numpy<1.24,>=1.18
 ods-tools>=3.0.4
 pandas>=1.0.3,!=1.1.0,!=1.1.1
 pytz

--- a/requirements-package.in
+++ b/requirements-package.in
@@ -6,7 +6,7 @@ fastparquet>=0.3.1
 msgpack
 numba>=0.55.1
 numexpr
-numpy<1.23,>=1.18
+numpy>=1.18
 ods-tools>=3.0.4
 pandas>=1.0.3,!=1.1.0,!=1.1.1
 pytz


### PR DESCRIPTION
<!--start_release_notes-->
### Update Numpy pin for oasislmf package requirements 
* **Numba** now supports **numpy** up to `1.24`
<!--end_release_notes-->
