### PR TITLE
Release 1.23.17

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,14 @@ OasisLMF Changelog
 * [#1251](https://github.com/OasisLMF/OasisLMF/pull/1254) - Error caused by pandas 2.0.0
 .. _`1.23.17`:  https://github.com/OasisLMF/OasisLMF/compare/1.23.16...1.23.17
 
+`1.23.17`_
+ ---------
+* [#1278](https://github.com/OasisLMF/OasisLMF/pull/1278) - Fixes for newer versions of pandas and numpy
+* [#1260](https://github.com/OasisLMF/OasisLMF/pull/1260) - Use low_memory=False in get_dataframe
+* [#1267](https://github.com/OasisLMF/OasisLMF/pull/1269) - Numba 0.57 breaks fmpy
+* [#1251](https://github.com/OasisLMF/OasisLMF/pull/1254) - Error caused by pandas 2.0.0
+.. _`1.23.17`:  https://github.com/OasisLMF/OasisLMF/compare/1.23.16...1.23.17
+
 `1.23.16`_
  ---------
 * [#1226](https://github.com/OasisLMF/OasisLMF/pull/1226) - Set ktools to 3.9.7 (oasislmf 1.23) 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 OasisLMF Changelog
 ==================
 
+`1.23.17`_
+ ---------
+* [#1278](https://github.com/OasisLMF/OasisLMF/pull/1278) - Fixes for newer versions of pandas and numpy
+* [#1260](https://github.com/OasisLMF/OasisLMF/pull/1260) - Use low_memory=False in get_dataframe
+* [#1267](https://github.com/OasisLMF/OasisLMF/pull/1269) - Numba 0.57 breaks fmpy
+* [#1251](https://github.com/OasisLMF/OasisLMF/pull/1254) - Error caused by pandas 2.0.0
+.. _`1.23.17`:  https://github.com/OasisLMF/OasisLMF/compare/1.23.16...1.23.17
+
 `1.23.16`_
  ---------
 * [#1226](https://github.com/OasisLMF/OasisLMF/pull/1226) - Set ktools to 3.9.7 (oasislmf 1.23) 

--- a/oasislmf/__init__.py
+++ b/oasislmf/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.23.16'
+__version__ = '1.23.17'
 
 import sys
 import os

--- a/oasislmf/pytools/fm/financial_structure.py
+++ b/oasislmf/pytools/fm/financial_structure.py
@@ -55,7 +55,7 @@ compute_info_dtype = from_dtype(np.dtype([('allocation_rule', np_oasis_int),
                                           ('start_level', np_oasis_int),
                                           ('items_len', np_oasis_int),
                                           ('output_len', np_oasis_int),
-                                          ('stepped', np.bool),
+                                          ('stepped', bool),
                                          ]))
 profile_index_dtype = from_dtype(np.dtype([('i_start', np_oasis_int),
                                            ('i_end', np_oasis_int),

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -83,10 +83,10 @@ PANDAS_BASIC_DTYPES = {
     'float32': np.float32,
     'float64': np.float64,
     builtins.float: np.float64,
-    'bool': np.bool,
-    builtins.bool: np.bool,
-    'str': np.object,
-    builtins.str: np.object,
+    'bool': bool,
+    builtins.bool: bool,
+    'str': object,
+    builtins.str: object,
     'category': 'category'
 }
 
@@ -716,7 +716,7 @@ def get_ids(df, usecols, group_by=[], sort_keys=True):
         else:
             return factorize_ndarray(df.loc[:, usecols].values, col_idxs=range(len(_usecols)))[0]
     else:
-        return (df[usecols].groupby(group_by).cumcount()) + 1
+        return (df[usecols].groupby(group_by, dropna=False).cumcount()) + 1
 
 
 def get_json(src_fp):


### PR DESCRIPTION
# Release 1.23.17
* [#1278](https://github.com/OasisLMF/OasisLMF/pull/1278) - Fixes for newer versions of pandas and numpy
* [#1260](https://github.com/OasisLMF/OasisLMF/pull/1260) - Use low_memory=False in get_dataframe
* [#1267](https://github.com/OasisLMF/OasisLMF/pull/1269) - Numba 0.57 breaks fmpy
* [#1251](https://github.com/OasisLMF/OasisLMF/pull/1254) - Error caused by pandas 2.0.0