### PR TITLE
Fixes for newer versions of pandas and numpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 The `oasislmf` Python package, loosely called the *model development kit (MDK)* or the *MDK package*, provides a command line toolkit for developing, testing and running Oasis models end-to-end locally, or remotely via the Oasis API. It can generate ground-up losses (GUL), direct/insured losses (IL) and reinsurance losses (RIL). It can also generate deterministic losses at all these levels.
 
 
+
 ## Releases and maintenance 
 Releases are published on a monthly cadence which tracks our team's development cycle. The planned fixes, enhancements and features can be seen on the [project development board](https://github.com/orgs/OasisLMF/projects/35) before each release. 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 The `oasislmf` Python package, loosely called the *model development kit (MDK)* or the *MDK package*, provides a command line toolkit for developing, testing and running Oasis models end-to-end locally, or remotely via the Oasis API. It can generate ground-up losses (GUL), direct/insured losses (IL) and reinsurance losses (RIL). It can also generate deterministic losses at all these levels.
 
 
-
 ## Releases and maintenance 
 Releases are published on a monthly cadence which tracks our team's development cycle. The planned fixes, enhancements and features can be seen on the [project development board](https://github.com/orgs/OasisLMF/projects/35) before each release. 
 

--- a/oasislmf/preparation/reinsurance_layer.py
+++ b/oasislmf/preparation/reinsurance_layer.py
@@ -630,7 +630,7 @@ class ReinsuranceLayer(object):
         self.logger.debug('Creating risk level and filter level profile IDs:')
         self.logger.debug(f'{oed.REINS_TYPE_FAC} profiles...')
         ri_df.loc[ri_df['reinstype'] == oed.REINS_TYPE_FAC, 'level_id'] = self._get_risk_level_id()
-        ri_df.loc[ri_df['reinstype'] == oed.REINS_TYPE_FAC, 'profile_id'] = pd.factorize(pd._lib.fast_zip([
+        ri_df.loc[ri_df['reinstype'] == oed.REINS_TYPE_FAC, 'profile_id'] = pd.factorize(pd._libs.lib.fast_zip([
             ri_df[ri_df['reinstype'] == oed.REINS_TYPE_FAC]['riskattachment'].values,
             ri_df[ri_df['reinstype'] == oed.REINS_TYPE_FAC]['risklimit'].values,
             ri_df[ri_df['reinstype'] == oed.REINS_TYPE_FAC]['cededpercent'].values,
@@ -645,7 +645,7 @@ class ReinsuranceLayer(object):
         # Per Risk profile IDs
         self.logger.debug(f'{oed.REINS_TYPE_PER_RISK} profiles...')
         ri_df.loc[ri_df['reinstype'] == oed.REINS_TYPE_PER_RISK, 'level_id'] = self._get_risk_level_id()
-        ri_df.loc[ri_df['reinstype'] == oed.REINS_TYPE_PER_RISK, 'profile_id'] = pd.factorize(pd._lib.fast_zip([
+        ri_df.loc[ri_df['reinstype'] == oed.REINS_TYPE_PER_RISK, 'profile_id'] = pd.factorize(pd._libs.lib.fast_zip([
             ri_df[ri_df['reinstype'] == oed.REINS_TYPE_PER_RISK]['riskattachment'].values,
             ri_df[ri_df['reinstype'] == oed.REINS_TYPE_PER_RISK]['risklimit'].values,
             ri_df[ri_df['reinstype'] == oed.REINS_TYPE_PER_RISK]['cededpercent'].values
@@ -658,7 +658,7 @@ class ReinsuranceLayer(object):
         # Quota Share profile IDs
         self.logger.debug(f'{oed.REINS_TYPE_QUOTA_SHARE} profiles...')
         ri_df.loc[ri_df['reinstype'] == oed.REINS_TYPE_QUOTA_SHARE, 'level_id'] = self._get_risk_level_id()
-        ri_df.loc[ri_df['reinstype'] == oed.REINS_TYPE_QUOTA_SHARE, 'profile_id'] = pd.factorize(pd._lib.fast_zip([
+        ri_df.loc[ri_df['reinstype'] == oed.REINS_TYPE_QUOTA_SHARE, 'profile_id'] = pd.factorize(pd._libs.lib.fast_zip([
             ri_df[ri_df['reinstype'] == oed.REINS_TYPE_QUOTA_SHARE]['risklimit'].values,
             ri_df[ri_df['reinstype'] == oed.REINS_TYPE_QUOTA_SHARE]['cededpercent'].values
         ]))[0] + 1 + fmprofiles_df['profile_id'].max()
@@ -670,7 +670,7 @@ class ReinsuranceLayer(object):
         # Surplus Share profile IDs
         self.logger.debug(f'{oed.REINS_TYPE_SURPLUS_SHARE} profiles...')
         ri_df.loc[ri_df['reinstype'] == oed.REINS_TYPE_SURPLUS_SHARE, 'level_id'] = self._get_risk_level_id()
-        ri_df.loc[ri_df['reinstype'] == oed.REINS_TYPE_SURPLUS_SHARE, 'profile_id'] = pd.factorize(pd._lib.fast_zip([
+        ri_df.loc[ri_df['reinstype'] == oed.REINS_TYPE_SURPLUS_SHARE, 'profile_id'] = pd.factorize(pd._libs.lib.fast_zip([
             ri_df[ri_df['reinstype'] == oed.REINS_TYPE_SURPLUS_SHARE]['riskattachment'].values,
             ri_df[ri_df['reinstype'] == oed.REINS_TYPE_SURPLUS_SHARE]['risklimit'].values,
             ri_df[ri_df['reinstype'] == oed.REINS_TYPE_SURPLUS_SHARE]['cededpercent_scope'].values

--- a/oasislmf/pytools/fm/financial_structure.py
+++ b/oasislmf/pytools/fm/financial_structure.py
@@ -51,7 +51,7 @@ compute_info_dtype = from_dtype(np.dtype([('allocation_rule', np_oasis_int),
                                           ('start_level', np_oasis_int),
                                           ('items_len', np_oasis_int),
                                           ('output_len', np_oasis_int),
-                                          ('stepped', np.bool),
+                                          ('stepped', bool),
                                          ]))
 profile_index_dtype = from_dtype(np.dtype([('i_start', np_oasis_int),
                                            ('i_end', np_oasis_int),

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -80,8 +80,8 @@ PANDAS_BASIC_DTYPES = {
     'float32': np.float32,
     'float64': np.float64,
     builtins.float: np.float64,
-    'bool': np.bool,
-    builtins.bool: np.bool,
+    'bool': bool,
+    builtins.bool: bool,
     'str': np.object,
     builtins.str: np.object,
     'category': 'category'

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -674,7 +674,7 @@ def get_ids(df, usecols, group_by=[], sort_keys=True):
         else:
             return factorize_ndarray(df.loc[:, usecols].values, col_idxs=range(len(_usecols)))[0]
     else:
-        return (df[usecols].groupby(group_by).cumcount()) + 1
+        return (df[usecols].groupby(group_by, dropna=False).cumcount()) + 1
 
 
 def get_json(src_fp):

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -82,8 +82,8 @@ PANDAS_BASIC_DTYPES = {
     builtins.float: np.float64,
     'bool': bool,
     builtins.bool: bool,
-    'str': np.object,
-    builtins.str: np.object,
+    'str': object,
+    builtins.str: object,
     'category': 'category'
 }
 


### PR DESCRIPTION
### Fixes for newer versions of pandas and numpy 
* `np.bool` replaced with builtin `bool`
* `np.object` replaced with builtin `object`
* `pd._lib.*`  replaced with `pd._libs.lib.*`
* Added `dropna=False` to get_ids, prevents `NaN` return in `layer_id` for test **test_insurance_step**
<!--end_release_notes-->
