### PR TITLE
Drop py3.7 in testing and add py3.11

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -46,10 +46,10 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - { python-version: "3.7", pkg-version: "", upload-cov: false }
           - { python-version: "3.8", pkg-version: "", upload-cov: false }
           - { python-version: "3.9", pkg-version: "", upload-cov: false }
           - { python-version: "3.10", pkg-version: "", upload-cov: true }
+          - { python-version: "3.11", pkg-version: "", upload-cov: true }
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -48,7 +48,7 @@ jobs:
         cfg:
           - { python-version: "3.8", pkg-version: "", upload-cov: false }
           - { python-version: "3.9", pkg-version: "", upload-cov: false }
-          - { python-version: "3.10", pkg-version: "", upload-cov: true }
+          - { python-version: "3.10", pkg-version: "", upload-cov: false }
           - { python-version: "3.11", pkg-version: "", upload-cov: true }
 
     steps:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The reusable libraries are organised into several sub-packages, the most relevan
 
 Starting from 1st January 2019, Pandas will no longer be supporting Python 2. As Pandas is a key dependency of the MDK we are **dropping Python 2 (2.7) support** as of this release (1.3.4). The last version which still supports Python 2.7 is version `1.3.3` (published 12/03/2019).
 
-Also for this release (and all future releases) a **minimum of Python 3.7 is required**.
+Also for this release (and all future releases) a **minimum of Python 3.8 is required**.
 
 
 ## Installation
@@ -169,7 +169,7 @@ below is the summary:
 
 ### pandas
 Pandas has released its major version number 2 breaking some of the compatibility with the 1st version
-Therefore, for all version of OasisLMF <= 1.27.2, the latest supported version for pandas is 1.5.3  
+Therefore, for all version of OasisLMF <= 1.27.2, the latest supported version for pandas is 1.5.3
 Support for pandas 2, starts from version 1.27.3
 
 ## Testing


### PR DESCRIPTION
### Update unit test python versions 
Numba 0.57 has moved its minimum python version to 3.8, update testing to track for and replace with py3.11 
<!--end_release_notes-->
