### PR TITLE
Adding tarfile member sanitization to extractall()

### DIFF
--- a/oasislmf/execution/bin.py
+++ b/oasislmf/execution/bin.py
@@ -134,7 +134,26 @@ def prepare_run_directory(
         else:
             with tarfile.open(inputs_archive) as input_tarfile:
                 p = os.path.join(run_dir, 'input') if not ri else os.path.join(run_dir)
-                input_tarfile.extractall(path=p)
+                def is_within_directory(directory, target):
+                    
+                    abs_directory = os.path.abspath(directory)
+                    abs_target = os.path.abspath(target)
+                
+                    prefix = os.path.commonprefix([abs_directory, abs_target])
+                    
+                    return prefix == abs_directory
+                
+                def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
+                
+                    for member in tar.getmembers():
+                        member_path = os.path.join(path, member.name)
+                        if not is_within_directory(path, member_path):
+                            raise Exception("Attempted Path Traversal in Tar File")
+                
+                    tar.extractall(path, members, numeric_owner=numeric_owner) 
+                    
+                
+                safe_extract(input_tarfile, path=p)
 
         oasis_dst_fp = os.path.join(run_dir, 'input')
 


### PR DESCRIPTION
> **Rebased from:** https://github.com/OasisLMF/OasisLMF/pull/1183

<!--start_release_notes-->
### Patch CVE-2007-4559 bug in the Python tarfile
* External PR Patch to fix [CVE-2007-4559](https://github.com/advisories/GHSA-gw9q-c7gh-j9vm) see https://github.com/OasisLMF/OasisLMF/pull/1183 for details
<!--end_release_notes-->
