### PR TITLE
builtin KeyServer not failing when no keys success in a batch

### DIFF
--- a/oasislmf/lookup/factory.py
+++ b/oasislmf/lookup/factory.py
@@ -402,9 +402,10 @@ class BasicKeyServer:
                 success_df = result[success]
                 if success_heading_row is None:
                     success_heading_row = self.get_success_heading_row(result.columns, keys_success_msg)
-                success_df[success_heading_row.keys()].rename(columns=success_heading_row
-                                                              ).to_csv(successes_file, index=False, header=not i)
-                successes_count += success_df.shape[0]
+                if not success_df.empty:
+                    success_df[success_heading_row.keys()].rename(columns=success_heading_row
+                                                                  ).to_csv(successes_file, index=False, header=not i)
+                    successes_count += success_df.shape[0]
                 if errors_file:
                     errors_df = result[~success]
                     if 'message' not in errors_df.columns:


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### builtin KeyServer not failing when no keys success in a batch
KeyServer will not raise an error in a batch of location contain no successful keys.
<!--end_release_notes-->
