### PR TITLE
lookup: remove extra column after failed combine step

### DIFF
--- a/oasislmf/lookup/builtin.py
+++ b/oasislmf/lookup/builtin.py
@@ -320,6 +320,7 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
             function: function combining all strategies
         """
         def fct(locations):
+            initial_columns = locations.columns
             result = []
             for child_strategy in strategy:
                 if not child_strategy['columns'].issubset(locations.columns):  # needed column not present to run this strategy
@@ -328,7 +329,7 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
                 is_valid = (locations[id_columns] != OASIS_UNKNOWN_ID).any(axis=1)
                 result.append(locations[is_valid])
 
-                locations = locations[~is_valid].drop(columns=id_columns)
+                locations = locations[~is_valid][initial_columns]
             result.append(locations)
             return Lookup.set_id_columns(pd.concat(result), id_columns)
 


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### lookup: remove extra column after failed combine step
In builtin lookup, for locations where a combine step is not valid, some extra column could be added on top of the id one.
With this change only the original column are passed to the next combine step

<!--end_release_notes-->
