### PR TITLE
log wrapper, check log level before running input log

### DIFF
--- a/oasislmf/utils/log.py
+++ b/oasislmf/utils/log.py
@@ -107,16 +107,17 @@ def oasis_log(*args, **kwargs):
             args_name = getargspec(func)[0]
             args_dict = dict(zip(args_name, args))
 
-            for key, value in args_dict.items():
-                if key == "self":
-                    continue
-                logger.debug("    {} == {}".format(key, value))
+            if logger.level <= logging.DEBUG:
+                for key, value in args_dict.items():
+                    if key == "self":
+                        continue
+                    logger.debug("    {} == {}".format(key, value))
 
-            if len(args) > len(args_name):
-                for i in range(len(args_name), len(args)):
-                    logger.debug("    {}".format(args[i]))
-            for key, value in kwargs.items():
-                logger.debug("    {} == {}".format(key, value))
+                if len(args) > len(args_name):
+                    for i in range(len(args_name), len(args)):
+                        logger.debug("    {}".format(args[i]))
+                for key, value in kwargs.items():
+                    logger.debug("    {} == {}".format(key, value))
 
             start = time.time()
             result = func(*args, **kwargs)

--- a/tests/utils/test_log.py
+++ b/tests/utils/test_log.py
@@ -17,6 +17,7 @@ from oasislmf.utils.log import (
 
 class MockLogger(object):
     def __init__(self):
+        self.level = logging.DEBUG
         self.debug = Mock()
         self.info = Mock()
 


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### fix wrapper computing debug level operation in non debug mode
Preparing to data to log the input argument of function can be very costly in time and memory. and it is perform before the debug call is ignored
With this change we preemptively check for the log level and perform this operation only if relevant

In case of big portfolio this can lead to a massive increase in preparation step time and memory

> **Note:** Performance impact can still occur when running with `--verbose` or `DEBUG` logging.  

<!--end_release_notes-->
