### PR TITLE
Bug fix for setcwd context manager

### DIFF
--- a/oasislmf/utils/path.py
+++ b/oasislmf/utils/path.py
@@ -152,10 +152,12 @@ def get_custom_module(custom_module_path, label):
 
 @contextmanager
 def setcwd(path):
-    pwd = os.getcwd()
-    os.chdir(str(path))
-    yield path
-    os.chdir(pwd)
+    orig_path = os.getcwd()
+    try:
+        os.chdir(str(path))
+        yield path
+    finally:
+        os.chdir(orig_path)
 
 
 if __name__ == '__main__':

--- a/tests/computation/test_generate_files.py
+++ b/tests/computation/test_generate_files.py
@@ -1,6 +1,7 @@
 import pathlib
 import os
 import logging
+import responses
 
 from unittest import mock
 from unittest.mock import patch, Mock, ANY
@@ -135,12 +136,15 @@ class TestGenFiles(ComputationChecker):
                 called_fm_agg = mock_get_il_items.call_args.kwargs['fm_aggregation_profile']
                 self.assertEqual(called_fm_agg, expected_fm_agg_profile)
 
+    @responses.activate
     @patch('oasislmf.computation.generate.files.get_il_input_items')
     def test_files__reporting_currency__is_set_valid(self, mock_get_il_items):
         currency_config = {
             "currency_conversion_type": "FxCurrencyRates",
             "datetime": "2018-10-10"
         }
+
+        responses.get(url='https://theforexapi.com/api/2018-10-10?base=GBP&symbols=JPY&rtype=fpy', json={'rates': {"JPY": 180.4}})
         mock_get_il_items.return_value = FAKE_IL_ITEMS_RETURN
         currency_config_file = self.tmp_files.get('currency_conversion_json')
         self.write_json(currency_config_file, currency_config)


### PR DESCRIPTION
<!--start_release_notes-->
### Bug fix for setcwd context manager 
If an exception happens within the path context manager `setcwd` the original path is not restored. 
This then breaks some of the other tests which rely on relative paths. 
<!--end_release_notes-->

The original error that raised this issue was due to the exchange rate API going down.
Replaced that call with a response mock, so our testing won't fail next time
```
requests.exceptions.ConnectTimeout: HTTPSConnectionPool(host='theforexapi.com', port=443): Max retries exceeded with url: /api/2018-10-10?base=GBP&symbols=JPY&rtype=fpy (Caused by ConnectTimeoutError(<urllib3.connection.HTTPSConnection object at 0x7f6cd42b6190>, 'Connection to theforexapi.com timed out. (connect timeout=None)'))
```
