### PR TITLE
regenerate ids after ExposurePreAnalysis

### DIFF
--- a/oasislmf/computation/hooks/pre_analysis.py
+++ b/oasislmf/computation/hooks/pre_analysis.py
@@ -98,6 +98,7 @@ class ExposurePreAnalysis(ComputationStep):
 
         exposure_data.save(path=input_dir, version_name='', save_config=True, unknown_columns=ids_option)
         # regenerate ids
+        exposure_data.location.dataframe = exposure_data.location.dataframe.drop(columns=['loc_id', 'loc_idx'])
         exposure_data.location.dataframe = prepare_location_df(exposure_data.location.dataframe)
 
         modified_files = {oed_source.oed_name: str(oed_source.current_source['filepath']) for oed_source in exposure_data.get_oed_sources()}

--- a/oasislmf/computation/hooks/pre_analysis.py
+++ b/oasislmf/computation/hooks/pre_analysis.py
@@ -4,9 +4,10 @@ __all__ = [
 
 import json
 import pathlib
+from ods_tools.oed import UnknownColumnSaveOption
 
 from ..base import ComputationStep
-from ...utils.data import get_exposure_data
+from ...utils.data import get_exposure_data, prepare_location_df
 from ...utils.inputs import str2bool
 from ...utils.path import get_custom_module
 from ...utils.exceptions import OasisException
@@ -70,7 +71,9 @@ class ExposurePreAnalysis(ComputationStep):
             input_dir = self.get_default_run_dir()
             pathlib.Path(input_dir).mkdir(parents=True, exist_ok=True)
 
-        exposure_data.save(path=input_dir, version_name='raw', save_config=True)
+        ids_option = {'loc_id': UnknownColumnSaveOption.DELETE,
+                      'loc_idx': UnknownColumnSaveOption.DELETE}
+        exposure_data.save(path=input_dir, version_name='raw', save_config=True, unknown_columns=ids_option)
         kwargs = {'exposure_data': exposure_data}
 
         if self.exposure_pre_analysis_setting_json:
@@ -93,7 +96,10 @@ class ExposurePreAnalysis(ComputationStep):
         print(_class(**kwargs))
         _class_return = _class(**kwargs).run()
 
-        exposure_data.save(path=input_dir, version_name='', save_config=True)
+        exposure_data.save(path=input_dir, version_name='', save_config=True, unknown_columns=ids_option)
+        # regenerate ids
+        exposure_data.location.dataframe = prepare_location_df(exposure_data.location.dataframe)
+
         modified_files = {oed_source.oed_name: str(oed_source.current_source['filepath']) for oed_source in exposure_data.get_oed_sources()}
         self.logger.info('\nPre-analysis modified files: {}'.format(
             json.dumps(modified_files, indent=4)))

--- a/tests/model_preparation/test_exposure_pre_analysis.py
+++ b/tests/model_preparation/test_exposure_pre_analysis.py
@@ -15,12 +15,12 @@ input_oed_location = """PortNumber,AccNumber,LocNumber,BuildingTIV
 1,A11111,10002082050,5
 """
 
-output_oed_location = """PortNumber,AccNumber,LocNumber,BuildingTIV,ContentsTIV,BITIV,loc_id,loc_idx
-1,A11111,10002082046,2.0,0.0,0.0,1,0
-1,A11111,10002082047,4.0,0.0,0.0,2,1
-1,A11111,10002082048,6.0,0.0,0.0,3,2
-1,A11111,10002082049,8.0,0.0,0.0,4,3
-1,A11111,10002082050,10.0,0.0,0.0,5,4
+output_oed_location = """PortNumber,AccNumber,LocNumber,BuildingTIV,ContentsTIV,BITIV
+1,A11111,10002082046,2.0,0.0,0.0
+1,A11111,10002082047,4.0,0.0,0.0
+1,A11111,10002082048,6.0,0.0,0.0
+1,A11111,10002082049,8.0,0.0,0.0
+1,A11111,10002082050,10.0,0.0,0.0
 """
 
 


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### regenerate ids after ExposurePreAnalysis
Make sure internal ids in location file are regenerated after ExposurePreAnalysis step in case the number of location has change.
for example, after a disaggregation or a filtering.
<!--end_release_notes-->
