### PR TITLE
Fix/ci skip ods build manual trigger

### DIFF
--- a/.github/workflows/piwind-test.yml
+++ b/.github/workflows/piwind-test.yml
@@ -50,7 +50,7 @@ jobs:
       ktools_branch: ${{ github.event_name != 'workflow_dispatch' && '' ||  inputs.ktools_branch }}
 
   ods_tools:
-    #if: inputs.ods_branch != ''
+    if: ${{ inputs.ods_branch != '' || github.event_name != 'workflow_dispatch' }}
     uses: OasisLMF/ODS_Tools/.github/workflows/build.yml@develop
     secrets: inherit
     with:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,11 +32,10 @@ jobs:
       ktools_branch: ${{ inputs.ktools_branch }}
 
   ods_tools:
-    #if: inputs.ods_branch != ''
+    if: ${{ inputs.ods_branch != '' || github.event_name != 'workflow_dispatch' }}
     uses: OasisLMF/ODS_Tools/.github/workflows/build.yml@develop
     secrets: inherit
     with:
-      #ods_branch: ${{ inputs.ods_branch }}         # Disable 'ods-tools' build
       ods_branch: ${{ github.event_name != 'workflow_dispatch' && 'develop' ||  inputs.ods_branch }} # Enable 'ods-tools' build by default
 
   unittest:


### PR DESCRIPTION
<!--start_release_notes-->
### Fixed skipping ODS-tools in CI
When manual actions Job is triggered ods-tools build was not skipped when `ods_branch` is blank
<!--end_release_notes-->
