### PR TITLE
Redefine key_columns as local variable

### DIFF
--- a/.github/workflows/piwind-test.yml
+++ b/.github/workflows/piwind-test.yml
@@ -24,7 +24,11 @@ on:
 
   workflow_dispatch:
     inputs:
-      platform_version:
+      platform_1_version:
+        description: 'OasisPlatform Version to test using [docker tag]'
+        required: true
+        default: latest
+      platform_2_version:
         description: 'OasisPlatform Version to test using [docker tag]'
         required: true
         default: latest
@@ -54,7 +58,7 @@ jobs:
     with:
       ods_branch: ${{ github.event_name != 'workflow_dispatch' && 'main' ||  inputs.ods_branch }}
 
-  piwind:
+  platform1:
     if: ${{ ! failure() || ! cancelled() }}
     uses: OasisLMF/OasisPiWind/.github/workflows/test.yml@main
     secrets: inherit
@@ -64,4 +68,19 @@ jobs:
       oasislmf_package: ${{ needs.build.outputs.linux_pkg_filename }}
       oasislmf_branch: ''
       ods_package: ${{ needs.ods_tools.outputs.whl_filename }}
-      platform_version: ${{ github.event_name != 'workflow_dispatch' && 'latest' ||  inputs.platform_version }}
+      platform_version: ${{ github.event_name != 'workflow_dispatch' && 'latest' ||  inputs.platform_1_version }}
+      storage_suffix: '_platform1'
+
+  platform2:
+    if: ${{ ! failure() || ! cancelled() }}
+    uses: OasisLMF/OasisPiWind/.github/workflows/test.yml@main
+    secrets: inherit
+    needs: [build, ods_tools]
+    with:
+      piwind_branch: ${{ github.event_name != 'workflow_dispatch' && 'main' || inputs.piwind_branch }}
+      oasislmf_package: ${{ needs.build.outputs.linux_pkg_filename }}
+      oasislmf_branch: ''
+      ods_package: ${{ needs.ods_tools.outputs.whl_filename }}
+      platform_version: ${{ github.event_name != 'workflow_dispatch' && '2.2.0' ||  inputs.platform_2_version }}
+      pytest_opts: "--docker-compose=./docker/plat2.docker-compose.yml "
+      storage_suffix: '_platform2'

--- a/oasislmf/lookup/builtin.py
+++ b/oasislmf/lookup/builtin.py
@@ -106,9 +106,6 @@ def nearest_neighbor(left_gdf, right_gdf, return_dist=False):
     return closest_points
 
 
-key_columns = ['loc_id', 'peril_id', 'coverage_type', 'area_peril_id', 'vulnerability_id', 'status', 'message']
-
-
 class DeterministicLookup(AbstractBasicKeyLookup):
     multiproc_enabled = False
 
@@ -260,7 +257,10 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
             step_function = self.set_step_function(step_name, step_config)
             locations = step_function(locations)
 
-        global key_columns
+        key_columns = [
+            'loc_id', 'peril_id', 'coverage_type', 'area_peril_id',
+            'vulnerability_id', 'status', 'message'
+        ]
         if 'amplification_id' in locations.columns:
             key_columns += ['amplification_id']
         locations = locations[key_columns]


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Redefine key_columns as local variable
Making changes the global variable `key_columns`, which is a list of location file columns used in the lookup process, can lead to errors. As the variable is only used in the method `builtin.py::Lookup::process_locations`, it can be defined local to that method instead.
<!--end_release_notes-->
