### PR TITLE
Fix removal of handlers to logger + give logfiles unique names

### DIFF
--- a/oasislmf/pytools/pla/manager.py
+++ b/oasislmf/pytools/pla/manager.py
@@ -7,8 +7,9 @@ from .structure import (
     get_items_amplifications,
     get_post_loss_amplification_factors
 )
+from oasislmf.pytools.utils import redirect_logging
 
-
+@redirect_logging(exec_name='plapy')
 def run(run_dir, file_in, file_out, input_path, static_path):
     """
     Execeute the main Post Loss Amplification workflow.

--- a/oasislmf/pytools/pla/manager.py
+++ b/oasislmf/pytools/pla/manager.py
@@ -9,6 +9,7 @@ from .structure import (
 )
 from oasislmf.pytools.utils import redirect_logging
 
+
 @redirect_logging(exec_name='plapy')
 def run(run_dir, file_in, file_out, input_path, static_path):
     """

--- a/oasislmf/pytools/utils.py
+++ b/oasislmf/pytools/utils.py
@@ -69,8 +69,7 @@ def redirect_logging(exec_name, log_dir='./log', log_level=logging.WARNING):
             formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
             log_file = f'{exec_name}_{os.getpid()}_{uuid.uuid4()}.log'
 
-            child_stream = open(os.path.join(log_dir, log_file), mode='a')
-            childFileHandler = logging.StreamHandler(child_stream)
+            childFileHandler = logging.FileHandler(os.path.join(log_dir, log_file))
             childFileHandler.setLevel(log_level)
             childFileHandler.setFormatter(formatter)
 
@@ -78,8 +77,6 @@ def redirect_logging(exec_name, log_dir='./log', log_level=logging.WARNING):
             rootFileHandler.setLevel(logging.INFO)
             rootFileHandler.setFormatter(formatter)
 
-            # https://docs.python.org/3/library/logging.html#logging.lastResort
-            # logging.lastResort.setLevel(logging.ERROR)
             # Set all logger handlers to level ERROR
             for lg_name in logging_config:
                 logging_set_handlers(lg_name, childFileHandler, log_level)
@@ -88,12 +85,14 @@ def redirect_logging(exec_name, log_dir='./log', log_level=logging.WARNING):
             logger = logging.getLogger('oasislmf')
             logger.setLevel(logging.INFO)
             logger.addHandler(rootFileHandler)
+
             # # Debug: print logging tree
             # import ipdb; ipdb.set_trace()
             # import logging_tree; logging_tree.printout()
             try:
                 logger.info(kwargs)
                 logger.info('starting process')
+
                 # Run the wrapped function
                 retval = func(*args, **kwargs)
                 logger.info('finishing process')
@@ -105,7 +104,6 @@ def redirect_logging(exec_name, log_dir='./log', log_level=logging.WARNING):
                 for lg_name in logging_config:
                     logging_reset_handlers(lg_name)
                 logger.removeHandler(rootFileHandler)
-                child_stream.close()
                 logging.shutdown()
         return wrapper
     return inner

--- a/oasislmf/pytools/utils.py
+++ b/oasislmf/pytools/utils.py
@@ -20,6 +20,7 @@ def logging_set_handlers(logger_name, handler, log_level):
     else:
         logger.setLevel(logging.ERROR)
 
+
 def logging_reset_handlers(logger_name):
     logger = logging.getLogger(logger_name)
     # revert all handlers to NOTSET
@@ -108,6 +109,7 @@ def redirect_logging(exec_name, log_dir='./log', log_level=logging.WARNING):
                 logging.shutdown()
         return wrapper
     return inner
+
 
 def assert_allclose(x, y, rtol=1e-10, atol=1e-8, x_name="x", y_name="y"):
     """

--- a/tests/cli/test_inputvalues.py
+++ b/tests/cli/test_inputvalues.py
@@ -18,7 +18,7 @@ from oasislmf.utils.exceptions import OasisException
 class InputValuesGet(TestCase):
     @given(text(min_size=1, max_size=10, alphabet=string.ascii_letters))
     def test_variable_is_on_the_command_line_but_not_in_config___command_line_is_used(self, cmd_var):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'bar': 'boo'}, conf_file)
             conf_file.close()
@@ -32,7 +32,7 @@ class InputValuesGet(TestCase):
             os.remove(conf_file.name)
 
     def test_boolean_variable_with_command_default_null_is_on_the_command_line_as_false_but_not_in_config___command_line_false_value_is_picked_up(self):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'bar': 'boo'}, conf_file)
             conf_file.close()
@@ -46,7 +46,7 @@ class InputValuesGet(TestCase):
             os.remove(conf_file.name)
 
     def test_boolean_variable_with_command_default_false_is_not_on_the_command_line_or_in_config___command_default_false_value_is_picked_up(self):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'bar': 'boo'}, conf_file)
             conf_file.close()
@@ -60,7 +60,7 @@ class InputValuesGet(TestCase):
             os.remove(conf_file.name)
 
     def test_boolean_variable_with_command_default_true_is_not_on_the_command_line_or_in_config___command_default_true_value_is_picked_up(self):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'bar': 'boo'}, conf_file)
             conf_file.close()
@@ -74,7 +74,7 @@ class InputValuesGet(TestCase):
             os.remove(conf_file.name)
 
     def test_boolean_variable_with_command_default_true_is_on_the_command_line_as_false_but_not_in_config___command_line_false_value_is_picked_up(self):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'bar': 'boo'}, conf_file)
             conf_file.close()
@@ -88,7 +88,7 @@ class InputValuesGet(TestCase):
             os.remove(conf_file.name)
 
     def test_boolean_variable_with_command_default_null_is_on_the_command_line_as_true_but_not_in_config___command_line_true_value_is_picked_up(self):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'bar': 'boo'}, conf_file)
             conf_file.close()
@@ -102,7 +102,7 @@ class InputValuesGet(TestCase):
             os.remove(conf_file.name)
 
     def test_boolean_variable_with_command_default_false_is_on_the_command_line_as_true_but_not_in_config___command_line_true_value_is_picked_up(self):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'bar': 'boo'}, conf_file)
             conf_file.close()
@@ -120,7 +120,7 @@ class InputValuesGet(TestCase):
         text(min_size=1, max_size=10, alphabet=string.ascii_letters),
     )
     def test_variable_is_on_the_command_line_and_in_config___command_line_is_used(self, cmd_var, conf_var):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'foo': conf_var}, conf_file)
             conf_file.close()
@@ -135,7 +135,7 @@ class InputValuesGet(TestCase):
 
     @given(text(min_size=1, max_size=10, alphabet=string.ascii_letters))
     def test_variable_is_not_on_the_command_line_but_is_in_config___config_is_used(self, conf_var):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'foo': conf_var}, conf_file)
             conf_file.close()
@@ -149,7 +149,7 @@ class InputValuesGet(TestCase):
             os.remove(conf_file.name)
 
     def test_boolean_variable_with_command_default_null_is_not_on_the_command_line_but_is_in_config_as_true___config_true_value_is_picked_up(self):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'foo': True}, conf_file)
             conf_file.close()
@@ -163,7 +163,7 @@ class InputValuesGet(TestCase):
             os.remove(conf_file.name)
 
     def test_boolean_variable_with_command_default_false_is_not_on_the_command_line_but_is_in_config_as_true___config_false_value_is_picked_up(self):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'foo': True}, conf_file)
             conf_file.close()
@@ -177,7 +177,7 @@ class InputValuesGet(TestCase):
             os.remove(conf_file.name)
 
     def test_boolean_variable_with_command_default_true_is_not_on_the_command_line_but_is_in_config_as_false___config_false_value_is_picked_up(self):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'foo': False}, conf_file)
             conf_file.close()
@@ -191,7 +191,7 @@ class InputValuesGet(TestCase):
             os.remove(conf_file.name)
 
     def test_boolean_variable_with_command_default_null_is_not_on_the_command_line_but_is_in_config_as_false___config_false_value_is_picked_up(self):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'foo': False}, conf_file)
             conf_file.close()
@@ -205,7 +205,7 @@ class InputValuesGet(TestCase):
             os.remove(conf_file.name)
 
     def test_variable_is_not_on_the_command_line_or_config_var_is_not_required___none_is_returned(self):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'bar': 'boo'}, conf_file)
             conf_file.close()
@@ -220,7 +220,7 @@ class InputValuesGet(TestCase):
 
     @given(text(min_size=1, max_size=10, alphabet=string.ascii_letters))
     def test_variable_is_not_on_the_command_line_or_config_var_is_not_required_default_is_supplied___default_is_returned(self, default):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'bar': 'boo'}, conf_file)
             conf_file.close()
@@ -234,7 +234,7 @@ class InputValuesGet(TestCase):
             os.remove(conf_file.name)
 
     def test_variable_is_not_on_the_command_line_or_config_var_is_required___error_is_raised(self):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'bar': 'boo'}, conf_file)
             conf_file.close()
@@ -250,7 +250,7 @@ class InputValuesGet(TestCase):
 
     @given(floats(0.0, 1.0))
     def test_float_variable_is_not_on_the_command_line_or_config_var_is_not_required_default_is_supplied___default_is_returned(self, default):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'bar': 'boo'}, conf_file)
             conf_file.close()
@@ -267,7 +267,7 @@ class InputValuesGet(TestCase):
 
     @given(floats(0.0, 1.0), floats(0.0, 1.0))
     def test_float_variable_is_on_the_command_line_but_not_in_config_var_is_not_required_default_is_supplied___command_line_is_used(self, cmd_var, default):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'bar': 'boo'}, conf_file)
             conf_file.close()
@@ -284,7 +284,7 @@ class InputValuesGet(TestCase):
 
     @given(floats(0.0, 1.0), floats(0.0, 1.0), floats(0.0, 1.0))
     def test_float_variable_is_on_the_command_line_and_in_config_var_is_not_required_default_is_supplied___command_line_is_used(self, cmd_var, conf_var, default):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'foo': conf_var}, conf_file)
             conf_file.close()
@@ -301,7 +301,7 @@ class InputValuesGet(TestCase):
 
     @given(floats(0.0, 1.0), floats(0.0, 1.0))
     def test_float_variable_is_not_on_command_line_but_is_in_config_var_is_not_required_default_is_supplied___config_is_used(self, conf_var, default):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             json.dump({'foo': conf_var}, conf_file)
             conf_file.close()
@@ -317,7 +317,7 @@ class InputValuesGet(TestCase):
             os.remove(conf_file.name)
 
     def test_variable_is_a_path___path_is_relative_to_config_file(self):
-        conf_file = NamedTemporaryFile('w', delete=False)
+        conf_file = NamedTemporaryFile('w', delete=False, prefix='inputvalues')
         try:
             test_path = os.path.join("some", "path")
             json.dump({'foo': test_path}, conf_file)

--- a/tests/computation/test_computation.py
+++ b/tests/computation/test_computation.py
@@ -3,10 +3,8 @@ __all__ = [
     'ComputationChecker',
 ]
 
-from os import path
+import contextlib
 import json
-import io
-import os
 from collections import ChainMap
 import unittest
 from tempfile import NamedTemporaryFile, TemporaryDirectory
@@ -14,10 +12,16 @@ import pytest
 
 
 class ComputationChecker(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.stack = contextlib.ExitStack()
 
-    @staticmethod
-    def create_tmp_files(file_list):
-        return {f: NamedTemporaryFile() for f in file_list}
+    def create_tmp_files(self, file_list):
+        return {f: self.stack.enter_context(NamedTemporaryFile(prefix=self.__class__.__name__)) for f in file_list}
+
+    def tearDown(self):
+        super().tearDown()
+        self.stack.close()
 
     @staticmethod
     def create_tmp_dirs(dirs_list):

--- a/tests/computation/test_generate_files.py
+++ b/tests/computation/test_generate_files.py
@@ -24,15 +24,16 @@ class TestGenFiles(ComputationChecker):
     def setUpClass(cls):
         cls.manager = OasisManager()
         cls.default_args = cls.manager._params_generate_files()
-        # Tempfiles
-        cls.tmp_dirs = cls.create_tmp_dirs([a for a in cls.default_args.keys() if 'dir' in a])
-        cls.tmp_files = cls.create_tmp_files(
-            [a for a in cls.default_args.keys() if 'csv' in a] +
-            [a for a in cls.default_args.keys() if 'path' in a] +
-            [a for a in cls.default_args.keys() if 'json' in a]
-        )
 
     def setUp(self):
+        # Tempfiles
+        self.tmp_dirs = self.create_tmp_dirs([a for a in self.default_args.keys() if 'dir' in a])
+        self.tmp_files = self.create_tmp_files(
+            [a for a in self.default_args.keys() if 'csv' in a] +
+            [a for a in self.default_args.keys() if 'path' in a] +
+            [a for a in self.default_args.keys() if 'json' in a]
+        )
+
         self.min_args = {
             'lookup_config_json': LOOKUP_CONFIG,
             'oed_location_csv': self.tmp_files['oed_location_csv'].name,

--- a/tests/computation/test_generate_keys.py
+++ b/tests/computation/test_generate_keys.py
@@ -23,15 +23,15 @@ class TestGenKeys(ComputationChecker):
         cls.manager = OasisManager()
         cls.default_args = cls.manager._params_generate_keys()
 
+    def setUp(self):
         # Tempfiles
-        cls.tmp_dirs = cls.create_tmp_dirs([a for a in cls.default_args.keys() if 'dir' in a])
-        cls.tmp_files = cls.create_tmp_files(
-            [a for a in cls.default_args.keys() if 'csv' in a] +
-            [a for a in cls.default_args.keys() if 'path' in a] +
-            [a for a in cls.default_args.keys() if 'json' in a]
+        self.tmp_dirs = self.create_tmp_dirs([a for a in self.default_args.keys() if 'dir' in a])
+        self.tmp_files = self.create_tmp_files(
+            [a for a in self.default_args.keys() if 'csv' in a] +
+            [a for a in self.default_args.keys() if 'path' in a] +
+            [a for a in self.default_args.keys() if 'json' in a]
         )
 
-    def setUp(self):
         self.min_args = {
             'lookup_config_json': LOOKUP_CONFIG,
             'oed_location_csv': self.tmp_files['oed_location_csv'].name,

--- a/tests/computation/test_generate_losses.py
+++ b/tests/computation/test_generate_losses.py
@@ -30,54 +30,55 @@ class TestGenLosses(ComputationChecker):
         cls.default_args = cls.manager._params_generate_losses()
         cls.files_args = cls.manager._params_generate_files()
 
+    def setUp(self):
         # Create Tempfiles (losses)
-        cls.tmp_dirs = cls.create_tmp_dirs([a for a in cls.default_args.keys() if 'dir' in a])
-        cls.tmp_files = cls.create_tmp_files(
-            [a for a in cls.default_args.keys() if 'csv' in a] +
-            [a for a in cls.default_args.keys() if 'path' in a] +
-            [a for a in cls.default_args.keys() if 'json' in a]
+        self.tmp_dirs = self.create_tmp_dirs([a for a in self.default_args.keys() if 'dir' in a])
+        self.tmp_files = self.create_tmp_files(
+            [a for a in self.default_args.keys() if 'csv' in a] +
+            [a for a in self.default_args.keys() if 'path' in a] +
+            [a for a in self.default_args.keys() if 'json' in a]
         )
         # Create Tempfiles (files)
-        cls.tmp_oasis_files = cls.create_tmp_files(
-            [a for a in cls.files_args.keys() if 'csv' in a] +
-            [a for a in cls.files_args.keys() if 'path' in a] +
-            [a for a in cls.files_args.keys() if 'json' in a]
+        self.tmp_oasis_files = self.create_tmp_files(
+            [a for a in self.files_args.keys() if 'csv' in a] +
+            [a for a in self.files_args.keys() if 'path' in a] +
+            [a for a in self.files_args.keys() if 'json' in a]
         )
         # tmp dirs for holding oasis files
-        cls.tmp_oasis_files_dirs = cls.create_tmp_dirs([
+        self.tmp_oasis_files_dirs = self.create_tmp_dirs([
             'oasis_files_dir__gul',
             'oasis_files_dir__il',
             'oasis_files_dir__ri',
         ])
         # Write minimum data to gen files
-        cls.write_json(cls.tmp_oasis_files.get('lookup_complex_config_json'), MIN_RUN_SETTINGS)
-        cls.write_str(cls.tmp_oasis_files.get('oed_location_csv'), MIN_LOC)
-        cls.write_str(cls.tmp_oasis_files.get('oed_accounts_csv'), MIN_ACC)
-        cls.write_str(cls.tmp_oasis_files.get('oed_info_csv'), MIN_INF)
-        cls.write_str(cls.tmp_oasis_files.get('oed_scope_csv'), MIN_SCP)
-        cls.write_str(cls.tmp_oasis_files.get('keys_data_csv'), MIN_KEYS)
-        cls.write_str(cls.tmp_oasis_files.get('keys_errors_csv'), MIN_KEYS_ERR)
+        self.write_json(self.tmp_oasis_files.get('lookup_complex_config_json'), MIN_RUN_SETTINGS)
+        self.write_str(self.tmp_oasis_files.get('oed_location_csv'), MIN_LOC)
+        self.write_str(self.tmp_oasis_files.get('oed_accounts_csv'), MIN_ACC)
+        self.write_str(self.tmp_oasis_files.get('oed_info_csv'), MIN_INF)
+        self.write_str(self.tmp_oasis_files.get('oed_scope_csv'), MIN_SCP)
+        self.write_str(self.tmp_oasis_files.get('keys_data_csv'), MIN_KEYS)
+        self.write_str(self.tmp_oasis_files.get('keys_errors_csv'), MIN_KEYS_ERR)
 
         # Args for generating sample data
-        cls.args_gen_files_gul = {
+        self.args_gen_files_gul = {
             'lookup_config_json': LOOKUP_CONFIG,
-            'oed_location_csv': cls.tmp_oasis_files['oed_location_csv'].name,
-            'oasis_files_dir': cls.tmp_oasis_files_dirs.get('oasis_files_dir__gul').name
+            'oed_location_csv': self.tmp_oasis_files['oed_location_csv'].name,
+            'oasis_files_dir': self.tmp_oasis_files_dirs.get('oasis_files_dir__gul').name
         }
-        cls.args_gen_files_il = {
-            **cls.args_gen_files_gul,
-            'oed_accounts_csv': cls.tmp_oasis_files['oed_accounts_csv'].name,
-            'oasis_files_dir': cls.tmp_oasis_files_dirs.get('oasis_files_dir__il').name
+        self.args_gen_files_il = {
+            **self.args_gen_files_gul,
+            'oed_accounts_csv': self.tmp_oasis_files['oed_accounts_csv'].name,
+            'oasis_files_dir': self.tmp_oasis_files_dirs.get('oasis_files_dir__il').name
         }
-        cls.args_gen_files_ri = {
-            **cls.args_gen_files_il,
-            'oed_info_csv': cls.tmp_oasis_files['oed_info_csv'].name,
-            'oed_scope_csv': cls.tmp_oasis_files['oed_scope_csv'].name,
-            'oasis_files_dir': cls.tmp_oasis_files_dirs.get('oasis_files_dir__ri').name
+        self.args_gen_files_ri = {
+            **self.args_gen_files_il,
+            'oed_info_csv': self.tmp_oasis_files['oed_info_csv'].name,
+            'oed_scope_csv': self.tmp_oasis_files['oed_scope_csv'].name,
+            'oasis_files_dir': self.tmp_oasis_files_dirs.get('oasis_files_dir__ri').name
         }
 
         # args for generating model data
-        cls.required_args_model_data = [
+        self.required_args_model_data = [
             'num_vulnerabilities',
             'num_intensity_bins',
             'num_damage_bins',
@@ -85,20 +86,19 @@ class TestGenLosses(ComputationChecker):
             'num_areaperils',
             'num_periods',
         ]
-        cls.args_model_data = {k: 10 for k in cls.required_args_model_data}
+        self.args_model_data = {k: 10 for k in self.required_args_model_data}
 
         # populate model data dir
-        cls.model_data_dir = cls.tmp_dirs.get('model_data_dir').name
-        cls.manager.generate_dummy_model_files(**{
-            **cls.args_model_data,
-            'target_dir': cls.model_data_dir
+        self.model_data_dir = self.tmp_dirs.get('model_data_dir').name
+        self.manager.generate_dummy_model_files(**{
+            **self.args_model_data,
+            'target_dir': self.model_data_dir
         })
-        for src_file in pathlib.Path(cls.model_data_dir).glob('*/*.*'):
-            shutil.copy(src_file, cls.model_data_dir)
-        shutil.rmtree(pathlib.Path(cls.model_data_dir).joinpath('static'))
-        shutil.rmtree(pathlib.Path(cls.model_data_dir).joinpath('input'))
+        for src_file in pathlib.Path(self.model_data_dir).glob('*/*.*'):
+            shutil.copy(src_file, self.model_data_dir)
+        shutil.rmtree(pathlib.Path(self.model_data_dir).joinpath('static'))
+        shutil.rmtree(pathlib.Path(self.model_data_dir).joinpath('input'))
 
-    def setUp(self):
         self.min_args = {
             'analysis_settings_json': self.tmp_files.get('analysis_settings_json').name,
             'oasis_files_dir': self.args_gen_files_gul['oasis_files_dir'],

--- a/tests/computation/test_platform.py
+++ b/tests/computation/test_platform.py
@@ -29,7 +29,6 @@ class TestPlatformList(ComputationChecker):
     def setUpClass(cls):
         cls.manager = OasisManager()
         cls.default_args = cls.manager._params_platform_list()
-        cls.tmp_files = cls.create_tmp_files([a for a in cls.default_args.keys() if 'json' in a])
 
     def add_connection_startup(self, responce_queue):
         responce_queue.get(
@@ -42,12 +41,14 @@ class TestPlatformList(ComputationChecker):
             headers={"authorization": "Bearer acc_tkn"})
 
     def setUp(self):
+        self.tmp_files = self.create_tmp_files([a for a in self.default_args.keys() if 'json' in a])
         assert responses, 'responses package required to run'
         self.api_url = 'http://example.com/api'
         responses.start()
         self.min_args = {'server_url': self.api_url}
 
     def tearDown(self):
+        super().tearDown()
         responses.stop()
         responses.reset()
 
@@ -156,10 +157,6 @@ class TestPlatformRunInputs(ComputationChecker):
     def setUpClass(cls):
         cls.manager = OasisManager()
         cls.default_args = cls.manager._params_platform_run_inputs()
-        cls.tmp_files = cls.create_tmp_files(
-            [a for a in cls.default_args.keys() if 'csv' in a] +
-            [a for a in cls.default_args.keys() if 'json' in a]
-        )
 
     def add_connection_startup(self, responce_queue=None):
         responce_queue.get(
@@ -172,6 +169,10 @@ class TestPlatformRunInputs(ComputationChecker):
             headers={"authorization": "Bearer acc_tkn"})
 
     def setUp(self):
+        self.tmp_files = self.create_tmp_files(
+            [a for a in self.default_args.keys() if 'csv' in a] +
+            [a for a in self.default_args.keys() if 'json' in a]
+        )
         assert responses, 'responses package required to run'
         self.api_url = 'http://localhost:8000'
         responses.start()
@@ -183,6 +184,7 @@ class TestPlatformRunInputs(ComputationChecker):
         self.write_str(self.tmp_files.get('oed_scope_csv'), "Sample scope content")
 
     def tearDown(self):
+        super().tearDown()
         responses.stop()
         responses.reset()
 
@@ -500,10 +502,10 @@ class TestPlatformRunLosses(ComputationChecker):
     def setUpClass(cls):
         cls.manager = OasisManager()
         cls.default_args = cls.manager._params_platform_run_losses()
-        cls.tmp_dirs = cls.create_tmp_dirs([a for a in cls.default_args if 'dir' in a])
-        cls.tmp_files = cls.create_tmp_files([a for a in cls.default_args if 'json' in a])
 
     def setUp(self):
+        self.tmp_dirs = self.create_tmp_dirs([a for a in self.default_args if 'dir' in a])
+        self.tmp_files = self.create_tmp_files([a for a in self.default_args if 'json' in a])
         self.write_json(self.tmp_files.get('analysis_settings_json'), {'test': 'run settings'})
         self.api_url = 'http://localhost:8000'
         responses.get(
@@ -516,6 +518,7 @@ class TestPlatformRunLosses(ComputationChecker):
         responses.start()
 
     def tearDown(self):
+        super().tearDown()
         responses.stop()
         responses.reset()
 
@@ -557,13 +560,13 @@ class TestPlatformRun(ComputationChecker):
 
         # Tempfiles
         cls.api_url = 'http://localhost:8000'
-        cls.tmp_dirs = cls.create_tmp_dirs([a for a in cls.default_args.keys() if 'dir' in a])
-        cls.tmp_files = cls.create_tmp_files(
-            [a for a in cls.default_args.keys() if 'csv' in a] +
-            [a for a in cls.default_args.keys() if 'json' in a]
-        )
 
     def setUp(self):
+        self.tmp_dirs = self.create_tmp_dirs([a for a in self.default_args.keys() if 'dir' in a])
+        self.tmp_files = self.create_tmp_files(
+            [a for a in self.default_args.keys() if 'csv' in a] +
+            [a for a in self.default_args.keys() if 'json' in a]
+        )
         self.write_json(self.tmp_files.get('analysis_settings_json'), {'test': 'run settings'})
         self.api_url = 'http://localhost:8000'
         responses.get(
@@ -576,6 +579,7 @@ class TestPlatformRun(ComputationChecker):
         responses.start()
 
     def tearDown(self):
+        super().tearDown()
         responses.stop()
         responses.reset()
 

--- a/tests/computation/test_run_generate_files.py
+++ b/tests/computation/test_run_generate_files.py
@@ -22,14 +22,13 @@ class TestGenerateFiles(ComputationChecker):
         cls.pre_hook_args = cls.manager._params_exposure_pre_analysis()
         cls.gen_files_args = cls.manager._params_generate_files()
 
-        # Tempfiles
-        cls.tmp_dirs = cls.create_tmp_dirs([a for a in cls.default_args.keys() if 'dir' in a])
-        cls.tmp_files = cls.create_tmp_files(
-            [a for a in cls.default_args.keys() if 'csv' in a] +
-            [a for a in cls.default_args.keys() if 'json' in a]
-        )
-
     def setUp(self):
+        # Tempfiles
+        self.tmp_dirs = self.create_tmp_dirs([a for a in self.default_args.keys() if 'dir' in a])
+        self.tmp_files = self.create_tmp_files(
+            [a for a in self.default_args.keys() if 'csv' in a] +
+            [a for a in self.default_args.keys() if 'json' in a]
+        )
         self.min_args = {
             'oed_location_csv': self.tmp_files['oed_location_csv'].name,
             'keys_data_csv': self.tmp_files['keys_data_csv'].name,

--- a/tests/computation/test_run_model.py
+++ b/tests/computation/test_run_model.py
@@ -23,14 +23,14 @@ class TestRunModel(ComputationChecker):
         cls.gen_files_args = cls.manager._params_generate_files()
         cls.gen_loss_args = cls.manager._params_generate_losses()
 
+    def setUp(self):
         # Tempfiles
-        cls.tmp_dirs = cls.create_tmp_dirs([a for a in cls.default_args.keys() if 'dir' in a])
-        cls.tmp_files = cls.create_tmp_files(
-            [a for a in cls.default_args.keys() if 'csv' in a] +
-            [a for a in cls.default_args.keys() if 'json' in a]
+        self.tmp_dirs = self.create_tmp_dirs([a for a in self.default_args.keys() if 'dir' in a])
+        self.tmp_files = self.create_tmp_files(
+            [a for a in self.default_args.keys() if 'csv' in a] +
+            [a for a in self.default_args.keys() if 'json' in a]
         )
 
-    def setUp(self):
         self.min_args = {
             'oed_location_csv': self.tmp_files['oed_location_csv'].name,
             'analysis_settings_json': self.tmp_files['analysis_settings_json'].name,

--- a/tests/model_execution/test_bash.py
+++ b/tests/model_execution/test_bash.py
@@ -193,7 +193,7 @@ class Genbash(TestCase):
         if self.fifo_tmp_dir:
             # Create temp Ref file
             ref_template = reference_filename
-            ref_tmp_file = NamedTemporaryFile("w+", delete=False)
+            ref_tmp_file = NamedTemporaryFile("w+", delete=False, prefix='bash')
             with io.open(output_filename, 'r') as f:
                 for line in f:
                     if '/tmp/' in line:

--- a/tests/model_execution/test_bin.py
+++ b/tests/model_execution/test_bin.py
@@ -508,7 +508,7 @@ class PrepareRunDirectory(TestCase):
             self.assertTrue(os.path.exists(os.path.join(run_dir, 'input', 'a_file.csv')))
 
     def test_analysis_settings_file_is_supplied___file_is_copied_into_run_dir(self):
-        analysis_settings_fp = NamedTemporaryFile('w', delete=False)
+        analysis_settings_fp = NamedTemporaryFile('w', delete=False, prefix='bin')
         try:
             with TemporaryDirectory() as run_dir, TemporaryDirectory() as oasis_src_fp, TemporaryDirectory() as model_data_fp:
                 analysis_settings_fp.write('{"analysis_settings": "analysis_settings"}')

--- a/tests/pytools/pla/test_plapy.py
+++ b/tests/pytools/pla/test_plapy.py
@@ -1,10 +1,10 @@
-import contextlib
 import filecmp
 from mock import patch
 import numpy as np
 import os
+from pathlib import Path
 import pytest
-from tempfile import NamedTemporaryFile, TemporaryDirectory
+from tempfile import NamedTemporaryFile
 from unittest import TestCase
 
 from oasislmf.pytools.pla.common import (
@@ -95,15 +95,13 @@ class TestPostLossAmplification(TestCase):
         Set up and write items amplifications, loss factors, input Ground Up
         Loss (GUL) and expected Post Loss Amplification (PLA) files for tests.
         """
+
         n_events = 2
         n_items = 2
 
         # Write items amplfications file
-        self.stack = contextlib.ExitStack()
-        self.tmp_dir = self.stack.enter_context(TemporaryDirectory())
-        os.chdir(self.tmp_dir)
-        self.input_dir = 'input'
-        os.makedirs(self.input_dir, exist_ok=True)
+        self.input_dir = Path('./input')
+        self.input_dir.mkdir(exist_ok=True)
         itemsamps_file = os.path.join(
             self.input_dir, AMPLIFICATIONS_FILE_NAME
         )
@@ -112,8 +110,8 @@ class TestPostLossAmplification(TestCase):
         )
 
         # Write loss factors file
-        self.static_dir = 'static'
-        os.makedirs(self.static_dir, exist_ok=True)
+        self.static_dir = Path('./static')
+        self.static_dir.mkdir(exist_ok=True)
         lossfactors_file = os.path.join(self.static_dir, LOSS_FACTORS_FILE_NAME)
         n_amplifications = 2
         factors = np.array([[1.1, 1.2], [1.0, 0.8]])
@@ -168,7 +166,14 @@ class TestPostLossAmplification(TestCase):
         Delete items amplifications, loss factors, input Ground Up Loss (GUL)
         and expected Post Loss Amplification (PLA) files.
         """
-        super().tearDown()
+        for f in self.input_dir.iterdir():
+            f.unlink()
+        self.input_dir.rmdir()
+
+        for f in self.static_dir.iterdir():
+            f.unlink()
+        self.static_dir.rmdir()
+
         self.gul_in.close()
         self.ctrl_pla_out.close()
 

--- a/tests/pytools/pla/test_plapy.py
+++ b/tests/pytools/pla/test_plapy.py
@@ -1,10 +1,10 @@
+import contextlib
 import filecmp
 from mock import patch
 import numpy as np
 import os
-from pathlib import Path
 import pytest
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest import TestCase
 
 from oasislmf.pytools.pla.common import (
@@ -95,13 +95,15 @@ class TestPostLossAmplification(TestCase):
         Set up and write items amplifications, loss factors, input Ground Up
         Loss (GUL) and expected Post Loss Amplification (PLA) files for tests.
         """
-
         n_events = 2
         n_items = 2
 
         # Write items amplfications file
-        self.input_dir = Path('./input')
-        self.input_dir.mkdir(exist_ok=True)
+        self.stack = contextlib.ExitStack()
+        self.tmp_dir = self.stack.enter_context(TemporaryDirectory())
+        os.chdir(self.tmp_dir)
+        self.input_dir = 'input'
+        os.makedirs(self.input_dir, exist_ok=True)
         itemsamps_file = os.path.join(
             self.input_dir, AMPLIFICATIONS_FILE_NAME
         )
@@ -110,8 +112,8 @@ class TestPostLossAmplification(TestCase):
         )
 
         # Write loss factors file
-        self.static_dir = Path('./static')
-        self.static_dir.mkdir(exist_ok=True)
+        self.static_dir = 'static'
+        os.makedirs(self.static_dir, exist_ok=True)
         lossfactors_file = os.path.join(self.static_dir, LOSS_FACTORS_FILE_NAME)
         n_amplifications = 2
         factors = np.array([[1.1, 1.2], [1.0, 0.8]])
@@ -166,14 +168,7 @@ class TestPostLossAmplification(TestCase):
         Delete items amplifications, loss factors, input Ground Up Loss (GUL)
         and expected Post Loss Amplification (PLA) files.
         """
-        for f in self.input_dir.iterdir():
-            f.unlink()
-        self.input_dir.rmdir()
-
-        for f in self.static_dir.iterdir():
-            f.unlink()
-        self.static_dir.rmdir()
-
+        super().tearDown()
         self.gul_in.close()
         self.ctrl_pla_out.close()
 

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -178,7 +178,7 @@ class TestGetDataframe(TestCase):
         )
     )
     def test_get_dataframe__from_csv_file__use_default_options(self, data):
-        fp = NamedTemporaryFile('w', delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             df.to_csv(path_or_buf=fp, columns=df.columns, encoding='utf-8', index=False)
@@ -205,7 +205,7 @@ class TestGetDataframe(TestCase):
         )
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_cols__use_default_options(self, data):
-        fp = NamedTemporaryFile('w', delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             df.to_csv(path_or_buf=fp, columns=df.columns, encoding='utf-8', index=False)
@@ -239,7 +239,7 @@ class TestGetDataframe(TestCase):
         })
     )
     def test_get_dataframe__from_csv_file__set_col_dtypes_option_and_use_defaults_for_all_other_options(self, data, dtypes):
-        fp = NamedTemporaryFile('w', delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             for col, dtype in dtypes.items():
@@ -274,7 +274,7 @@ class TestGetDataframe(TestCase):
         })
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_cols__set_col_dtypes_option_and_use_defaults_for_all_other_options(self, data, dtypes):
-        fp = NamedTemporaryFile('w', delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             for col, dtype in dtypes.items():
@@ -294,7 +294,7 @@ class TestGetDataframe(TestCase):
     @settings(max_examples=10, deadline=None)
     @given(empty_data_err_msg=text(min_size=1, max_size=10, alphabet=string.ascii_lowercase))
     def test_get_dataframe__from_empty_csv_file__set_empty_data_err_msg_and_defaults_for_all_other_options__oasis_exception_is_raised_with_empty_data_err_msg(self, empty_data_err_msg):
-        fp = NamedTemporaryFile('w', delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame()
             df.to_csv(path_or_buf=fp)
@@ -331,7 +331,7 @@ class TestGetDataframe(TestCase):
         )
     )
     def test_get_dataframe__from_csv_file__set_required_cols_option_and_use_defaults_for_all_other_options(self, data, required):
-        fp = NamedTemporaryFile('w', delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             df.to_csv(path_or_buf=fp, columns=df.columns, encoding='utf-8', index=False)
@@ -370,7 +370,7 @@ class TestGetDataframe(TestCase):
         )
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_cols__set_required_cols_option_and_use_defaults_for_all_other_options(self, data, required):
-        fp = NamedTemporaryFile('w', delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             df.to_csv(path_or_buf=fp, columns=df.columns, encoding='utf-8', index=False)
@@ -410,7 +410,7 @@ class TestGetDataframe(TestCase):
         )
     )
     def test_get_dataframe__from_csv_file_missing_some_required_cols__set_required_cols_option_and_use_defaults_for_all_other_options__oasis_exception_is_raised(self, data, missing_cols):
-        fp = NamedTemporaryFile('w', delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             df.drop(missing_cols, axis=1).to_csv(path_or_buf=fp, encoding='utf-8', index=False)
@@ -446,7 +446,7 @@ class TestGetDataframe(TestCase):
         )
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_cols_and_missing_some_required_cols__set_required_cols_option_and_use_defaults_for_all_other_options__oasis_exception_is_raised(self, data, missing):
-        fp = NamedTemporaryFile('w', delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             df.drop(missing, axis=1).to_csv(path_or_buf=fp, encoding='utf-8', index=False)
@@ -480,7 +480,7 @@ class TestGetDataframe(TestCase):
         })
     )
     def test_get_dataframe__from_csv_file__set_col_defaults_option_and_use_defaults_for_all_other_options(self, data, defaults):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             df.to_csv(path_or_buf=fp, columns=df.columns, encoding='utf-8', index=False)
@@ -516,7 +516,7 @@ class TestGetDataframe(TestCase):
         })
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_cols__set_col_defaults_option_and_use_defaults_for_all_other_options(self, data, defaults):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             df.to_csv(path_or_buf=fp, columns=df.columns, encoding='utf-8', index=False)
@@ -547,7 +547,7 @@ class TestGetDataframe(TestCase):
         )
     )
     def test_get_dataframe__from_csv_file_with_nulls_in_some_columns__set_non_na_cols_option_and_use_defaults_for_all_other_options(self, data):
-        fp = NamedTemporaryFile('w', delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             data[-1]['int_col'] = np.nan
             data[-2]['str_col'] = np.nan
@@ -577,7 +577,7 @@ class TestGetDataframe(TestCase):
         )
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_cols_and_nulls_in_some_columns__set_non_na_cols_option_and_use_defaults_for_all_other_options(self, data):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             data[-1]['int_col'] = np.nan
             data[-2]['STR_COL'] = np.nan
@@ -610,7 +610,7 @@ class TestGetDataframe(TestCase):
         )
     )
     def test_get_dataframe__from_csv_file__set_sort_cols_option_on_single_col_and_use_defaults_for_all_other_options(self, data):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             data = [{k: (v if k != 'int_col' else np.random.choice(range(10))) for k, v in it.items()} for it in data]
             df = pd.DataFrame(data)
@@ -641,7 +641,7 @@ class TestGetDataframe(TestCase):
         )
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_cols__set_sort_cols_option_on_single_col_and_use_defaults_for_all_other_options(self, data):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             data = [{k: (v if k != 'IntCol' else np.random.choice(range(10))) for k, v in it.items()} for it in data]
             df = pd.DataFrame(data)
@@ -673,7 +673,7 @@ class TestGetDataframe(TestCase):
         )
     )
     def test_get_dataframe__from_csv_file__set_sort_cols_option_on_two_cols_and_use_defaults_for_all_other_options(self, data):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             data = [
                 {k: (v if k not in ('int_col', 'str_col') else (np.random.choice(range(10)) if k ==
@@ -708,7 +708,7 @@ class TestGetDataframe(TestCase):
         )
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_cols__set_sort_cols_option_on_two_cols_and_use_defaults_for_all_other_options(self, data):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             data = [
                 {k: (v if k not in ('IntCol', 'STR_COL') else (np.random.choice(range(10)) if k ==
@@ -757,7 +757,7 @@ class TestGetDataframe(TestCase):
         })
     )
     def test_get_dataframe__from_csv_file__set_required_cols_and_col_defaults_options_and_use_defaults_for_all_other_options(self, data, required, defaults):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             df.to_csv(path_or_buf=fp, encoding='utf-8', index=False)
@@ -801,7 +801,7 @@ class TestGetDataframe(TestCase):
         })
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_cols__set_required_cols_and_col_defaults_options_and_use_defaults_for_all_other_options(self, data, required, defaults):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             df.to_csv(path_or_buf=fp, encoding='utf-8', index=False)
@@ -846,7 +846,7 @@ class TestGetDataframe(TestCase):
         })
     )
     def test_get_dataframe__from_csv_file_missing_some_required_cols__set_required_cols_and_col_defaults_options_and_use_defaults_for_all_other_options__oasis_exception_is_raised(self, data, missing, defaults):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             df.drop(missing, axis=1).to_csv(path_or_buf=fp, encoding='utf-8', index=False)
@@ -886,7 +886,7 @@ class TestGetDataframe(TestCase):
         })
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_cols_and_missing_some_required_cols__set_required_cols_and_col_defaults_options_and_use_defaults_for_all_other_options__oasis_exception_is_raised(self, data, missing, defaults):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             df.drop(missing, axis=1).to_csv(path_or_buf=fp, encoding='utf-8', index=False)
@@ -913,7 +913,7 @@ class TestGetDataframe(TestCase):
         )
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_columns___set_lowercase_cols_option_to_false_and_use_defaults_for_all_other_options(self, data):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             df.to_csv(path_or_buf=fp, columns=df.columns, encoding='utf-8', index=False)
@@ -946,7 +946,7 @@ class TestGetDataframe(TestCase):
         })
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_columns__set_lowercase_col_option_to_false_and_col_dtypes_option_and_use_defaults_for_all_other_options(self, data, dtypes):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             for col, dtype in dtypes.items():
@@ -984,7 +984,7 @@ class TestGetDataframe(TestCase):
         )
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_cols__set_lowercase_cols_option_to_false_and_required_cols_option_and_use_defaults_for_all_other_options(self, data, required):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             df.to_csv(path_or_buf=fp, columns=df.columns, encoding='utf-8', index=False)
@@ -1024,7 +1024,7 @@ class TestGetDataframe(TestCase):
         )
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_cols_and_missing_some_required_cols__set_lowercase_cols_option_to_false_and_required_cols_option_and_use_defaults_for_all_other_options__oasis_exception_is_raised(self, data, missing):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             df.drop(missing, axis=1).to_csv(path_or_buf=fp, encoding='utf-8', index=False)
@@ -1059,7 +1059,7 @@ class TestGetDataframe(TestCase):
         })
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_cols__set_lowercase_cols_option_to_false_and_col_defaults_option_and_use_defaults_for_all_other_options(self, data, defaults):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             df.to_csv(path_or_buf=fp, columns=df.columns, encoding='utf-8', index=False)
@@ -1100,7 +1100,7 @@ class TestGetDataframe(TestCase):
         )
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_cols_and_nulls_in_some_columns__set_lowercase_cols_option_to_false_and_non_na_cols_option_and_use_defaults_for_all_other_options(self, data):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             data[-1]['int_col'] = np.nan
             data[-2]['STR_COL'] = np.nan
@@ -1132,7 +1132,7 @@ class TestGetDataframe(TestCase):
         )
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_cols__set_lowercase_cols_option_to_false_and_sort_cols_option_on_single_col_and_use_defaults_for_all_other_options(self, data):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             data = [{k: (v if k != 'IntCol' else np.random.choice(range(10))) for k, v in it.items()} for it in data]
             df = pd.DataFrame(data)
@@ -1163,7 +1163,7 @@ class TestGetDataframe(TestCase):
         )
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_cols__set_lowercase_cols_option_to_false_and_sort_cols_option_on_two_cols_and_use_defaults_for_all_other_options(self, data):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             data = [
                 {k: (v if k not in ('IntCol', 'STR_COL') else (np.random.choice(range(10)) if k ==
@@ -1211,7 +1211,7 @@ class TestGetDataframe(TestCase):
         })
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_cols__set_lowercase_cols_option_to_false__set_required_cols_and_col_defaults_options_and_use_defaults_for_all_other_options(self, data, required, defaults):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             df.to_csv(path_or_buf=fp, encoding='utf-8', index=False)
@@ -1255,7 +1255,7 @@ class TestGetDataframe(TestCase):
         })
     )
     def test_get_dataframe__from_csv_file_with_mixed_case_cols_and_missing_some_required_cols__set_lowercase_cols_option_to_false__set_required_cols_and_col_defaults_options_and_use_defaults_for_all_other_options__oasis_exception_is_raised(self, data, missing, defaults):
-        fp = NamedTemporaryFile("w", delete=False)
+        fp = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             df = pd.DataFrame(data)
             df.drop(missing, axis=1).to_csv(path_or_buf=fp, encoding='utf-8', index=False)
@@ -1298,7 +1298,7 @@ class TestGetJson(TestCase):
     )
     def test_get_json__with_nesting_depth_of_1(self, data):
         expected = copy.deepcopy(data)
-        f1 = NamedTemporaryFile("w", delete=False)
+        f1 = NamedTemporaryFile('w', delete=False, prefix='data')
         try:
             f1.write(json.dumps(expected, indent=4, sort_keys=True))
             f1.close()

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -13,7 +13,6 @@ import pandas as pd
 import pytest
 import pytz
 from hypothesis import example, given, settings
-# from hypothesis import reproduce_failure
 from hypothesis.strategies import (datetimes, fixed_dictionaries, floats,
                                    integers, just, lists, sampled_from, text)
 from pandas.testing import assert_frame_equal as pd_assert_frame_equal
@@ -1577,7 +1576,6 @@ class TestOedDataTypes(TestCase):
             "Payroll": sampled_from([np.nan, str(1), int(1), float(1)]),
         })
     )
-    # @reproduce_failure('6.82.0', b'AXicY2AYTgAAAM4AAQ==')
     def test_location_dtypes_loaded_correctly(self, data):
         df = pd.DataFrame(data, index=[0])
         oed_exposure = OedExposure(**{'location': df, 'use_field': True})
@@ -1588,7 +1586,6 @@ class TestOedDataTypes(TestCase):
 
         for col in df_result.columns:
             if col in loc_expected_dtypes:
-                #import ipdb; ipdb.set_trace()
                 dtype_expected = loc_expected_dtypes[col]['pd_dtype']
                 dtype_found = type(df_result[col][0])
                 print(f'{col} - Expected: {dtype_expected}, Found: {dtype_found}')

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -13,6 +13,7 @@ import pandas as pd
 import pytest
 import pytz
 from hypothesis import example, given, settings
+# from hypothesis import reproduce_failure
 from hypothesis.strategies import (datetimes, fixed_dictionaries, floats,
                                    integers, just, lists, sampled_from, text)
 from pandas.testing import assert_frame_equal as pd_assert_frame_equal
@@ -1342,7 +1343,8 @@ class TestOedDataTypes(TestCase):
     def setUp(self):
         # Set vaild types
         self.valid_str_types = (
-            str
+            str,
+            pd.Categorical,
         )
         self.valid_int_types = (
             int,
@@ -1575,6 +1577,7 @@ class TestOedDataTypes(TestCase):
             "Payroll": sampled_from([np.nan, str(1), int(1), float(1)]),
         })
     )
+    # @reproduce_failure('6.82.0', b'AXicY2AYTgAAAM4AAQ==')
     def test_location_dtypes_loaded_correctly(self, data):
         df = pd.DataFrame(data, index=[0])
         oed_exposure = OedExposure(**{'location': df, 'use_field': True})
@@ -1585,6 +1588,7 @@ class TestOedDataTypes(TestCase):
 
         for col in df_result.columns:
             if col in loc_expected_dtypes:
+                #import ipdb; ipdb.set_trace()
                 dtype_expected = loc_expected_dtypes[col]['pd_dtype']
                 dtype_found = type(df_result[col][0])
                 print(f'{col} - Expected: {dtype_expected}, Found: {dtype_found}')

--- a/tests/utils/test_diff.py
+++ b/tests/utils/test_diff.py
@@ -24,7 +24,7 @@ class UnifiedDiff(TestCase):
             unified_diff('first', 'second')
 
     def test_two_files_are_the_same___result_is_empty(self):
-        f = NamedTemporaryFile(mode='w', delete=False)
+        f = NamedTemporaryFile(mode='w', delete=False, prefix='diff')
         try:
             f.write('content')
             f.close()
@@ -36,8 +36,8 @@ class UnifiedDiff(TestCase):
             os.remove(f.name)
 
     def test_two_files_are_different___result_is_list_of_differences(self):
-        first = NamedTemporaryFile(mode='w', delete=False)
-        second = NamedTemporaryFile(mode='w', delete=False)
+        first = NamedTemporaryFile(mode='w', delete=False, prefix='diff')
+        second = NamedTemporaryFile(mode='w', delete=False, prefix='diff')
         try:
             first.writelines([
                 'HEADING\n',
@@ -76,8 +76,8 @@ class UnifiedDiff(TestCase):
             os.remove(second.name)
 
     def test_two_files_are_different_as_string_is_true___result_is_concatenated_list_of_differences(self):
-        first = NamedTemporaryFile(mode='w', delete=False)
-        second = NamedTemporaryFile(mode='w', delete=False)
+        first = NamedTemporaryFile(mode='w', delete=False, prefix='diff')
+        second = NamedTemporaryFile(mode='w', delete=False, prefix='diff')
         try:
             first.writelines([
                 'HEADING\n',


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Fixed the removal of log handlers in logging redirect wrapper
* Log handlers were not correctly removed when exiting from log redirect
* Added log redirect to plapy
* Fixed open file leaks in testing 
<!--end_release_notes-->



### Logging tree before and after fix
[log-tree_error.txt](https://github.com/OasisLMF/OasisLMF/files/12172050/log-tree.txt)
[logging_tree_fix_branch.txt](https://github.com/OasisLMF/OasisLMF/files/12172054/logging_tree_fix_branch.txt)
