### PR TITLE
Support multiple identifiers for footprint files

### DIFF
--- a/.github/workflows/piwind-test.yml
+++ b/.github/workflows/piwind-test.yml
@@ -24,7 +24,11 @@ on:
 
   workflow_dispatch:
     inputs:
-      platform_version:
+      platform_1_version:
+        description: 'OasisPlatform Version to test using [docker tag]'
+        required: true
+        default: latest
+      platform_2_version:
         description: 'OasisPlatform Version to test using [docker tag]'
         required: true
         default: latest
@@ -54,7 +58,7 @@ jobs:
     with:
       ods_branch: ${{ github.event_name != 'workflow_dispatch' && 'main' ||  inputs.ods_branch }}
 
-  piwind:
+  platform1:
     if: ${{ ! failure() || ! cancelled() }}
     uses: OasisLMF/OasisPiWind/.github/workflows/test.yml@main
     secrets: inherit
@@ -64,4 +68,19 @@ jobs:
       oasislmf_package: ${{ needs.build.outputs.linux_pkg_filename }}
       oasislmf_branch: ''
       ods_package: ${{ needs.ods_tools.outputs.whl_filename }}
-      platform_version: ${{ github.event_name != 'workflow_dispatch' && 'latest' ||  inputs.platform_version }}
+      platform_version: ${{ github.event_name != 'workflow_dispatch' && 'latest' ||  inputs.platform_1_version }}
+      storage_suffix: '_platform1'
+
+  platform2:
+    if: ${{ ! failure() || ! cancelled() }}
+    uses: OasisLMF/OasisPiWind/.github/workflows/test.yml@main
+    secrets: inherit
+    needs: [build, ods_tools]
+    with:
+      piwind_branch: ${{ github.event_name != 'workflow_dispatch' && 'main' || inputs.piwind_branch }}
+      oasislmf_package: ${{ needs.build.outputs.linux_pkg_filename }}
+      oasislmf_branch: ''
+      ods_package: ${{ needs.ods_tools.outputs.whl_filename }}
+      platform_version: ${{ github.event_name != 'workflow_dispatch' && '2.2.0' ||  inputs.platform_2_version }}
+      pytest_opts: "--docker-compose=./docker/plat2.docker-compose.yml "
+      storage_suffix: '_platform2'

--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -583,7 +583,7 @@ class GenerateLosses(GenerateLossesDir):
         {'name': 'fmpy_sort_output', 'default': False, 'type': str2bool, 'const': True, 'nargs': '?', 'help': 'order fmpy output by item_id'},
         {'name': 'model_custom_gulcalc', 'default': None, 'help': 'Custom gulcalc binary name to call in the model losses step'},
         {'name': 'model_py_server', 'default': False, 'type': str2bool, 'help': 'running the data server for modelpy'},
-        {'name': 'peril_filter', 'default': [], 'nargs':'+', 'help': 'Peril specific run'},
+        {'name': 'peril_filter', 'default': [], 'nargs': '+', 'help': 'Peril specific run'},
         {'name': 'model_custom_gulcalc_log_start', 'default': None, 'help': 'Log message produced when custom gulcalc binary process starts'},
         {'name': 'model_custom_gulcalc_log_finish', 'default': None, 'help': 'Log message produced when custom gulcalc binary process ends'},
     ]

--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -29,7 +29,7 @@ from ods_tools.oed.setting_schema import ModelSettingSchema, AnalysisSettingSche
 from ...execution import bash, runner
 from ...execution.bash import get_fmcmd
 from ...execution.bin import (csv_to_bin, prepare_run_directory,
-                              prepare_run_inputs)
+                              prepare_run_inputs, set_footprint_set)
 from ...preparation.summaries import generate_summaryxref_files
 from ...pytools.fm.financial_structure import create_financial_structure
 from ...utils.data import (fast_zip_dataframe_columns,
@@ -317,6 +317,9 @@ class GenerateLossesDir(GenerateLossesBase):
             analysis_settings['number_of_samples'] = default_model_samples
 
         prepare_run_inputs(analysis_settings, model_run_fp, ri=ri)
+        footprint_set_val = analysis_settings.get('model_settings', {}).get('footprint_set')
+        if footprint_set_val:
+            set_footprint_set(footprint_set_val, model_run_fp)
 
         # Test call to create fmpy files in GenerateLossesDir
         if il and self.fmpy:

--- a/oasislmf/execution/bin.py
+++ b/oasislmf/execution/bin.py
@@ -39,9 +39,9 @@ from ..utils.defaults import STATIC_DATA_FP
 from .files import TAR_FILE, INPUT_FILES, GUL_INPUT_FILES, IL_INPUT_FILES
 from .bash import leccalc_enabled, ord_enabled, ORD_LECCALC
 from oasislmf.pytools.getmodel.common import footprint_file_formats
-from oasislmf.pytools.getmodel.footprint import (
-    FootprintParquet, FootprintBinZ, FootprintBin, FootprintCsv
-)
+from oasislmf.pytools.getmodel.footprint import (   # noqa: F401
+    FootprintParquet, FootprintBinZ, FootprintBin, FootprintCsv   # noqa: F401
+)   # noqa: F401
 
 logger = logging.getLogger(__name__)
 

--- a/oasislmf/execution/bin.py
+++ b/oasislmf/execution/bin.py
@@ -38,10 +38,10 @@ from ..utils.log import oasis_log
 from ..utils.defaults import STATIC_DATA_FP
 from .files import TAR_FILE, INPUT_FILES, GUL_INPUT_FILES, IL_INPUT_FILES
 from .bash import leccalc_enabled, ord_enabled, ORD_LECCALC
-from oasislmf.pytools.getmodel.common import footprint_file_formats
-from oasislmf.pytools.getmodel.footprint import (   # noqa: F401
-    FootprintParquet, FootprintBinZ, FootprintBin, FootprintCsv   # noqa: F401
-)   # noqa: F401
+from oasislmf.pytools.getmodel.common import fp_format_priorities
+from oasislmf.pytools.getmodel.footprint import (
+    FootprintParquet, FootprintBinZ, FootprintBin, FootprintCsv
+)
 
 logger = logging.getLogger(__name__)
 
@@ -411,7 +411,11 @@ def set_footprint_set(setting_val, run_dir):
     :param run_dir: model run directory
     :type run_dir: string
     """
-    priorities = [eval(footprint_class) for footprint_class in footprint_file_formats]
+    format_to_class = {
+        'parquet': FootprintParquet, 'binZ': FootprintBinZ,
+        'bin': FootprintBin, 'csv': FootprintCsv
+    }
+    priorities = [format_to_class[fmt] for fmt in fp_format_priorities if fmt in format_to_class]
     setting_val = str(setting_val)
 
     for footprint_class in priorities:

--- a/oasislmf/lookup/builtin.py
+++ b/oasislmf/lookup/builtin.py
@@ -106,9 +106,6 @@ def nearest_neighbor(left_gdf, right_gdf, return_dist=False):
     return closest_points
 
 
-key_columns = ['loc_id', 'peril_id', 'coverage_type', 'area_peril_id', 'vulnerability_id', 'status', 'message']
-
-
 class DeterministicLookup(AbstractBasicKeyLookup):
     multiproc_enabled = False
 
@@ -260,7 +257,10 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
             step_function = self.set_step_function(step_name, step_config)
             locations = step_function(locations)
 
-        global key_columns
+        key_columns = [
+            'loc_id', 'peril_id', 'coverage_type', 'area_peril_id',
+            'vulnerability_id', 'status', 'message'
+        ]
         if 'amplification_id' in locations.columns:
             key_columns += ['amplification_id']
         locations = locations[key_columns]

--- a/oasislmf/pytools/getmodel/common.py
+++ b/oasislmf/pytools/getmodel/common.py
@@ -6,10 +6,8 @@ import numpy as np
 
 from oasislmf.pytools.common import areaperil_int, oasis_float
 
-# names of footprint file format classes in order of priority
-footprint_file_formats = [
-    'FootprintParquet', 'FootprintBinZ', 'FootprintBin', 'FootprintCsv'
-]
+# Footprint file formats in order of priority
+fp_format_priorities = ['parquet', 'binZ', 'bin', 'csv']
 
 # filenames
 footprint_filename = 'footprint.bin'

--- a/oasislmf/pytools/getmodel/common.py
+++ b/oasislmf/pytools/getmodel/common.py
@@ -6,6 +6,11 @@ import numpy as np
 
 from oasislmf.pytools.common import areaperil_int, oasis_float
 
+# names of footprint file format classes in order of priority
+footprint_file_formats = [
+    'FootprintParquet', 'FootprintBinZ', 'FootprintBin', 'FootprintCsv'
+]
+
 # filenames
 footprint_filename = 'footprint.bin'
 footprint_index_filename = 'footprint.idx'

--- a/oasislmf/pytools/getmodel/footprint.py
+++ b/oasislmf/pytools/getmodel/footprint.py
@@ -16,7 +16,8 @@ import numba as nb
 
 from .common import (FootprintHeader, EventIndexBin, EventIndexBinZ, Event, EventCSV,
                      footprint_filename, footprint_index_filename, zfootprint_filename, zfootprint_index_filename,
-                     csvfootprint_filename, parquetfootprint_filename, parquetfootprint_meta_filename)
+                     csvfootprint_filename, parquetfootprint_filename, parquetfootprint_meta_filename,
+                     footprint_file_formats)
 
 logger = logging.getLogger(__name__)
 
@@ -89,12 +90,7 @@ class Footprint:
 
         Returns: (Union[FootprintBinZ, FootprintBin, FootprintCsv]) the loaded class
         """
-        priorities = [
-            FootprintParquet,
-            FootprintBinZ,
-            FootprintBin,
-            FootprintCsv
-        ]
+        priorities = [eval(footprint_class) for footprint_class in footprint_file_formats]
 
         for footprint_class in priorities:
             for filename in footprint_class.footprint_filenames:

--- a/oasislmf/pytools/getmodel/footprint.py
+++ b/oasislmf/pytools/getmodel/footprint.py
@@ -17,7 +17,7 @@ import numba as nb
 from .common import (FootprintHeader, EventIndexBin, EventIndexBinZ, Event, EventCSV,
                      footprint_filename, footprint_index_filename, zfootprint_filename, zfootprint_index_filename,
                      csvfootprint_filename, parquetfootprint_filename, parquetfootprint_meta_filename,
-                     footprint_file_formats)
+                     fp_format_priorities)
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +90,11 @@ class Footprint:
 
         Returns: (Union[FootprintBinZ, FootprintBin, FootprintCsv]) the loaded class
         """
-        priorities = [eval(footprint_class) for footprint_class in footprint_file_formats]
+        format_to_class = {
+            'parquet': FootprintParquet, 'binZ': FootprintBinZ,
+            'bin': FootprintBin, 'csv': FootprintCsv
+        }
+        priorities = [format_to_class[fmt] for fmt in fp_format_priorities if fmt in format_to_class]
 
         for footprint_class in priorities:
             for filename in footprint_class.footprint_filenames:

--- a/tests/model_execution/test_bin.py
+++ b/tests/model_execution/test_bin.py
@@ -919,7 +919,7 @@ class SetFootprintSet(TestCase):
                 if fp_format == 'parquet':
                     continue
                 for filename in fp_filename:
-                    assert os.path.exists(os.path.join(d, 'static', filename)) == False
+                    assert os.path.exists(os.path.join(d, 'static', filename)) is False
 
     def test_symbolic_links_to_binz_files(self):
         """
@@ -944,7 +944,7 @@ class SetFootprintSet(TestCase):
                 if fp_format == 'binz':
                     continue
                 for filename in fp_filename:
-                    assert os.path.exists(os.path.join(d, 'static', filename)) == False
+                    assert os.path.exists(os.path.join(d, 'static', filename)) is False
 
     def test_symbolic_links_to_bin_files(self):
         """
@@ -969,7 +969,7 @@ class SetFootprintSet(TestCase):
                 if fp_format == 'bin':
                     continue
                 for filename in fp_filename:
-                    assert os.path.exists(os.path.join(d, 'static', filename)) == False
+                    assert os.path.exists(os.path.join(d, 'static', filename)) is False
 
     def test_symbolic_link_to_csv_file(self):
         """
@@ -991,7 +991,7 @@ class SetFootprintSet(TestCase):
                 if fp_format == 'csv':
                     continue
                 for filename in fp_filename:
-                    assert os.path.exists(os.path.join(d, 'static', filename)) == False
+                    assert os.path.exists(os.path.join(d, 'static', filename)) is False
 
     def test_no_valid_symbolic_links_raises_exception(self):
         """

--- a/tests/model_execution/test_bin.py
+++ b/tests/model_execution/test_bin.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 import tarfile
 
-from itertools import chain
+from itertools import chain, islice
 from tempfile import TemporaryDirectory
 from copy import copy, deepcopy
 from tempfile import NamedTemporaryFile
@@ -32,6 +32,7 @@ from oasislmf.model_execution.bin import (
     csv_to_bin,
     prepare_run_directory,
     prepare_run_inputs,
+    set_footprint_set
 )
 from oasislmf.utils.exceptions import OasisException
 
@@ -854,6 +855,152 @@ class PrepareRunInputs(TestCase):
 
             with io.open(os.path.join(d, 'input', 'periods.bin'), 'r', encoding='utf-8') as new_periods_file:
                 self.assertEqual('periods bin', new_periods_file.read())
+
+
+class SetFootprintSet(TestCase):
+
+    def setUp(self):
+        """
+        Declare identifier for footprint file set, footprint file names and
+        symbolic link names for tests.
+        """
+        self.setting_val = 'f'
+        self.parquet_format, self.zip_bin_format, self.bin_format, self.csv_format = range(4)
+
+        # Ordered by priority, i.e. parquet files take priority over all others
+        self.fp_filenames = {
+            'parquet': ['footprint.parquet', 'footprint_parquet_meta.json'],
+            'binz': ['footprint.bin.z', 'footprint.idx.z'],
+            'bin': ['footprint.bin', 'footprint.idx'],
+            'csv': ['footprint.csv']
+        }
+        self.fp_set_filenames = {}
+        for fp_format, fp_filenames in self.fp_filenames.items():
+            self.fp_set_filenames[fp_format] = []
+            for filename in fp_filenames:
+                stem, extension = filename.split('.', 1)
+                self.fp_set_filenames[fp_format].append(f'{stem}_{self.setting_val}.{extension}')
+
+    def make_fake_footprint_files(self, d, priority_level):
+        """
+        Write footprint files to directory.
+
+        Args:
+            d (str): directory name
+            priority_level (int): file format being tested - formats with higher
+                priority (closer to 1) include those of lower priority
+        """
+        os.mkdir(os.path.join(d, 'static'))
+        for fp_format, fp_filename in islice(self.fp_filenames.items(), priority_level, None):
+            for filename in fp_filename:
+                stem, extension = filename.split('.', 1)
+                Path(os.path.join(d, 'static', f'{stem}_{self.setting_val}.{extension}')).touch()
+
+    def test_symbolic_links_to_parquet_files(self):
+        """
+        Test symbolic links pointing to footprint files in parquet format are
+        created. Also test links to zipped binary, binary and csv formatted
+        footprint files are not created.
+        """
+        with TemporaryDirectory() as d:
+            self.make_fake_footprint_files(d, self.parquet_format)
+
+            set_footprint_set(self.setting_val, d)
+
+            for fp_filename, fp_set_filename in zip(
+                self.fp_filenames['parquet'], self.fp_set_filenames['parquet']
+            ):
+                self.assertEqual(
+                    os.readlink(os.path.join(d, 'static', fp_filename)),
+                    os.path.join(d, 'static', fp_set_filename)
+                )
+
+            for fp_format, fp_filename in self.fp_filenames.items():
+                if fp_format == 'parquet':
+                    continue
+                for filename in fp_filename:
+                    assert os.path.exists(os.path.join(d, 'static', filename)) == False
+
+    def test_symbolic_links_to_binz_files(self):
+        """
+        Test symbolic links pointing to footprint files in zipped binary format
+        are created. Also test links to parquet, binary and csv formatted
+        footprint files are not created.
+        """
+        with TemporaryDirectory() as d:
+            self.make_fake_footprint_files(d, self.zip_bin_format)
+
+            set_footprint_set(self.setting_val, d)
+
+            for fp_filename, fp_set_filename in zip(
+                self.fp_filenames['binz'], self.fp_set_filenames['binz']
+            ):
+                self.assertEqual(
+                    os.readlink(os.path.join(d, 'static', fp_filename)),
+                    os.path.join(d, 'static', fp_set_filename)
+                )
+
+            for fp_format, fp_filename in self.fp_filenames.items():
+                if fp_format == 'binz':
+                    continue
+                for filename in fp_filename:
+                    assert os.path.exists(os.path.join(d, 'static', filename)) == False
+
+    def test_symbolic_links_to_bin_files(self):
+        """
+        Test symbolic links pointing to footprint files in binary format are
+        created. Also test links to parquet, zipped binary and csv formatted
+        footprint files are not created.
+        """
+        with TemporaryDirectory() as d:
+            self.make_fake_footprint_files(d, self.bin_format)
+
+            set_footprint_set(self.setting_val, d)
+
+            for fp_filename, fp_set_filename in zip(
+                self.fp_filenames['bin'], self.fp_set_filenames['bin']
+            ):
+                self.assertEqual(
+                    os.readlink(os.path.join(d, 'static', fp_filename)),
+                    os.path.join(d, 'static', fp_set_filename)
+                )
+
+            for fp_format, fp_filename in self.fp_filenames.items():
+                if fp_format == 'bin':
+                    continue
+                for filename in fp_filename:
+                    assert os.path.exists(os.path.join(d, 'static', filename)) == False
+
+    def test_symbolic_link_to_csv_file(self):
+        """
+        Test symbolic link pointing to footprint file in csv format is created.
+        Also test links to parquet, zipped binary and binary formatted footprint
+        files are not created.
+        """
+        with TemporaryDirectory() as d:
+            self.make_fake_footprint_files(d, self.csv_format)
+
+            set_footprint_set(self.setting_val, d)
+
+            self.assertEqual(
+                os.readlink(os.path.join(d, 'static', self.fp_filenames['csv'][0])),
+                os.path.join(d, 'static', self.fp_set_filenames['csv'][0])
+            )
+
+            for fp_format, fp_filename in self.fp_filenames.items():
+                if fp_format == 'csv':
+                    continue
+                for filename in fp_filename:
+                    assert os.path.exists(os.path.join(d, 'static', filename)) == False
+
+    def test_no_valid_symbolic_links_raises_exception(self):
+        """
+        Test exception is raised should there be no valid footprint file format
+        available.
+        """
+        with TemporaryDirectory() as d:
+            with self.assertRaises(OasisException):
+                set_footprint_set(self.setting_val, d)
 
 
 class CleanBinDirectory(TestCase):


### PR DESCRIPTION
<!--start_release_notes-->
### Support multiple identifiers for footprint files
To enable the storage of footprints in multiple files rather than a single master file, optional identifiers in the form of footprint file suffixes are now supported. This is executed in a similar way to that currently in place to distinguish multiple events and event occurrences files. The `footprint_set` model settings option in the analysis settings file can be set to the desired file suffix for the footprint files to be used. A symbolic link to the desired footprint set is created in the `static/` directory within the model run directory. Footprint file priorities are identical to those set by `modelpy` and `gulmc`, which in order of descending priority are: parquet; zipped binary; binary; and csv.
<!--end_release_notes-->