### PR TITLE
Fixed loading booleans from oasislmf.json

### DIFF
--- a/oasislmf/computation/base.py
+++ b/oasislmf/computation/base.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 
 from ..utils.data import get_utctimestamp
 from ..utils.exceptions import OasisException
-from ..utils.inputs import update_config, str2bool, has_oasis_env, get_oasis_env
+from ..utils.inputs import update_config, str2bool, has_oasis_env, get_oasis_env, ArgumentTypeError
 
 
 class ComputationStep:
@@ -50,7 +50,14 @@ class ComputationStep:
                     param_value = param.get('default')
 
             if (param.get('type', None) == str2bool) and (not isinstance(param_value, bool)):
-                param_value = str2bool(param_value)
+                try:
+                    param_value = str2bool(param_value)
+                except ArgumentTypeError:
+                    raise OasisException(
+                        f"The param '{param.get('name')}' has an invalid value '{param_value}' for boolean"
+                        "\n  Valid strings for True:  ['yes', 'true', 't', 'y', '1']"
+                        "\n  Valid strings for False: ['no', 'false', 'f', 'n', '0']"
+                    )
 
             if (param.get('is_path')
                     and param_value is not None

--- a/oasislmf/computation/base.py
+++ b/oasislmf/computation/base.py
@@ -49,6 +49,9 @@ class ComputationStep:
                 else:
                     param_value = param.get('default')
 
+            if (param.get('type', None) == str2bool) and (not isinstance(param_value, bool)):
+                param_value = str2bool(param_value)
+
             if (param.get('is_path')
                     and param_value is not None
                     and not isinstance(param_value, OedSource)):

--- a/oasislmf/computation/base.py
+++ b/oasislmf/computation/base.py
@@ -54,9 +54,9 @@ class ComputationStep:
                     param_value = str2bool(param_value)
                 except ArgumentTypeError:
                     raise OasisException(
-                        f"The param '{param.get('name')}' has an invalid value '{param_value}' for boolean"
-                        "\n  Valid strings for True:  ['yes', 'true', 't', 'y', '1']"
-                        "\n  Valid strings for False: ['no', 'false', 'f', 'n', '0']"
+                        f"The param '{param.get('name')}' has an invalid value '{param_value}' for boolean. Valid strings are (case insensitive):"
+                        "\n  True:  ['yes', 'true', 't', 'y', '1']"
+                        "\n  False: ['no', 'false', 'f', 'n', '0']"
                     )
 
             if (param.get('is_path')

--- a/oasislmf/computation/base.py
+++ b/oasislmf/computation/base.py
@@ -54,7 +54,7 @@ class ComputationStep:
                     param_value = str2bool(param_value)
                 except ArgumentTypeError:
                     raise OasisException(
-                        f"The param '{param.get('name')}' has an invalid value '{param_value}' for boolean. Valid strings are (case insensitive):"
+                        f"The parameter '{param.get('name')}' has an invalid value '{param_value}' for boolean. Valid strings are (case insensitive):"
                         "\n  True:  ['yes', 'true', 't', 'y', '1']"
                         "\n  False: ['no', 'false', 'f', 'n', '0']"
                     )

--- a/oasislmf/computation/base.py
+++ b/oasislmf/computation/base.py
@@ -49,7 +49,7 @@ class ComputationStep:
                 else:
                     param_value = param.get('default')
 
-            if (param.get('type', None) == str2bool) and (not isinstance(param_value, bool)):
+            if (getattr(param.get('type'), '__name__', None) == 'str2bool') and (not isinstance(param_value, bool)):
                 try:
                     param_value = str2bool(param_value)
                 except ArgumentTypeError:

--- a/tests/computation/test_run_model.py
+++ b/tests/computation/test_run_model.py
@@ -93,7 +93,7 @@ class TestRunModel(ComputationChecker):
 
         with patch.object(oasislmf.computation.run.model, 'GenerateFiles', files_mock), \
                 patch.object(oasislmf.computation.run.model, 'GenerateLosses', losses_mock), \
-                  patch.object(oasislmf.computation.base, 'str2bool', str2bool_mock):
+        patch.object(oasislmf.computation.base, 'str2bool', str2bool_mock):
             self.manager.run_model(**call_args)
         str2bool_mock.assert_called_with('False')
 

--- a/tests/computation/test_run_model.py
+++ b/tests/computation/test_run_model.py
@@ -112,7 +112,7 @@ class TestRunModel(ComputationChecker):
                     patch.object(oasislmf.computation.run.model, 'GenerateLosses', losses_mock):
                 self.manager.run_model(**call_args)
 
-        expected_err_msg = "The param 'gulpy' has an invalid value 'invalid-string' for boolean."
+        expected_err_msg = "The parameter 'gulpy' has an invalid value 'invalid-string' for boolean."
         self.assertIn(expected_err_msg, str(context.exception))
 
     def test_model_run__with_pre_analysis(self):


### PR DESCRIPTION
<!--start_release_notes-->
### Fixed loading booleans from oasislmf.json
The function **str2bool(var)** converts `"False" (str)` to `False (bool)` but is not correctly called from the oasislmf.json file. 

So setting, a boolean flag with:
```
{
  "do_disaggregation": "False"
}  
```

Evaluates to `True` because the type is **str** and not **bool**
```
> (self.do_disaggregation)
'False'
> bool(self.do_disaggregation)
True

```

<!--end_release_notes-->
