### PR TITLE
Feature/vulnerability file can be selected from analysis_settings

### DIFF
--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -28,7 +28,7 @@ from ods_tools.oed.setting_schema import AnalysisSettingSchema, ModelSettingSche
 from ...execution import bash, runner
 from ...execution.bash import get_fmcmd
 from ...execution.bin import (csv_to_bin, prepare_run_directory,
-                              prepare_run_inputs, set_footprint_set)
+                              prepare_run_inputs, set_footprint_set, set_vulnerability_set)
 from ...preparation.summaries import generate_summaryxref_files
 from ...pytools.fm.financial_structure import create_financial_structure
 from ...utils.data import (fast_zip_dataframe_columns, get_dataframe, get_exposure_data, get_json,
@@ -314,6 +314,9 @@ class GenerateLossesDir(GenerateLossesBase):
         footprint_set_val = analysis_settings.get('model_settings', {}).get('footprint_set')
         if footprint_set_val:
             set_footprint_set(footprint_set_val, model_run_fp)
+        vulnerability_set_val = analysis_settings.get('model_settings', {}).get('vulnerability_set')
+        if vulnerability_set_val:
+            set_vulnerability_set(vulnerability_set_val, model_run_fp)
 
         # Test call to create fmpy files in GenerateLossesDir
         if il and self.fmpy:

--- a/oasislmf/execution/bin.py
+++ b/oasislmf/execution/bin.py
@@ -43,6 +43,7 @@ from oasislmf.pytools.getmodel.common import fp_format_priorities
 from oasislmf.pytools.getmodel.footprint import (
     FootprintParquet, FootprintBinZ, FootprintBin, FootprintCsv
 )
+from oasislmf.pytools.getmodel.vulnerability import vulnerability_dataset, vulnerability_filename
 
 logger = logging.getLogger(__name__)
 
@@ -455,14 +456,27 @@ def set_vulnerability_set(setting_val, run_dir):
     setting_val = str(setting_val)
 
     for file_format in vulnerability_formats:
-        vulnerability_fp = os.path.join(run_dir, 'static', f'vulnerability_{setting_val}.{file_format}')
-        vulnerability_target_fp = os.path.join(run_dir, 'static', f'vulnerability.{file_format}')
-        if os.path.isfile(vulnerability_fp):
-            os.symlink(vulnerability_fp, vulnerability_target_fp)
-            return
+
+        if file_format == 'parquet':
+            # For Parquet, check if it's a directory
+            vulnerability_fp = os.path.join(run_dir, 'static', f'{vulnerability_dataset}_{setting_val}')
+            vulnerability_target_fp = os.path.join(run_dir, 'static', f'{vulnerability_dataset}')
+            if os.path.isdir(vulnerability_fp):
+                os.symlink(vulnerability_fp, vulnerability_target_fp)
+                return
+            else:
+                logger.debug(f'{vulnerability_fp} not found, trying next format')
         else:
-            logger.debug(f'{vulnerability_fp} not found, trying next format')
-    raise OasisException(f'Could not find vulnerability data files with identifier {setting_val}')
+            # For other file formats, check if it's a file
+            vulnerability_fp = os.path.join(run_dir, 'static', f'{vulnerability_filename}_{setting_val}.{file_format}')
+            vulnerability_target_fp = os.path.join(run_dir, 'static', f'{vulnerability_filename}.{file_format}')
+            if os.path.isfile(vulnerability_fp):
+                os.symlink(vulnerability_fp, vulnerability_target_fp)
+                return
+            else:
+                logger.debug(f'{vulnerability_fp} not found, trying next format')
+
+    raise OasisException(f'Could not find vulnerability data files with identifier "{setting_val}"')
 
 
 @oasis_log

--- a/oasislmf/execution/bin.py
+++ b/oasislmf/execution/bin.py
@@ -43,7 +43,7 @@ from oasislmf.pytools.getmodel.common import fp_format_priorities
 from oasislmf.pytools.getmodel.footprint import (
     FootprintParquet, FootprintBinZ, FootprintBin, FootprintCsv
 )
-from oasislmf.pytools.getmodel.vulnerability import vulnerability_dataset, vulnerability_filename
+from oasislmf.pytools.getmodel.vulnerability import vulnerability_dataset
 
 logger = logging.getLogger(__name__)
 
@@ -436,7 +436,7 @@ def set_footprint_set(setting_val, run_dir):
         else:
             return
 
-    raise OasisException(f'Could not find footprint data files with identifier {setting_val}')
+    raise OasisException(f'Could not find footprint data files with identifier "{setting_val}"')
 
 
 @oasis_log
@@ -468,8 +468,8 @@ def set_vulnerability_set(setting_val, run_dir):
                 logger.debug(f'{vulnerability_fp} not found, trying next format')
         else:
             # For other file formats, check if it's a file
-            vulnerability_fp = os.path.join(run_dir, 'static', f'{vulnerability_filename}_{setting_val}.{file_format}')
-            vulnerability_target_fp = os.path.join(run_dir, 'static', f'{vulnerability_filename}.{file_format}')
+            vulnerability_fp = os.path.join(run_dir, 'static', f'vulnerability_{setting_val}.{file_format}')
+            vulnerability_target_fp = os.path.join(run_dir, 'static', f'vulnerability.{file_format}')
             if os.path.isfile(vulnerability_fp):
                 os.symlink(vulnerability_fp, vulnerability_target_fp)
                 return

--- a/oasislmf/execution/bin.py
+++ b/oasislmf/execution/bin.py
@@ -12,7 +12,8 @@ __all__ = [
     'csv_to_bin',
     'prepare_run_directory',
     'prepare_run_inputs',
-    'set_footprint_set'
+    'set_footprint_set',
+    'set_vulnerability_set'
 ]
 
 
@@ -435,6 +436,33 @@ def set_footprint_set(setting_val, run_dir):
             return
 
     raise OasisException(f'Could not find footprint data files with identifier {setting_val}')
+
+
+@oasis_log
+def set_vulnerability_set(setting_val, run_dir):
+    """
+    Create symbolic link to vulnerability file set that will be used for output
+    calculation.
+
+    :param setting_val: identifier for vulnerability set
+    :type setting_val: string
+
+    :param run_dir: model run directory
+    :type run_dir: string
+    """
+
+    vulnerability_formats = ['bin', 'parquet', 'csv']
+    setting_val = str(setting_val)
+
+    for file_format in vulnerability_formats:
+        vulnerability_fp = os.path.join(run_dir, 'static', f'vulnerability_{setting_val}.{file_format}')
+        vulnerability_target_fp = os.path.join(run_dir, 'static', f'vulnerability.{file_format}')
+        if os.path.isfile(vulnerability_fp):
+            os.symlink(vulnerability_fp, vulnerability_target_fp)
+            return
+        else:
+            logger.debug(f'{vulnerability_fp} not found, trying next format')
+    raise OasisException(f'Could not find vulnerability data files with identifier {setting_val}')
 
 
 @oasis_log

--- a/tests/model_execution/test_bin.py
+++ b/tests/model_execution/test_bin.py
@@ -1011,8 +1011,8 @@ class SetVulnerabilitySet(TestCase):
         self.setting_val = 'test'
         self.vulnerability_dataset = 'vulnerability_dataset'
 
-    def make_fake_vulnerability_files(self, directory, file_format):
-        """ Write a fake vulnerability file in the specified format to the directory. """
+    def make_mock_vulnerability_files(self, directory, file_format):
+        """ Write a mock vulnerability file in the specified format to the directory. """
         os.makedirs(os.path.join(directory, 'static'), exist_ok=True)
         if file_format == 'parquet':
             # Create a directory for parquet format
@@ -1028,7 +1028,7 @@ class SetVulnerabilitySet(TestCase):
 
         for file_format in vulnerability_formats:
             with TemporaryDirectory() as d:
-                self.make_fake_vulnerability_files(d, file_format)
+                self.make_mock_vulnerability_files(d, file_format)
                 set_vulnerability_set(self.setting_val, d)
 
                 if file_format == 'parquet':


### PR DESCRIPTION
<!--start_release_notes-->
### Vulnerability file options can be selected using the apposite field in analysis_settings
If "vulnerability_set" contains an identifier, the corresponding vulnerability file will be used.
<!--end_release_notes-->

Resolves issue #1403.

As already possible with footprint files (see PR #1352), the key "vulnerability_set", under "model_settings" in analysis settings can be used to select a specific vulnerability file to be used.

## Example:
if `analysis_settings.json` contains:
```
    "model_settings": {
        "vulnerability_set": "example"
```

the vulnerability file used will be either `vulnerability_example.bin`, the folder `vulnerability_dataset_example` containing the parquet file/files, or `vulnerability_example.csv` (with that order or priorities).

*Note:* as with the footprint file, no file called vulnerability.bin should be present in the same folder if selecting a vile with this option.