### PR TITLE
Feature/acc participation

### DIFF
--- a/oasislmf/_data/calc_rules_direct.csv
+++ b/oasislmf/_data/calc_rules_direct.csv
@@ -1,68 +1,130 @@
-desc,calcrule_id,deductible_gt_0,deductible_min_gt_0,deductible_max_gt_0,limit_gt_0,ded_type,ded_code,lim_type,lim_code,id_key
-deductible and limit,1,1,0,0,1,0,0,0,0,"(1, 0, 0, 1, 0, 0, 0, 0)"
-franchise deductible and limit,3,1,0,0,1,0,2,0,0,"(1, 0, 0, 1, 0, 2, 0, 0)"
-deductible % loss with limit % loss,5,1,0,0,1,1,0,1,0,"(1, 0, 0, 1, 1, 0, 1, 0)"
-no deductible; limit and max. deductible,7,0,0,1,1,0,0,0,0,"(0, 0, 1, 1, 0, 0, 0, 0)"
-no deductible % loss; limit and max. deductible,7,0,0,1,1,1,0,0,0,"(0, 0, 1, 1, 1, 0, 0, 0)"
-deductible; limit and max. deductible,7,1,0,1,1,0,0,0,0,"(1, 0, 1, 1, 0, 0, 0, 0)"
-deductible; limit and min and max. deductible,7,1,1,1,1,0,0,0,0,"(1, 1, 1, 1, 0, 0, 0, 0)"
-no deductible; limit and min and max. deductible,7,0,1,1,1,0,0,0,0,"(0, 1, 1, 1, 0, 0, 0, 0)"
-no deductible; limit and min. deductible,8,0,1,0,1,0,0,0,0,"(0, 1, 0, 1, 0, 0, 0, 0)"
-no deductible % loss; limit and min. deductible,8,0,1,0,1,1,0,0,0,"(0, 1, 0, 1, 1, 0, 0, 0)"
-deductible; limit and min. deductible,8,1,1,0,1,0,0,0,0,"(1, 1, 0, 1, 0, 0, 0, 0)"
-no deductible or limit; max. deductible,10,0,0,1,0,0,0,0,0,"(0, 0, 1, 0, 0, 0, 0, 0)"
-no deductible or limit % loss; max. deductible,10,0,0,1,0,0,0,1,0,"(0, 0, 1, 0, 0, 0, 1, 0)"
-"deductible, no limit, max. deductible",10,1,0,1,0,0,0,0,0,"(1, 0, 1, 0, 0, 0, 0, 0)"
-"deductible, no limit % loss; max. deductible",10,1,0,1,0,0,0,1,0,"(1, 0, 1, 0, 0, 0, 1, 0)"
-no deductible % loss or limit; max. deductible,10,0,0,1,0,1,0,0,0,"(0, 0, 1, 0, 1, 0, 0, 0)"
-no deductible % loss or limit % loss; max. deductible,10,0,0,1,0,1,0,1,0,"(0, 0, 1, 0, 1, 0, 1, 0)"
-no deductible or limit; min. deductible,11,0,1,0,0,0,0,0,0,"(0, 1, 0, 0, 0, 0, 0, 0)"
-no deductible or limit % loss; min. deductible,11,0,1,0,0,0,0,1,0,"(0, 1, 0, 0, 0, 0, 1, 0)"
-"deductible, no limit; min. deductible",11,1,1,0,0,0,0,0,0,"(1, 1, 0, 0, 0, 0, 0, 0)"
-"deductible, no limit % loss; min. deductible",11,1,1,0,0,0,0,1,0,"(1, 1, 0, 0, 0, 0, 1, 0)"
-no deductible % loss or limit; min. deductible,11,0,1,0,0,1,0,0,0,"(0, 1, 0, 0, 1, 0, 0, 0)"
-no deductible % loss or limit % loss; min. deductible,11,0,1,0,0,1,0,1,0,"(0, 1, 0, 0, 1, 0, 1, 0)"
-deductible; no limit,12,1,0,0,0,0,0,0,0,"(1, 0, 0, 0, 0, 0, 0, 0)"
-deductible; no limit % loss,12,1,0,0,0,0,0,1,0,"(1, 0, 0, 0, 0, 0, 1, 0)"
-no deductible or limit; min. & max. deductible,13,0,1,1,0,0,0,0,0,"(0, 1, 1, 0, 0, 0, 0, 0)"
-no deductible or limit % loss; min. & max. deductible,13,0,1,1,0,0,0,1,0,"(0, 1, 1, 0, 0, 0, 1, 0)"
-no deductible % loss or limit; min. & max. deductible,13,0,1,1,0,1,0,0,0,"(0, 1, 1, 0, 1, 0, 0, 0)"
-no deductible % loss or limit % loss; min. & max. deductible,13,0,1,1,0,1,0,1,0,"(0, 1, 1, 0, 1, 0, 1, 0)"
-"no deductible, limit only",14,0,0,0,1,0,0,0,0,"(0, 0, 0, 1, 0, 0, 0, 0)"
-no deductible % loss; limit only,14,0,0,0,1,1,0,0,0,"(0, 0, 0, 1, 1, 0, 0, 0)"
-no deductible; limit % loss,15,0,0,0,1,0,0,1,0,"(0, 0, 0, 1, 0, 0, 1, 0)"
-no deductible % loss; limit % loss,15,0,0,0,1,1,0,1,0,"(0, 0, 0, 1, 1, 0, 1, 0)"
-deductible; limit % loss,15,1,0,0,1,0,0,1,0,"(1, 0, 0, 1, 0, 0, 1, 0)"
-deductible % loss; no limit,16,1,0,0,0,1,0,0,0,"(1, 0, 0, 0, 1, 0, 0, 0)"
-deductible % loss; no limit % loss,16,1,0,0,0,1,0,1,0,"(1, 0, 0, 0, 1, 0, 1, 0)"
-deductible % loss; limit,33,1,0,0,1,1,0,0,0,"(1, 0, 0, 1, 1, 0, 0, 0)"
-deductible % loss with min. and max. deductible; no limit,19,1,1,1,0,1,0,0,0,"(1, 1, 1, 0, 1, 0, 0, 0)"
-deductible % loss with min. and max. deductible; no limit % loss,19,1,1,1,0,1,0,1,0,"(1, 1, 1, 0, 1, 0, 1, 0)"
-deductible % loss with max. deductible; no limit,19,1,0,1,0,1,0,0,0,"(1, 0, 1, 0, 1, 0, 0, 0)"
-deductible % loss with max. deductible; no limit % loss,19,1,0,1,0,1,0,1,0,"(1, 0, 1, 0, 1, 0, 1, 0)"
-deductible % loss with min. deductible; no limit,19,1,1,0,0,1,0,0,0,"(1, 1, 0, 0, 1, 0, 0, 0)"
-deductible % loss with min. deductible; no limit % loss,19,1,1,0,0,1,0,1,0,"(1, 1, 0, 0, 1, 0, 1, 0)"
-reverse franchise deductible; no limit,20,1,0,0,0,0,99,0,0,"(1, 0, 0, 0, 0, 99, 0, 0)"
-reverse franchise deductible; no limit % loss,20,1,0,0,0,0,99,1,0,"(1, 0, 0, 0, 0, 99, 1, 0)"
-"deductible with min and max deductible, no limit",13,1,1,1,0,0,0,0,0,"(1, 1, 1, 0, 0, 0, 0, 0)"
-"deductible with min and max deductible, no limit % loss",13,1,1,1,0,0,0,1,0,"(1, 1, 1, 0, 0, 0, 1, 0)"
-"pass through; no deductible, no limit",100,0,0,0,0,0,0,0,0,"(0, 0, 0, 0, 0, 0, 0, 0)"
-pass through; no deductible % loss,100,0,0,0,0,1,0,0,0,"(0, 0, 0, 0, 1, 0, 0, 0)"
-pass through; no limit % loss,100,0,0,0,0,0,0,1,0,"(0, 0, 0, 0, 0, 0, 1, 0)"
-"pass through; no deductible % loss, no limit % loss",100,0,0,0,0,1,0,1,0,"(0, 0, 0, 0, 1, 0, 1, 0)"
-deductible % loss with min and max deductible and limit,26,1,1,1,1,1,0,0,0,"(1, 1, 1, 1, 1, 0, 0, 0)"
-no deductible % loss;  min and max deductible and limit,26,0,1,1,1,1,0,0,0,"(0, 1, 1, 1, 1, 0, 0, 0)"
-deductible % loss with min deductible and limit,26,1,1,0,1,1,0,0,0,"(1, 1, 0, 1, 1, 0, 0, 0)"
-deductible % loss with max deductible and limit,26,1,0,1,1,1,0,0,0,"(1, 0, 1, 1, 1, 0, 0, 0)"
-deductible % loss with min deductible and limit % loss,35,1,1,0,1,1,0,1,0,"(1, 1, 0, 1, 1, 0, 1, 0)"
-deductible % loss  with max deductible and limit % loss,35,1,0,1,1,1,0,1,0,"(1, 0, 1, 1, 1, 0, 1, 0)"
-deductible % loss with min and max deductible and limit % loss,35,1,1,1,1,1,0,1,0,"(1, 1, 1, 1, 1, 0, 1, 0)"
-no deductible % loss with min deductible and limit % loss,35,0,1,0,1,1,0,1,0,"(0, 1, 0, 1, 1, 0, 1, 0)"
-no deductible % loss  with max deductible and limit % loss,35,0,0,1,1,1,0,1,0,"(0, 0, 1, 1, 1, 0, 1, 0)"
-no deductible % loss with min and max deductible and limit % loss,35,0,1,1,1,1,0,1,0,"(0, 1, 1, 1, 1, 0, 1, 0)"
-deductible with min deductible and limit % loss,36,1,1,0,1,0,0,1,0,"(1, 1, 0, 1, 0, 0, 1, 0)"
-deductible with max deductible and limit % loss,36,1,0,1,1,0,0,1,0,"(1, 0, 1, 1, 0, 0, 1, 0)"
-deductible with min and max deductible and limit % loss,36,1,1,1,1,0,0,1,0,"(1, 1, 1, 1, 0, 0, 1, 0)"
-no deductible with min deductible and limit % loss,36,0,1,0,1,0,0,1,0,"(0, 1, 0, 1, 0, 0, 1, 0)"
-no deductible with max deductible and limit % loss,36,0,0,1,1,0,0,1,0,"(0, 0, 1, 1, 0, 0, 1, 0)"
-no deductible with min and max deductible and limit % loss,36,0,1,1,1,0,0,1,0,"(0, 1, 1, 1, 0, 0, 1, 0)"
+desc,calcrule_id,attachment_gt_0,deductible_gt_0,deductible_min_gt_0,deductible_max_gt_0,limit_gt_0,ded_type,ded_code,lim_type,lim_code,share_gt_0
+deductible and limit,1,0,1,0,0,1,0,0,0,0,0
+franchise deductible and limit,3,0,1,0,0,1,0,2,0,0,0
+deductible % loss with limit % loss,5,0,1,0,0,1,1,0,1,0,0
+no deductible; limit and max. deductible,7,0,0,0,1,1,0,0,0,0,0
+no deductible % loss; limit and max. deductible,7,0,0,0,1,1,1,0,0,0,0
+deductible; limit and max. deductible,7,0,1,0,1,1,0,0,0,0,0
+deductible; limit and min and max. deductible,7,0,1,1,1,1,0,0,0,0,0
+no deductible; limit and min and max. deductible,7,0,0,1,1,1,0,0,0,0,0
+no deductible; limit and min. deductible,8,0,0,1,0,1,0,0,0,0,0
+no deductible % loss; limit and min. deductible,8,0,0,1,0,1,1,0,0,0,0
+deductible; limit and min. deductible,8,0,1,1,0,1,0,0,0,0,0
+no deductible or limit; max. deductible,10,0,0,0,1,0,0,0,0,0,0
+no deductible or limit % loss; max. deductible,10,0,0,0,1,0,0,0,1,0,0
+"deductible, no limit, max. deductible",10,0,1,0,1,0,0,0,0,0,0
+"deductible, no limit % loss; max. deductible",10,0,1,0,1,0,0,0,1,0,0
+no deductible % loss or limit; max. deductible,10,0,0,0,1,0,1,0,0,0,0
+no deductible % loss or limit % loss; max. deductible,10,0,0,0,1,0,1,0,1,0,0
+no deductible or limit; min. deductible,11,0,0,1,0,0,0,0,0,0,0
+no deductible or limit % loss; min. deductible,11,0,0,1,0,0,0,0,1,0,0
+"deductible, no limit; min. deductible",11,0,1,1,0,0,0,0,0,0,0
+"deductible, no limit % loss; min. deductible",11,0,1,1,0,0,0,0,1,0,0
+no deductible % loss or limit; min. deductible,11,0,0,1,0,0,1,0,0,0,0
+no deductible % loss or limit % loss; min. deductible,11,0,0,1,0,0,1,0,1,0,0
+deductible; no limit,12,0,1,0,0,0,0,0,0,0,0
+deductible; no limit % loss,12,0,1,0,0,0,0,0,1,0,0
+no deductible or limit; min. & max. deductible,13,0,0,1,1,0,0,0,0,0,0
+no deductible or limit % loss; min. & max. deductible,13,0,0,1,1,0,0,0,1,0,0
+no deductible % loss or limit; min. & max. deductible,13,0,0,1,1,0,1,0,0,0,0
+no deductible % loss or limit % loss; min. & max. deductible,13,0,0,1,1,0,1,0,1,0,0
+"no deductible, limit only",14,0,0,0,0,1,0,0,0,0,0
+no deductible % loss; limit only,14,0,0,0,0,1,1,0,0,0,0
+no deductible; limit % loss,15,0,0,0,0,1,0,0,1,0,0
+no deductible % loss; limit % loss,15,0,0,0,0,1,1,0,1,0,0
+deductible; limit % loss,15,0,1,0,0,1,0,0,1,0,0
+deductible % loss; no limit,16,0,1,0,0,0,1,0,0,0,0
+deductible % loss; no limit % loss,16,0,1,0,0,0,1,0,1,0,0
+deductible % loss; limit,33,0,1,0,0,1,1,0,0,0,0
+deductible % loss with min. and max. deductible; no limit,19,0,1,1,1,0,1,0,0,0,0
+deductible % loss with min. and max. deductible; no limit % loss,19,0,1,1,1,0,1,0,1,0,0
+deductible % loss with max. deductible; no limit,19,0,1,0,1,0,1,0,0,0,0
+deductible % loss with max. deductible; no limit % loss,19,0,1,0,1,0,1,0,1,0,0
+deductible % loss with min. deductible; no limit,19,0,1,1,0,0,1,0,0,0,0
+deductible % loss with min. deductible; no limit % loss,19,0,1,1,0,0,1,0,1,0,0
+reverse franchise deductible; no limit,20,0,1,0,0,0,0,99,0,0,0
+reverse franchise deductible; no limit % loss,20,0,1,0,0,0,0,99,1,0,0
+"deductible with min and max deductible, no limit",13,0,1,1,1,0,0,0,0,0,0
+"deductible with min and max deductible, no limit % loss",13,0,1,1,1,0,0,0,1,0,0
+"pass through; no deductible, no limit",100,0,0,0,0,0,0,0,0,0,0
+pass through; no deductible % loss,100,0,0,0,0,0,1,0,0,0,0
+pass through; no limit % loss,100,0,0,0,0,0,0,0,1,0,0
+"pass through; no deductible % loss, no limit % loss",100,0,0,0,0,0,1,0,1,0,0
+deductible % loss with min and max deductible and limit,26,0,1,1,1,1,1,0,0,0,0
+no deductible % loss;  min and max deductible and limit,26,0,0,1,1,1,1,0,0,0,0
+deductible % loss with min deductible and limit,26,0,1,1,0,1,1,0,0,0,0
+deductible % loss with max deductible and limit,26,0,1,0,1,1,1,0,0,0,0
+deductible % loss with min deductible and limit % loss,35,0,1,1,0,1,1,0,1,0,0
+deductible % loss  with max deductible and limit % loss,35,0,1,0,1,1,1,0,1,0,0
+deductible % loss with min and max deductible and limit % loss,35,0,1,1,1,1,1,0,1,0,0
+no deductible % loss with min deductible and limit % loss,35,0,0,1,0,1,1,0,1,0,0
+no deductible % loss  with max deductible and limit % loss,35,0,0,0,1,1,1,0,1,0,0
+no deductible % loss with min and max deductible and limit % loss,35,0,0,1,1,1,1,0,1,0,0
+deductible with min deductible and limit % loss,36,0,1,1,0,1,0,0,1,0,0
+deductible with max deductible and limit % loss,36,0,1,0,1,1,0,0,1,0,0
+deductible with min and max deductible and limit % loss,36,0,1,1,1,1,0,0,1,0,0
+no deductible with min deductible and limit % loss,36,0,0,1,0,1,0,0,1,0,0
+no deductible with max deductible and limit % loss,36,0,0,0,1,1,0,0,1,0,0
+no deductible with min and max deductible and limit % loss,36,0,0,1,1,1,0,0,1,0,0
+"deductible, limit; share",101,0,1,0,0,1,0,0,0,0,1
+"franchise deductible, limit; share",103,0,1,0,0,1,0,2,0,0,1
+deductible % loss with limit % loss; share,105,0,1,0,0,1,1,0,1,0,1
+"no deductible; limit, max. deductible; share",107,0,0,0,1,1,0,0,0,0,1
+"no deductible % loss; limit, max. deductible; share",107,0,0,0,1,1,1,0,0,0,1
+"deductible; limit, max. deductible; share",107,0,1,0,1,1,0,0,0,0,1
+"deductible; limit, min and max. deductible; share",107,0,1,1,1,1,0,0,0,0,1
+"no deductible; limit, min and max. deductible; share",107,0,0,1,1,1,0,0,0,0,1
+"no deductible; limit, min. deductible; share",108,0,0,1,0,1,0,0,0,0,1
+"no deductible % loss; limit, min. deductible; share",108,0,0,1,0,1,1,0,0,0,1
+"deductible; limit, min. deductible; share",108,0,1,1,0,1,0,0,0,0,1
+no deductible or limit; max. deductible; share,110,0,0,0,1,0,0,0,0,0,1
+no deductible or limit % loss; max. deductible; share,110,0,0,0,1,0,0,0,1,0,1
+"deductible, no limit, max. deductible; share",110,0,1,0,1,0,0,0,0,0,1
+"deductible, no limit % loss; max. deductible; share",110,0,1,0,1,0,0,0,1,0,1
+no deductible % loss or limit; max. deductible; share,110,0,0,0,1,0,1,0,0,0,1
+no deductible % loss or limit % loss; max. deductible; share,110,0,0,0,1,0,1,0,1,0,1
+no deductible or limit; min. deductible; share,111,0,0,1,0,0,0,0,0,0,1
+no deductible or limit % loss; min. deductible; share,111,0,0,1,0,0,0,0,1,0,1
+"deductible, no limit; min. deductible; share",111,0,1,1,0,0,0,0,0,0,1
+"deductible, no limit % loss; min. deductible; share",111,0,1,1,0,0,0,0,1,0,1
+no deductible % loss or limit; min. deductible; share,111,0,0,1,0,0,1,0,0,0,1
+no deductible % loss or limit % loss; min. deductible; share,111,0,0,1,0,0,1,0,1,0,1
+deductible; no limit; share,112,0,1,0,0,0,0,0,0,0,1
+deductible; no limit % loss; share,112,0,1,0,0,0,0,0,1,0,1
+no deductible or limit; min. & max. deductible; share,113,0,0,1,1,0,0,0,0,0,1
+no deductible or limit % loss; min. & max. deductible; share,113,0,0,1,1,0,0,0,1,0,1
+no deductible % loss or limit; min. & max. deductible; share,113,0,0,1,1,0,1,0,0,0,1
+no deductible % loss or limit % loss; min. & max. deductible; share,113,0,0,1,1,0,1,0,1,0,1
+"no deductible, limit only; share",114,0,0,0,0,1,0,0,0,0,1
+no deductible % loss; limit only; share,114,0,0,0,0,1,1,0,0,0,1
+no deductible; limit % loss; share,115,0,0,0,0,1,0,0,1,0,1
+no deductible % loss; limit % loss; share,115,0,0,0,0,1,1,0,1,0,1
+deductible; limit % loss; share,115,0,1,0,0,1,0,0,1,0,1
+deductible % loss; no limit; share,116,0,1,0,0,0,1,0,0,0,1
+deductible % loss; no limit % loss; share,116,0,1,0,0,0,1,0,1,0,1
+deductible % loss; limit; share,133,0,1,0,0,1,1,0,0,0,1
+deductible % loss with min. and max. deductible; no limit; share,119,0,1,1,1,0,1,0,0,0,1
+deductible % loss with min. and max. deductible; no limit % loss; share,119,0,1,1,1,0,1,0,1,0,1
+deductible % loss with max. deductible; no limit; share,119,0,1,0,1,0,1,0,0,0,1
+deductible % loss with max. deductible; no limit % loss; share,119,0,1,0,1,0,1,0,1,0,1
+deductible % loss with min. deductible; no limit; share,119,0,1,1,0,0,1,0,0,0,1
+deductible % loss with min. deductible; no limit % loss; share,119,0,1,1,0,0,1,0,1,0,1
+reverse franchise deductible; no limit; share,120,0,1,0,0,0,0,99,0,0,1
+reverse franchise deductible; no limit % loss; share,120,0,1,0,0,0,0,99,1,0,1
+"deductible with min and max deductible, no limit; share",113,0,1,1,1,0,0,0,0,0,1
+"deductible with min and max deductible, no limit % loss; share",113,0,1,1,1,0,0,0,1,0,1
+"deductible % loss with min and max deductible, limit; share",126,0,1,1,1,1,1,0,0,0,1
+"no deductible % loss;  min and max deductible, limit; share",126,0,0,1,1,1,1,0,0,0,1
+"deductible % loss with min deductible, limit; share",126,0,1,1,0,1,1,0,0,0,1
+"deductible % loss with max deductible, limit; share",126,0,1,0,1,1,1,0,0,0,1
+"deductible % loss with min deductible, limit % loss; share",135,0,1,1,0,1,1,0,1,0,1
+"deductible % loss  with max deductible, limit % loss; share",135,0,1,0,1,1,1,0,1,0,1
+"deductible % loss with min and max deductible, limit % loss; share",135,0,1,1,1,1,1,0,1,0,1
+"no deductible % loss with min deductible, limit % loss; share",135,0,0,1,0,1,1,0,1,0,1
+"no deductible % loss  with max deductible, limit % loss; share",135,0,0,0,1,1,1,0,1,0,1
+"no deductible % loss with min and max deductible, limit % loss; share",135,0,0,1,1,1,1,0,1,0,1
+"deductible with min deductible, limit % loss; share",136,0,1,1,0,1,0,0,1,0,1
+"deductible with max deductible, limit % loss; share",136,0,1,0,1,1,0,0,1,0,1
+"deductible with min and max deductible, limit % loss; share",136,0,1,1,1,1,0,0,1,0,1
+"no deductible with min deductible, limit % loss; share",136,0,0,1,0,1,0,0,1,0,1
+"no deductible with max deductible, limit % loss; share",136,0,0,0,1,1,0,0,1,0,1

--- a/oasislmf/_data/calc_rules_direct_layer.csv
+++ b/oasislmf/_data/calc_rules_direct_layer.csv
@@ -1,9 +1,9 @@
-desc,calcrule_id,limit_gt_0,share_gt_0,attachment_gt_0,id_key
-limit and participation,2,1,1,0,"(1, 1, 0)"
-"attachment, limit and participation",2,1,1,1,"(1, 1, 1)"
-no terms (pass through),100,0,0,0,"(0, 0, 0)"
-participation only,34,0,1,0,"(0, 1, 0)"
-attachment and participation,34,0,1,1,"(0, 1, 1)"
-attachment and zero participation,34,0,0,1,"(0, 0, 1)"
-"attachment, limit and zero participation",2,1,0,1,"(1, 0, 1)"
-limit and zero participation,2,1,0,0,"(1, 0, 0)"
+desc,calcrule_id,limit_gt_0,share_gt_0,attachment_gt_0
+limit and participation,2,1,1,0
+"attachment, limit and participation",2,1,1,1
+no terms (pass through),100,0,0,0
+participation only,34,0,1,0
+attachment and participation,34,0,1,1
+attachment and zero participation,34,0,0,1
+"attachment, limit and zero participation",2,1,0,1
+limit and zero participation,2,1,0,0

--- a/oasislmf/_data/default_acc_profile.json
+++ b/oasislmf/_data/default_acc_profile.json
@@ -1010,5 +1010,13 @@
         "FMTermType": "LimitType",
         "FMTermGroupID": 1,
         "ProfileType": "Acc"
+    },
+    "AccParticipation": {
+        "ProfileElementName": "AccParticipation",
+        "FMLevelName": "AccAll",
+        "FMLevel": 13,
+        "FMTermType": "Share",
+        "FMTermGroupID": 1,
+        "ProfileType": "Acc"
     }
 }

--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -88,7 +88,7 @@ def get_calc_rule_ids(il_inputs_calc_rules_df, calc_rule_type):
         pandas Series of calc. rule IDs
     """
     calc_rules_df, calc_rule_term_info = get_calc_rules(calc_rule_type)
-    calc_rules_df = calc_rules_df.drop(['desc', 'id_key'], axis=1)
+    calc_rules_df = calc_rules_df.drop(columns=['desc', 'id_key'], axis=1, errors='ignore')
 
     terms = []
     terms_indicators = []

--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -666,7 +666,7 @@ def get_il_input_items(
             )
 
             __drop_duplicated_row(il_inputs_df_list[-1] if il_inputs_df_list else None, prev_level_df, prev_df_subset)
-            il_inputs_df_list.append(pd.concat([prev_level_df, root_df]))
+            il_inputs_df_list.append(pd.concat([df for df in [prev_level_df, root_df] if not df.empty]))
 
             level_df['level_id'] = len(il_inputs_df_list) + 1
             level_df['orig_level_id'] = level_id

--- a/oasislmf/pytools/fm/common.py
+++ b/oasislmf/pytools/fm/common.py
@@ -22,7 +22,7 @@ def almost_equal(a, b):
 
 null_index = np_oasis_int(-1)
 need_tiv_policy = (4, 6, 18, 27, 28, 29, 30, 31, 32, 37)
-need_extras = (7, 8, 10, 11, 13, 19, 26, 27, 35, 36)
+need_extras = (7, 8, 10, 11, 13, 19, 26, 27, 35, 36, 107, 108, 110, 111, 113, 119, 126, 135, 136)
 EXTRA_VALUES = 3
 
 # financial structure static input dtypes

--- a/oasislmf/pytools/fm/policy.py
+++ b/oasislmf/pytools/fm/policy.py
@@ -360,11 +360,17 @@ def calc(policy, loss_out, loss_in, stepped):
     elif policy['calcrule_id'] == 100:
         loss_out[:] = loss_in
     # policies non layer policy with share
+    elif policy['calcrule_id'] == 101:
+        calcrule_1(policy, loss_out, loss_in)
+        loss_out *= policy['share_1']
     elif policy['calcrule_id'] == 103:
         calcrule_3(policy, loss_out, loss_in)
         loss_out *= policy['share_1']
     elif policy['calcrule_id'] == 105:
         calcrule_5(policy, loss_out, loss_in)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 112:
+        calcrule_12(policy, loss_out, loss_in)
         loss_out *= policy['share_1']
     elif policy['calcrule_id'] == 114:
         calcrule_14(policy, loss_out, loss_in)

--- a/oasislmf/pytools/fm/policy.py
+++ b/oasislmf/pytools/fm/policy.py
@@ -359,7 +359,29 @@ def calc(policy, loss_out, loss_in, stepped):
         calcrule_34(policy, loss_out, loss_in)
     elif policy['calcrule_id'] == 100:
         loss_out[:] = loss_in
-    elif stepped is not None:
+    # policies non layer policy with share
+    elif policy['calcrule_id'] == 103:
+        calcrule_3(policy, loss_out, loss_in)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 105:
+        calcrule_5(policy, loss_out, loss_in)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 114:
+        calcrule_14(policy, loss_out, loss_in)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 115:
+        calcrule_15(policy, loss_out, loss_in)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 116:
+        calcrule_16(policy, loss_out, loss_in)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 120:
+        calcrule_20(policy, loss_out, loss_in)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 133:
+        calcrule_33(policy, loss_out, loss_in)
+        loss_out *= policy['share_1']
+    elif stepped is not None: # step policies
         if policy['calcrule_id'] == 28:
             calcrule_28(policy, loss_out, loss_in)
         elif policy['calcrule_id'] == 32:

--- a/oasislmf/pytools/fm/policy.py
+++ b/oasislmf/pytools/fm/policy.py
@@ -381,7 +381,7 @@ def calc(policy, loss_out, loss_in, stepped):
     elif policy['calcrule_id'] == 133:
         calcrule_33(policy, loss_out, loss_in)
         loss_out *= policy['share_1']
-    elif stepped is not None: # step policies
+    elif stepped is not None:  # step policies
         if policy['calcrule_id'] == 28:
             calcrule_28(policy, loss_out, loss_in)
         elif policy['calcrule_id'] == 32:

--- a/oasislmf/pytools/fm/policy_extras.py
+++ b/oasislmf/pytools/fm/policy_extras.py
@@ -713,6 +713,9 @@ def calc(policy, loss_out, loss_in, deductible, over_limit, under_limit, stepped
         calcrule_36(policy, loss_out, loss_in, deductible, over_limit, under_limit)
     elif policy['calcrule_id'] == 100:
         loss_out[:] = loss_in
+    elif policy['calcrule_id'] == 101:
+        calcrule_1(policy, loss_out, loss_in, deductible, over_limit, under_limit)
+        loss_out *= policy['share_1']
     elif policy['calcrule_id'] == 103:
         calcrule_3(policy, loss_out, loss_in, deductible, over_limit, under_limit)
         loss_out *= policy['share_1']
@@ -730,6 +733,9 @@ def calc(policy, loss_out, loss_in, deductible, over_limit, under_limit, stepped
         loss_out *= policy['share_1']
     elif policy['calcrule_id'] == 111:
         calcrule_11(policy, loss_out, loss_in, deductible, over_limit, under_limit)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 112:
+        calcrule_12(policy, loss_out, loss_in, deductible, over_limit, under_limit)
         loss_out *= policy['share_1']
     elif policy['calcrule_id'] == 113:
         calcrule_13(policy, loss_out, loss_in, deductible, over_limit, under_limit)

--- a/oasislmf/pytools/fm/policy_extras.py
+++ b/oasislmf/pytools/fm/policy_extras.py
@@ -713,6 +713,54 @@ def calc(policy, loss_out, loss_in, deductible, over_limit, under_limit, stepped
         calcrule_36(policy, loss_out, loss_in, deductible, over_limit, under_limit)
     elif policy['calcrule_id'] == 100:
         loss_out[:] = loss_in
+    elif policy['calcrule_id'] == 103:
+        calcrule_3(policy, loss_out, loss_in, deductible, over_limit, under_limit)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 105:
+        calcrule_5(policy, loss_out, loss_in, deductible, over_limit, under_limit)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 107:
+        calcrule_7(policy, loss_out, loss_in, deductible, over_limit, under_limit)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 108:
+        calcrule_8(policy, loss_out, loss_in, deductible, over_limit, under_limit)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 110:
+        calcrule_10(policy, loss_out, loss_in, deductible, over_limit, under_limit)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 111:
+        calcrule_11(policy, loss_out, loss_in, deductible, over_limit, under_limit)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 113:
+        calcrule_13(policy, loss_out, loss_in, deductible, over_limit, under_limit)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 114:
+        calcrule_14(policy, loss_out, loss_in, deductible, over_limit, under_limit)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 115:
+        calcrule_15(policy, loss_out, loss_in, deductible, over_limit, under_limit)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 116:
+        calcrule_16(policy, loss_out, loss_in, deductible, over_limit, under_limit)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 119:
+        calcrule_19(policy, loss_out, loss_in, deductible, over_limit, under_limit)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 120:
+        calcrule_20(policy, loss_out, loss_in, deductible, over_limit, under_limit)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 126:
+        calcrule_26(policy, loss_out, loss_in, deductible, over_limit, under_limit)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 133:
+        calcrule_33(policy, loss_out, loss_in, deductible, over_limit, under_limit)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 135:
+        calcrule_35(policy, loss_out, loss_in, deductible, over_limit, under_limit)
+        loss_out *= policy['share_1']
+    elif policy['calcrule_id'] == 136:
+        calcrule_36(policy, loss_out, loss_in, deductible, over_limit, under_limit)
+        loss_out *= policy['share_1']
     elif stepped is not None:
         if policy['calcrule_id'] == 27:
             calcrule_27(policy, loss_out, loss_in, deductible, over_limit, under_limit)

--- a/oasislmf/utils/calc_rules.py
+++ b/oasislmf/utils/calc_rules.py
@@ -1,6 +1,5 @@
 __all__ = [
     'get_calc_rules',
-    'get_step_calc_rules'
 ]
 
 import os
@@ -9,24 +8,28 @@ from .data import get_dataframe
 from .defaults import (
     STATIC_DATA_FP,
 )
+CALC_RULE_FILES = {
+    'base': 'calc_rules_direct.csv',
+    'policy_layer': 'calc_rules_direct_layer.csv',
+    'step': 'calc_rules_step.csv',
+}
 
+CALC_RULE_TERMS_INFO = {
+    'base': {
+        'terms': ['deductible', 'deductible_min', 'deductible_max', 'limit'],
+        'types_and_codes': ['ded_type', 'ded_code', 'lim_type', 'lim_code'],
+    },
+    'policy_layer': {
+        'terms': ['limit', 'share', 'attachment'],
+        'types_and_codes': []
+    },
+    'step': {
+        'terms': ['deductible1', 'payout_start', 'payout_end', 'limit1', 'limit2'],
+        'types_and_codes': ['trigger_type', 'payout_type']
+    }
+}
 
 # Ktools calc. rules
-def get_calc_rules(policy_layer=False):
-    calc_rules_filename = 'calc_rules_direct'
-    if policy_layer:
-        calc_rules_filename += '_layer'
-    calc_rules_filename += '.csv'
-    fp = os.path.join(STATIC_DATA_FP, calc_rules_filename)
-    return get_dataframe(src_fp=fp)
+def get_calc_rules(calc_rule_type):
+    return get_dataframe(src_fp=os.path.join(STATIC_DATA_FP, CALC_RULE_FILES[calc_rule_type])), CALC_RULE_TERMS_INFO[calc_rule_type]
 
-
-def get_step_calc_rules():
-    """
-    Get dataframe of calc rules for step policies
-
-    :return: dataframe of calc rules for step policies
-    :rtype: pandas.DataFrame
-    """
-    fp = os.path.join(STATIC_DATA_FP, 'calc_rules_step.csv')
-    return get_dataframe(src_fp=fp)

--- a/oasislmf/utils/calc_rules.py
+++ b/oasislmf/utils/calc_rules.py
@@ -30,6 +30,7 @@ CALC_RULE_TERMS_INFO = {
 }
 
 # Ktools calc. rules
+
+
 def get_calc_rules(calc_rule_type):
     return get_dataframe(src_fp=os.path.join(STATIC_DATA_FP, CALC_RULE_FILES[calc_rule_type])), CALC_RULE_TERMS_INFO[calc_rule_type]
-

--- a/oasislmf/utils/calc_rules.py
+++ b/oasislmf/utils/calc_rules.py
@@ -16,7 +16,7 @@ CALC_RULE_FILES = {
 
 CALC_RULE_TERMS_INFO = {
     'base': {
-        'terms': ['deductible', 'deductible_min', 'deductible_max', 'limit'],
+        'terms': ['deductible', 'deductible_min', 'deductible_max', 'limit', 'share'],
         'types_and_codes': ['ded_type', 'ded_code', 'lim_type', 'lim_code'],
     },
     'policy_layer': {

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ except ImportError:
     from urllib2 import URLError
 
 
-KTOOLS_VERSION = '3.11.0'
+KTOOLS_VERSION = '3.11.1'
 
 SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Support for AccParticipation
add support for AccParticipation in account all level.
introduce new calcrule where a share term is positive for all direct calcrule.
this "duplicated" calcrules have an id corresponding to their no share term calcrule plus 100
(ex: deductible and limit , id 1 => deductible, limit and share, id 101)
Note that calcrules with the same terms can have different id if they are perform in "direct" levels or in "direct layer" levels because in "direct" the share is apply on top of the policy that may have to keep track of deductible underlimit and overlimit
<!--end_release_notes-->
