### PR TITLE
use category for peril_id in keys.csv, improve write_fm_xref_file

### DIFF
--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -206,7 +206,7 @@ class GenerateFiles(ComputationStep):
         # Load keys file  **** WARNING - REFACTOR THIS ****
         dtypes = {
             'locid': 'int64',
-            'perilid': 'str',
+            'perilid': 'category',
             'coveragetypeid': 'uint8',
             'areaperilid': 'uint64',
             'vulnerabilityid': 'uint32',
@@ -307,7 +307,7 @@ class GenerateFiles(ComputationStep):
         )
         gul_summary_mapping = get_summary_mapping(gul_inputs_df, oed_hierarchy)
         write_mapping_file(gul_summary_mapping, target_dir)
-
+        del gul_summary_mapping
         # If no source accounts file path has been provided assume that IL
         # input files, and therefore also RI input files, are not needed
         if not il:
@@ -359,7 +359,7 @@ class GenerateFiles(ComputationStep):
             oed_column_set=[loc_grp],
             defaults={loc_grp: 1}
         ).sort_values(by='agg_id')
-
+        del fm_summary_mapping
         self.kwargs['oed_info_csv'] = exposure_data.ri_info
 
         ri_layers = write_files_for_reinsurance(

--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -1090,14 +1090,9 @@ def write_fm_xref_file(il_inputs_df, fm_xref_fp, chunksize=100000):
     :rtype: str
     """
     try:
-        xref_df = get_xref_df(il_inputs_df)
-        pd.DataFrame(
-            {
-                'output': factorize_ndarray(xref_df.loc[:, ['gul_input_id', 'layer_id']].values, col_idxs=range(2))[0],
-                'agg_id': xref_df['gul_input_id'],
-                'layer_id': xref_df['layer_id']
-            }
-        ).to_csv(
+        xref_df = get_xref_df(il_inputs_df)[['gul_input_id', 'layer_id']].rename(columns={'gul_input_id': 'agg_id'})
+        xref_df['output'] = xref_df.reset_index().index + 1
+        xref_df[['output', 'agg_id', 'layer_id']].to_csv(
             path_or_buf=fm_xref_fp,
             encoding='utf-8',
             mode=('w' if os.path.exists(fm_xref_fp) else 'a'),


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Improve memory usage when reading keys.csv
use category for peril_id when reading keys.csv.
use directly index when creating fm_xref_file
<!--end_release_notes-->
