### PR TITLE
fix useful columns when extra aggregation level is needed

### DIFF
--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -656,6 +656,7 @@ def get_il_input_items(
                 'FMTermType': step_term['FMProfileField'],
                 'FMProfileStep': step_term.get('FMProfileStep')
             }
+
     for term_df_source, levels, fm_peril_field in get_levels(gul_inputs_df, locations_df, accounts_df, get_cond_info(locations_df, accounts_df)):
         for level, level_info in levels:
             level_id = level_info['id']
@@ -664,7 +665,6 @@ def get_il_input_items(
                                                                                             fm_peril_field)
             if not terms_maps:  # no terms we skip this level
                 continue
-
             agg_key = [v['field'] for v in fm_aggregation_profile[level_id]['FMAggKey'].values()]
             # get all rows with terms in term_df_source and determine the correct FMTermGroupID
             level_df_list = []
@@ -815,7 +815,9 @@ def get_il_input_items(
                                     .max() > 1)
 
         if need_account_aggregation:
-            level_df = gul_inputs_df.merge(accounts_df[agg_key + sub_agg_key + ['layer_id']])
+            level_df = gul_inputs_df.merge(accounts_df[list(set(agg_key + sub_agg_key + ['layer_id'])
+                                                            .union(set(useful_cols).difference(set(gul_inputs_df.columns)))
+                                                            .intersection(accounts_df.columns))])
             level_df['orig_level_id'] = level_id
             level_df['level_id'] = len(il_inputs_df_list) + 2
             level_df['agg_id'] = factorize_ndarray(level_df.loc[:, agg_key].values, col_idxs=range(len(agg_key)))[0]


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Fix in IL file generation with missing columns when final level of aggregation is needed
When account level aggregation is performed but there is no terms, some needed columns where not  taken from the account file leading to error in get_xref_df:
KeyError: "['acc_idx', 'PolNumber'] not in index"

This fix the issue by using all useful columns when the account file is merged.
<!--end_release_notes-->
