### PR TITLE
Fix Blank Optional TIV fields in file generation

### DIFF
--- a/oasislmf/preparation/gul_inputs.py
+++ b/oasislmf/preparation/gul_inputs.py
@@ -224,6 +224,9 @@ def get_gul_input_items(
                 correlation_check = True
 
     query_nonzero_tiv = " | ".join(f"({tiv_col} != 0)" for tiv_col in tiv_cols)
+    for tiv_col in tiv_cols:
+        if tiv_col not in exposure_df.columns:
+            exposure_df[tiv_col] = 0
     exposure_df.loc[:, tiv_cols] = exposure_df.loc[:, tiv_cols].fillna(0.0)
     exposure_df.query(query_nonzero_tiv, inplace=True, engine='numexpr')
 

--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -16,6 +16,7 @@ __all__ = [
 ]
 
 import copy
+import gc
 import itertools
 import os
 import sys
@@ -823,6 +824,7 @@ def __process_standard_level_df(column_base_il_df,
                    if v['field'] in level_df_with_term.columns]
 
     level_df_with_term['agg_id'] = factorize_ndarray(level_df_with_term.loc[:, agg_key].values, col_idxs=range(len(agg_key)))[0]
+
     level_df_with_term['prev_agg_id'] = factorize_ndarray(level_df_with_term.loc[:, prev_agg_key].values, col_idxs=range(len(prev_agg_key)))[0]
 
     # check rows in prev df that are this level granularity (if prev_agg_id has multiple corresponding agg_id)
@@ -1023,10 +1025,10 @@ def get_il_input_items(
 
     # get column name to fm term
     fm_terms = get_grouped_fm_terms_by_level_and_term_group(grouped_profile_by_level_and_term_group=profile, lowercase=False)
-    gul_inputs_df = __merge_exposure_and_gul(exposure_df, gul_inputs_df, fm_terms, profile, oed_hierarchy)
+    column_base_il_df = __merge_exposure_and_gul(exposure_df, gul_inputs_df, fm_terms, profile, oed_hierarchy)
     bi_tiv_col = 'BITIV'
 
-    column_base_il_df = __merge_gul_and_account(gul_inputs_df, accounts_df, fm_terms, oed_hierarchy)
+    column_base_il_df = __merge_gul_and_account(column_base_il_df, accounts_df, fm_terms, oed_hierarchy)
 
     # Profile dict are base on key that correspond to the fm term name.
     # this prevent multiple file column to point to the same fm term
@@ -1203,6 +1205,9 @@ def get_il_input_items(
         il_inputs_df_list.append(prev_level_df)
         prev_level_df = level_df
 
+    del column_base_il_df
+    gc.collect()
+
     prev_level_df['to_agg_id'] = 0
     il_inputs_df_list.append(prev_level_df)
     il_inputs_df = pd.concat(il_inputs_df_list)
@@ -1211,6 +1216,10 @@ def get_il_input_items(
             il_inputs_df[col].fillna(0, inplace=True)
         except Exception:
             pass
+
+    del prev_level_df
+    del il_inputs_df_list
+    gc.collect()
 
     # set top agg_id for later xref computation
     il_inputs_df['top_agg_id'] = factorize_ndarray(il_inputs_df.loc[:, agg_key].values, col_idxs=range(len(agg_key)))[0]


### PR DESCRIPTION
<!--start_release_notes-->
### Fix Blank Optional TIV fields in file generation 
When `OtherTIV` is not in the location file (vaild OED), the file generation fails with 
```
    raise KeyError(f"{not_found} not in index")
KeyError: "['OtherTIV'] not in index"
``` 
This issue was indirectly fixed with https://github.com/OasisLMF/OasisLMF/pull/1340
<!--end_release_notes-->
