### PR TITLE
Add missing loc_id check

### DIFF
--- a/.github/workflows/piwind-test.yml
+++ b/.github/workflows/piwind-test.yml
@@ -65,7 +65,7 @@ jobs:
       oasislmf_package: ${{ needs.build.outputs.linux_pkg_filename }}
       oasislmf_branch: ''
       ods_package: ${{ needs.ods_tools.outputs.whl_filename }}
-      platform_version: ${{ github.event_name != 'workflow_dispatch' && 'latest' ||  inputs.platform_1_version }}
+      platform_version: ${{ github.event_name != 'workflow_dispatch' && '1-latest' ||  inputs.platform_1_version }}
       worker_api_ver: 'v1'
       storage_suffix: '_platform1'
 
@@ -79,7 +79,7 @@ jobs:
       oasislmf_package: ${{ needs.build.outputs.linux_pkg_filename }}
       oasislmf_branch: ''
       ods_package: ${{ needs.ods_tools.outputs.whl_filename }}
-      platform_version: ${{ github.event_name != 'workflow_dispatch' && '2.2.0' ||  inputs.platform_2_version }}
+      platform_version: ${{ github.event_name != 'workflow_dispatch' && 'latest' ||  inputs.platform_2_version }}
       pytest_opts: "--docker-compose=./docker/plat2.docker-compose.yml "
       worker_api_ver: 'v1'
       storage_suffix: '_platform2'

--- a/.github/workflows/piwind-test.yml
+++ b/.github/workflows/piwind-test.yml
@@ -80,6 +80,6 @@ jobs:
       oasislmf_branch: ''
       ods_package: ${{ needs.ods_tools.outputs.whl_filename }}
       platform_version: ${{ github.event_name != 'workflow_dispatch' && 'latest' ||  inputs.platform_2_version }}
-      pytest_opts: "--docker-compose=./docker/plat2.docker-compose.yml "
-      worker_api_ver: 'v1'
+      pytest_opts: "--docker-compose=./docker/plat2-v2.docker-compose.yml"
+      worker_api_ver: 'v2'
       storage_suffix: '_platform2'

--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -242,7 +242,7 @@ class GenerateFiles(ComputationStep):
         del keys_errors_df
 
         if missing_locid != set():  # if not empty set
-            raise OasisException('Missing loc_id in keys lookup: {missing_locid}')
+            raise OasisException(f'Missing loc_id in keys lookup: {missing_locid}')
 
         # Columns from loc file to assign group_id
         model_damage_group_fields = []

--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -9,6 +9,8 @@ import json
 import os
 from pathlib import Path
 from typing import List
+import numpy as np
+import pandas as pd
 
 from oasislmf.computation.base import ComputationStep
 from oasislmf.computation.data.dummy_model.generate import (AmplificationsFile,
@@ -236,13 +238,21 @@ class GenerateFiles(ComputationStep):
         # ************************************************
 
         # check that all loc_ids have been returned from keys lookup
-        keys_errors_df = get_dataframe(src_fp=_keys_errors_fp, memory_map=True)
-        returned_locid = set(keys_errors_df['locid'].unique()).union(set(keys_df['locid'].unique()))
-        missing_locid = set(location_df['loc_id']).difference(returned_locid)
+        try:
+            if self.keys_errors_csv:
+                keys_errors_df = get_dataframe(src_fp=self.keys_errors_csv, memory_map=True)
+            else:
+                keys_errors_df = get_dataframe(src_fp=_keys_errors_fp, memory_map=True)
+        except OasisException:
+            # Assume empty file on read error.
+            keys_errors_df = pd.DataFrame(columns=['locid'])
+
+        returned_locid_df = np.union1d(keys_errors_df['locid'], keys_df['locid'])
         del keys_errors_df
 
-        if missing_locid != set():  # if not empty set
-            raise OasisException(f'Missing loc_id in keys lookup: {missing_locid}')
+        missing_ids = np.setdiff1d(location_df['loc_id'].unique(), returned_locid_df)
+        if len(missing_ids) > 0:
+            raise OasisException(f'Lookup error: missing "loc_id" values from keys return: {missing_ids}')
 
         # Columns from loc file to assign group_id
         model_damage_group_fields = []

--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -241,7 +241,7 @@ class GenerateFiles(ComputationStep):
         missing_locid = set(location_df['loc_id']).difference(returned_locid)
         del keys_errors_df
 
-        if missing_locid != set(): # if not empty set
+        if missing_locid != set():  # if not empty set
             raise OasisException('Missing loc_id in keys lookup: {missing_locid}')
 
         # Columns from loc file to assign group_id

--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -235,6 +235,15 @@ class GenerateFiles(ComputationStep):
         )
         # ************************************************
 
+        # check that all loc_ids have been returned from keys lookup
+        keys_errors_df = get_dataframe(src_fp=_keys_errors_fp, memory_map=True)
+        returned_locid = set(keys_errors_df['locid'].unique()).union(set(keys_df['locid'].unique()))
+        missing_locid = set(location_df['loc_id']).difference(returned_locid)
+        del keys_errors_df
+
+        if missing_locid != set(): # if not empty set
+            raise OasisException('Missing loc_id in keys lookup: {missing_locid}')
+
         # Columns from loc file to assign group_id
         model_damage_group_fields = []
         model_hazard_group_fields = []

--- a/tests/computation/data/common.py
+++ b/tests/computation/data/common.py
@@ -10,6 +10,7 @@ __all__ = [
     'MIN_KEYS',
     'MIN_KEYS_ERR',
     'MIN_LOC',
+    'N2_LOC',
     'MIN_ACC',
     'MIN_INF',
     'MIN_SCP',
@@ -403,6 +404,11 @@ MIN_INF = """ReinsNumber,ReinsLayerNumber,ReinsName,ReinsPeril,ReinsInceptionDat
 """
 MIN_SCP = """ReinsNumber,PortNumber,AccNumber,PolNumber,LocGroup,LocNumber,CedantName,ProducerName,LOB,CountryCode,ReinsTag,CededPercent,OEDVersion
 1,1,A11111,,,10002082047,,,,,,0.1,2.0.0
+"""
+
+N2_LOC = """PortNumber,AccNumber,LocNumber,IsTenant,BuildingID,CountryCode,Latitude,Longitude,StreetAddress,PostalCode,OccupancyCode,ConstructionCode,LocPerilsCovered,BuildingTIV,OtherTIV,ContentsTIV,BITIV,LocCurrency,OEDVersion
+1,A11111,10002082046,1,1,GB,52.76698052,-0.895469856,1 ABINGDON ROAD,LE13 0HL,1050,5000,WW1,220000,0,0,0,GBP,2.0.0
+1,A11111,10002082047,1,1,GB,52.76697956,-0.89536613,2 ABINGDON ROAD,LE13 0HL,1050,5000,WW1,790000,0,0,0,GBP,2.0.0
 """
 
 EXPECTED_KEYS = b'LocID,PerilID,CoverageTypeID,AreaPerilID,VulnerabilityID,AmplificationID\n1,WSS,1,1000,8,2\n1,WTC,1,500,2,1\n1,WSS,3,1000,11,2\n1,WTC,3,500,5,1\n'

--- a/tests/computation/test_generate_files.py
+++ b/tests/computation/test_generate_files.py
@@ -31,7 +31,8 @@ class TestGenFiles(ComputationChecker):
         self.tmp_files = self.create_tmp_files(
             [a for a in self.default_args.keys() if 'csv' in a] +
             [a for a in self.default_args.keys() if 'path' in a] +
-            [a for a in self.default_args.keys() if 'json' in a]
+            [a for a in self.default_args.keys() if 'json' in a] +
+            ['oed_location_csv__2r']
         )
 
         self.min_args = {
@@ -52,6 +53,7 @@ class TestGenFiles(ComputationChecker):
         self.write_json(self.tmp_files.get('model_settings_json'), MIN_MODEL_SETTINGS)
         self.write_json(self.tmp_files.get('analysis_settings_json'), MIN_RUN_SETTINGS)
         self.write_str(self.tmp_files.get('oed_location_csv'), MIN_LOC)
+        self.write_str(self.tmp_files.get('oed_location_csv__2r'), N2_LOC)
         self.write_str(self.tmp_files.get('oed_accounts_csv'), MIN_ACC)
         self.write_str(self.tmp_files.get('oed_info_csv'), MIN_INF)
         self.write_str(self.tmp_files.get('oed_scope_csv'), MIN_SCP)
@@ -200,23 +202,24 @@ class TestGenFiles(ComputationChecker):
             file_gen_return = self.manager.generate_files(**call_args)
 
     def test_files__keys_csv__is_given(self):
+
         keys_file = self.tmp_files.get('keys_data_csv').name
         keys_err_file = self.tmp_files.get('keys_errors_csv').name
         with self.tmp_dir() as t_dir:
             call_args = {**self.ri_args,
+                         'oasis_files_dir': t_dir,
                          'keys_data_csv': keys_file,
                          'keys_errors_csv': keys_err_file}
             file_gen_return = self.manager.generate_files(**call_args)
 
     def test_files__keys_csv__missing_loc_id__error_is_raised(self):
-        oed_location_csv = self.tmp_files.get('oed_location_csv')
-        self.write_str(oed_location_csv, N2_LOC)
         keys_file = self.tmp_files.get('keys_data_csv').name
         keys_err_file = self.tmp_files.get('keys_errors_csv').name
+        loc_file = self.tmp_files.get('oed_location_csv__2r').name
         with self.tmp_dir() as t_dir:
             with self.assertRaises(OasisException) as context:
                 call_args = {**self.ri_args,
-                             'oed_location_csv': oed_location_csv.name,
+                             'oed_location_csv': loc_file,
                              'keys_data_csv': keys_file,
                              'keys_errors_csv': keys_err_file}
                 file_gen_return = self.manager.generate_files(**call_args)
@@ -224,14 +227,13 @@ class TestGenFiles(ComputationChecker):
         self.assertIn(expected_err_msg, str(context.exception))
 
     def test_files__error_file_not_given__missing_loc_id__error_is_raised(self):
-        oed_location_csv = self.tmp_files.get('oed_location_csv')
-        self.write_str(oed_location_csv, N2_LOC)
         keys_file = self.tmp_files.get('keys_data_csv').name
         keys_err_file = self.tmp_files.get('keys_errors_csv').name
+        loc_file = self.tmp_files.get('oed_location_csv__2r').name
         with self.tmp_dir() as t_dir:
             with self.assertRaises(OasisException) as context:
                 call_args = {**self.ri_args,
-                             'oed_location_csv': oed_location_csv.name,
+                             'oed_location_csv': loc_file,
                              'keys_data_csv': keys_file}
                 file_gen_return = self.manager.generate_files(**call_args)
         expected_err_msg = 'Lookup error: missing "loc_id" values from keys return: [2]'

--- a/tests/computation/test_generate_files.py
+++ b/tests/computation/test_generate_files.py
@@ -208,6 +208,35 @@ class TestGenFiles(ComputationChecker):
                          'keys_errors_csv': keys_err_file}
             file_gen_return = self.manager.generate_files(**call_args)
 
+    def test_files__keys_csv__missing_loc_id__error_is_raised(self):
+        oed_location_csv = self.tmp_files.get('oed_location_csv')
+        self.write_str(oed_location_csv, N2_LOC)
+        keys_file = self.tmp_files.get('keys_data_csv').name
+        keys_err_file = self.tmp_files.get('keys_errors_csv').name
+        with self.tmp_dir() as t_dir:
+            with self.assertRaises(OasisException) as context:
+                call_args = {**self.ri_args,
+                             'oed_location_csv': oed_location_csv.name,
+                             'keys_data_csv': keys_file,
+                             'keys_errors_csv': keys_err_file}
+                file_gen_return = self.manager.generate_files(**call_args)
+        expected_err_msg = 'Lookup error: missing "loc_id" values from keys return: [2]'
+        self.assertIn(expected_err_msg, str(context.exception))
+
+    def test_files__error_file_not_given__missing_loc_id__error_is_raised(self):
+        oed_location_csv = self.tmp_files.get('oed_location_csv')
+        self.write_str(oed_location_csv, N2_LOC)
+        keys_file = self.tmp_files.get('keys_data_csv').name
+        keys_err_file = self.tmp_files.get('keys_errors_csv').name
+        with self.tmp_dir() as t_dir:
+            with self.assertRaises(OasisException) as context:
+                call_args = {**self.ri_args,
+                             'oed_location_csv': oed_location_csv.name,
+                             'keys_data_csv': keys_file}
+                file_gen_return = self.manager.generate_files(**call_args)
+        expected_err_msg = 'Lookup error: missing "loc_id" values from keys return: [2]'
+        self.assertIn(expected_err_msg, str(context.exception))
+
     @patch('oasislmf.computation.generate.files.establish_correlations')
     def test_files__model_settings_given__analysis_settings_replace_correlations(self, establish_correlations):
         model_settings_file = self.tmp_files.get('model_settings_json')


### PR DESCRIPTION
<!--start_release_notes-->
### Added check for missing loc_ids after lookup returns keys
* Safe guard to ensure all location rows are processed by the lookup class, a return for each `loc_id` should exist in either **keys.csv** or **keys_error.csv** 
* Fixed platform testing after release of `2.3.0`
<!--end_release_notes-->
