### PR TITLE
use correct error_model in back allocation

### DIFF
--- a/oasislmf/pytools/fm/back_allocation.py
+++ b/oasislmf/pytools/fm/back_allocation.py
@@ -2,7 +2,7 @@ from numba import njit
 from .common import DEDUCTIBLE, UNDERLIMIT, OVERLIMIT
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, error_model="numpy")
 def back_alloc_extra_a2(base_children_len, temp_children_queue, nodes_array, p,
                         node_val_len, node_sidx, sidx_indptr, sidx_indexes, sidx_val,
                         loss_in, loss_out, temp_node_loss, loss_indptr, loss_val,
@@ -134,7 +134,7 @@ def back_alloc_extra_a2(base_children_len, temp_children_queue, nodes_array, p,
             # extras_indptr[child['extra'] + p], child_extra[0])
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, error_model="numpy")
 def back_alloc_a2(base_children_len, temp_children_queue, nodes_array, p,
                   node_val_len, node_sidx, sidx_indptr, sidx_indexes, sidx_val,
                   loss_in, loss_out, temp_node_loss, loss_indptr, loss_val):
@@ -182,7 +182,7 @@ def back_alloc_a2(base_children_len, temp_children_queue, nodes_array, p,
             # print('ba', child['level_id'], child['agg_id'], p, loss_indptr[child['loss'] + p], child_loss[0], temp_node_loss[p, -3])
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, error_model="numpy")
 def back_alloc_layer(layer_len, node_val_len, node_loss_indptr,
                      loss_in, loss_out, loss_indptr, loss_val,
                      temp_node_loss_layer_ba):
@@ -208,7 +208,7 @@ def back_alloc_layer(layer_len, node_val_len, node_loss_indptr,
             temp_node_loss_layer_ba[l, i] = loss_val[layer_loss_indptr + i] * loss_factor
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, error_model="numpy")
 def back_alloc_layer_extra(layer_len, node_val_len, node_loss_indptr, node_extra_indptr,
                            loss_in, loss_out, loss_indptr, loss_val,
                            temp_node_loss_layer_ba,

--- a/oasislmf/pytools/fm/compute_sparse.py
+++ b/oasislmf/pytools/fm/compute_sparse.py
@@ -501,62 +501,63 @@ def compute_event(compute_info,
 
             if compute_node['cross_layer_profile']:
                 node_profile = node_profiles_array[compute_node['profiles']]
-                if compute_node['extra'] != null_index:
-                    temp_node_loss_layer_merge.fill(0)
-                    temp_node_extras_layer_merge.fill(0)
+                if node_profile['i_start'] < node_profile['i_end']:
+                    if compute_node['extra'] != null_index:
+                        temp_node_loss_layer_merge.fill(0)
+                        temp_node_extras_layer_merge.fill(0)
 
-                    for l in range(compute_node['layer_len']):
-                        temp_node_loss_layer_merge[:node_val_len] += loss_val[
-                            loss_indptr[storage_node['loss'] + l]:
-                            loss_indptr[storage_node['loss'] + l] + node_val_len
-                        ]
-                        temp_node_extras_layer_merge[:node_val_len] += extras_val[
-                            extras_indptr[storage_node['extra'] + l]:
-                            extras_indptr[storage_node['extra'] + l] + node_val_len
-                        ]
-                    loss_in = temp_node_loss_layer_merge[:node_val_len]
-                    loss_out = temp_node_loss_sparse[:node_val_len]
-                    temp_node_extras_layer_merge_save[:node_val_len] = temp_node_extras_layer_merge[
-                        :node_val_len]  # save values as they are overwriten
+                        for l in range(compute_node['layer_len']):
+                            temp_node_loss_layer_merge[:node_val_len] += loss_val[
+                                loss_indptr[storage_node['loss'] + l]:
+                                loss_indptr[storage_node['loss'] + l] + node_val_len
+                            ]
+                            temp_node_extras_layer_merge[:node_val_len] += extras_val[
+                                extras_indptr[storage_node['extra'] + l]:
+                                extras_indptr[storage_node['extra'] + l] + node_val_len
+                            ]
+                        loss_in = temp_node_loss_layer_merge[:node_val_len]
+                        loss_out = temp_node_loss_sparse[:node_val_len]
+                        temp_node_extras_layer_merge_save[:node_val_len] = temp_node_extras_layer_merge[
+                            :node_val_len]  # save values as they are overwriten
 
-                    for profile_index in range(node_profile['i_start'], node_profile['i_end']):
-                        calc_extra(fm_profile[profile_index],
-                                   loss_out,
-                                   loss_in,
-                                   temp_node_extras_layer_merge[:, DEDUCTIBLE],
-                                   temp_node_extras_layer_merge[:, OVERLIMIT],
-                                   temp_node_extras_layer_merge[:, UNDERLIMIT],
-                                   stepped)
-                    # print(level, compute_node['agg_id'], base_children_len, fm_profile[profile_index]['calcrule_id'],
-                    #       loss_indptr[storage_node['loss']], loss_in, '=>', loss_out)
-                    # print(temp_node_extras_layer_merge_save[node_sidx[0], DEDUCTIBLE], '=>', temp_node_extras_layer_merge[0, DEDUCTIBLE], extras_indptr[storage_node['extra']])
-                    # print(temp_node_extras_layer_merge_save[node_sidx[0], OVERLIMIT], '=>', temp_node_extras_layer_merge[0, OVERLIMIT])
-                    # print(temp_node_extras_layer_merge_save[node_sidx[0], UNDERLIMIT], '=>', temp_node_extras_layer_merge[0, UNDERLIMIT])
-                    back_alloc_layer_extra(compute_node['layer_len'], node_val_len, storage_node['loss'], storage_node['extra'],
-                                           loss_in, loss_out, loss_indptr, loss_val,
-                                           temp_node_loss_layer_ba,
-                                           extras_indptr, extras_val,
-                                           temp_node_extras_layer_merge, temp_node_extras_layer_merge_save
-                                           )
+                        for profile_index in range(node_profile['i_start'], node_profile['i_end']):
+                            calc_extra(fm_profile[profile_index],
+                                       loss_out,
+                                       loss_in,
+                                       temp_node_extras_layer_merge[:, DEDUCTIBLE],
+                                       temp_node_extras_layer_merge[:, OVERLIMIT],
+                                       temp_node_extras_layer_merge[:, UNDERLIMIT],
+                                       stepped)
+                        # print(level, compute_node['agg_id'], base_children_len, fm_profile[profile_index]['calcrule_id'],
+                        #       loss_indptr[storage_node['loss']], loss_in, '=>', loss_out)
+                        # print(temp_node_extras_layer_merge_save[node_sidx[0], DEDUCTIBLE], '=>', temp_node_extras_layer_merge[0, DEDUCTIBLE], extras_indptr[storage_node['extra']])
+                        # print(temp_node_extras_layer_merge_save[node_sidx[0], OVERLIMIT], '=>', temp_node_extras_layer_merge[0, OVERLIMIT])
+                        # print(temp_node_extras_layer_merge_save[node_sidx[0], UNDERLIMIT], '=>', temp_node_extras_layer_merge[0, UNDERLIMIT])
+                        back_alloc_layer_extra(compute_node['layer_len'], node_val_len, storage_node['loss'], storage_node['extra'],
+                                               loss_in, loss_out, loss_indptr, loss_val,
+                                               temp_node_loss_layer_ba,
+                                               extras_indptr, extras_val,
+                                               temp_node_extras_layer_merge, temp_node_extras_layer_merge_save
+                                               )
 
-                else:
-                    temp_node_loss_layer_merge.fill(0)
-                    for l in range(compute_node['layer_len']):
-                        temp_node_loss_layer_merge[:node_val_len] += loss_val[
-                            loss_indptr[storage_node['loss'] + l]:
-                            loss_indptr[storage_node['loss'] + l] + node_val_len
-                        ]
-                    loss_in = temp_node_loss_layer_merge[:node_val_len]
-                    loss_out = temp_node_loss_sparse[:node_val_len]
-                    for profile_index in range(node_profile['i_start'], node_profile['i_end']):
-                        calc(fm_profile[profile_index],
-                             loss_out,
-                             loss_in,
-                             stepped)
-                    # print(level, compute_node['agg_id'], base_children_len, fm_profile[profile_index]['calcrule_id'],
-                    #       loss_indptr[storage_node['loss']], loss_in, '=>', loss_out)
-                    back_alloc_layer(compute_node['layer_len'], node_val_len, storage_node['loss'],
-                                     loss_in, loss_out, loss_indptr, loss_val, temp_node_loss_layer_ba)
+                    else:
+                        temp_node_loss_layer_merge.fill(0)
+                        for l in range(compute_node['layer_len']):
+                            temp_node_loss_layer_merge[:node_val_len] += loss_val[
+                                loss_indptr[storage_node['loss'] + l]:
+                                loss_indptr[storage_node['loss'] + l] + node_val_len
+                            ]
+                        loss_in = temp_node_loss_layer_merge[:node_val_len]
+                        loss_out = temp_node_loss_sparse[:node_val_len]
+                        for profile_index in range(node_profile['i_start'], node_profile['i_end']):
+                            calc(fm_profile[profile_index],
+                                 loss_out,
+                                 loss_in,
+                                 stepped)
+                        # print(level, compute_node['agg_id'], base_children_len, fm_profile[profile_index]['calcrule_id'],
+                        #       loss_indptr[storage_node['loss']], loss_in, '=>', loss_out)
+                        back_alloc_layer(compute_node['layer_len'], node_val_len, storage_node['loss'],
+                                         loss_in, loss_out, loss_indptr, loss_val, temp_node_loss_layer_ba)
 
             # we apply the policy term on each layer
             for p in range(compute_node['profile_len']):

--- a/oasislmf/pytools/fm/compute_sparse.py
+++ b/oasislmf/pytools/fm/compute_sparse.py
@@ -284,7 +284,7 @@ def set_parent_next_compute(parent_id, child_id, nodes_array, children, computes
         compute_idx['next_compute_i'] += 1
 
 
-@njit(cache=True, fastmath=True)
+@njit(cache=True, fastmath=True, error_model="numpy")
 def compute_event(compute_info,
                   net_loss,
                   nodes_array,

--- a/oasislmf/pytools/fm/manager.py
+++ b/oasislmf/pytools/fm/manager.py
@@ -21,7 +21,7 @@ def run(create_financial_structure_files, **kwargs):
         return run_synchronous(**kwargs)
 
 
-#@redirect_logging(exec_name='fmpy')
+# @redirect_logging(exec_name='fmpy')
 def run_synchronous(allocation_rule, files_in, files_out, net_loss, storage_method, **kwargs):
     if allocation_rule == 3:
         allocation_rule = 2

--- a/oasislmf/pytools/fm/manager.py
+++ b/oasislmf/pytools/fm/manager.py
@@ -21,7 +21,7 @@ def run(create_financial_structure_files, **kwargs):
         return run_synchronous(**kwargs)
 
 
-@redirect_logging(exec_name='fmpy')
+#@redirect_logging(exec_name='fmpy')
 def run_synchronous(allocation_rule, files_in, files_out, net_loss, storage_method, **kwargs):
     if allocation_rule == 3:
         allocation_rule = 2
@@ -74,20 +74,27 @@ def run_synchronous_sparse(max_sidx_val, allocation_rule, static_path, streams_i
 
         with event_writer_cls(files_out, nodes_array, output_array, sidx_indexes, sidx_indptr, sidx_val,
                               loss_indptr, loss_val, pass_through_out, max_sidx_val, computes) as event_writer:
-            for event_id in read_streams_sparse(streams_in, nodes_array, sidx_indexes, sidx_indptr, sidx_val,
-                                                loss_indptr, loss_val, pass_through, len_array, computes, compute_idx):
-                compute_event_sparse(
-                    compute_info,
-                    net_loss,
-                    nodes_array,
-                    node_parents_array,
-                    node_profiles_array,
-                    len_array, max_sidx_val, sidx_indexes, sidx_indptr, sidx_val, loss_indptr, loss_val, extras_indptr, extras_val,
-                    children,
-                    computes,
-                    compute_idx,
-                    item_parent_i,
-                    fm_profile,
-                    stepped)
-                event_writer.write(event_id, compute_idx)
-                reset_variable_sparse(children, compute_idx, computes)
+            for i, event_id in enumerate(read_streams_sparse(
+                    streams_in, nodes_array, sidx_indexes, sidx_indptr, sidx_val,
+                    loss_indptr, loss_val, pass_through, len_array, computes, compute_idx)):
+                try:
+                    compute_event_sparse(
+                        compute_info,
+                        net_loss,
+                        nodes_array,
+                        node_parents_array,
+                        node_profiles_array,
+                        len_array, max_sidx_val, sidx_indexes, sidx_indptr, sidx_val, loss_indptr, loss_val, extras_indptr, extras_val,
+                        children,
+                        computes,
+                        compute_idx,
+                        item_parent_i,
+                        fm_profile,
+                        stepped)
+                    event_writer.write(event_id, compute_idx)
+                    reset_variable_sparse(children, compute_idx, computes)
+                except Exception:
+                    node = nodes_array[computes[compute_idx['compute_i']]]
+                    logger.error(f"event index={i} id={event_id}, "
+                                 f"at node level_id={node['level_id']} agg_id={node['agg_id']}")
+                    raise

--- a/oasislmf/pytools/fm/manager.py
+++ b/oasislmf/pytools/fm/manager.py
@@ -21,7 +21,7 @@ def run(create_financial_structure_files, **kwargs):
         return run_synchronous(**kwargs)
 
 
-# @redirect_logging(exec_name='fmpy')
+@redirect_logging(exec_name='fmpy')
 def run_synchronous(allocation_rule, files_in, files_out, net_loss, storage_method, **kwargs):
     if allocation_rule == 3:
         allocation_rule = 2


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### fix potential ZeroDivisionError in during fmpy back allocation
<!--end_release_notes-->
in Numba they use low level parallelisation for lots of operation including division
To do that they skip some if in the function to do the division and then assign the value base on the if
for example a code equivalent to that:
num = np.array([1,2,3,4])
den =np.array([1,0,3,4])
res = np.empy(4)
for i in range(4):
    if den[i]==0:
        res[i] = 0
    else:
        res[i] = num[i]/den[i]
will actually execute more like this
res_true = [0,0,0,0]
res_false = num/den (=>raise the error)
for i in range(4):
   if den[i]==0:
      res[i] = res_true[i]
   else:
      res[i] = res_false[i]
to avoid that we need to use error_model="numpy" when compiling with jit
result is still correct as the nan generated but the division is replace by the correct value  in the result

