### PR TITLE
Fix parquet checks

### DIFF
--- a/oasislmf/execution/bin.py
+++ b/oasislmf/execution/bin.py
@@ -493,7 +493,7 @@ def set_vulnerability_set(setting_val, run_dir):
                 os.symlink(vulnerability_meta, vulnerability_meta_target)
                 return
             else:
-                logger.debug(f'{vulnerability_fp} not found, trying next format')
+                logger.debug(f'{vulnerability_fp} and/or {vulnerability_meta} not found, trying next format')
         else:
             # For other file formats, check if it's a file
             vulnerability_fp = os.path.join(run_dir, 'static', f'vulnerability_{setting_val}.{file_format}')

--- a/oasislmf/execution/bin.py
+++ b/oasislmf/execution/bin.py
@@ -44,7 +44,7 @@ from oasislmf.pytools.getmodel.common import fp_format_priorities
 from oasislmf.pytools.getmodel.footprint import (
     FootprintParquet, FootprintBinZ, FootprintBin, FootprintCsv
 )
-from oasislmf.pytools.getmodel.vulnerability import vulnerability_dataset
+from oasislmf.pytools.getmodel.vulnerability import vulnerability_dataset, parquetvulnerability_meta_filename
 
 logger = logging.getLogger(__name__)
 
@@ -448,11 +448,11 @@ def set_footprint_set(setting_val, run_dir):
             stem, extension = filename.split('.', 1)
             footprint_fp = os.path.join(run_dir, 'static', f'{stem}_{setting_val}.{extension}')
             footprint_target_fp = os.path.join(run_dir, 'static', filename)
-            if not os.path.isfile(footprint_fp):
+            if not os.path.exists(footprint_fp):
                 # 'compatibility' - Fallback name formatting to keep existing conversion
                 setting_val_old = setting_val.replace(' ', '_').lower()
                 footprint_fp = os.path.join(run_dir, 'static', f'{stem}_{setting_val_old}.{extension}')
-                if not os.path.isfile(footprint_fp):
+                if not os.path.exists(footprint_fp):
                     logger.debug(f'{footprint_fp} not found, moving on to next footprint class')
                     break
             os.symlink(footprint_fp, footprint_target_fp)
@@ -481,11 +481,16 @@ def set_vulnerability_set(setting_val, run_dir):
     for file_format in vulnerability_formats:
 
         if file_format == 'parquet':
+            base_name, format_extension = vulnerability_dataset.split('.', 1)
+            base_meta_name, _ = parquetvulnerability_meta_filename.split('.', 1)
             # For Parquet, check if it's a directory
-            vulnerability_fp = os.path.join(run_dir, 'static', f'{vulnerability_dataset}_{setting_val}')
+            vulnerability_fp = os.path.join(run_dir, 'static', f'{base_name}_{setting_val}.{format_extension}')
             vulnerability_target_fp = os.path.join(run_dir, 'static', f'{vulnerability_dataset}')
-            if os.path.isdir(vulnerability_fp):
+            vulnerability_meta = os.path.join(run_dir, 'static', f'{base_meta_name}_{setting_val}.json')
+            vulnerability_meta_target = os.path.join(run_dir, 'static', f'{parquetvulnerability_meta_filename}')
+            if os.path.isdir(vulnerability_fp) and os.path.isfile(vulnerability_meta):
                 os.symlink(vulnerability_fp, vulnerability_target_fp)
+                os.symlink(vulnerability_meta, vulnerability_meta_target)
                 return
             else:
                 logger.debug(f'{vulnerability_fp} not found, trying next format')

--- a/tests/model_execution/test_bin.py
+++ b/tests/model_execution/test_bin.py
@@ -931,7 +931,7 @@ class SetFootprintSet(TestCase):
                     stem, extension = filename.split('.', 1)
                     file_path = os.path.join(d, 'static', f'{stem}_{self.setting_val}.{extension}')
                     Path(file_path).touch()
-                
+
     def test_symbolic_links_to_parquet_files(self):
         """
         Test symbolic links pointing to footprint files in parquet format are

--- a/tests/model_execution/test_bin.py
+++ b/tests/model_execution/test_bin.py
@@ -911,12 +911,27 @@ class SetFootprintSet(TestCase):
             priority_level (int): file format being tested - formats with higher
                 priority (closer to 1) include those of lower priority
         """
-        os.mkdir(os.path.join(d, 'static'))
-        for fp_format, fp_filename in islice(self.fp_filenames.items(), priority_level, None):
-            for filename in fp_filename:
-                stem, extension = filename.split('.', 1)
-                Path(os.path.join(d, 'static', f'{stem}_{self.setting_val}.{extension}')).touch()
-
+        os.makedirs(os.path.join(d, 'static'), exist_ok=True)
+        for fp_format, fp_filenames in islice(self.fp_filenames.items(), priority_level, None):
+            if fp_format == 'parquet':
+                # Handle parquet as a directory
+                for filename in fp_filenames:
+                    stem, extension = filename.split('.', 1)
+                    if 'meta' in filename:
+                        # For the meta file, create a file instead of a directory
+                        meta_fp = os.path.join(d, 'static', f'{stem}_{self.setting_val}.{extension}')
+                        Path(meta_fp).touch()
+                    else:
+                        # Create a directory for the parquet format
+                        parquet_dir_path = os.path.join(d, 'static', f'{stem}_{self.setting_val}.{extension}')
+                        os.makedirs(parquet_dir_path, exist_ok=True)
+            else:
+                # For other formats, just create files
+                for filename in fp_filenames:
+                    stem, extension = filename.split('.', 1)
+                    file_path = os.path.join(d, 'static', f'{stem}_{self.setting_val}.{extension}')
+                    Path(file_path).touch()
+                
     def test_symbolic_links_to_parquet_files(self):
         """
         Test symbolic links pointing to footprint files in parquet format are


### PR DESCRIPTION
<!--start_release_notes-->
### Fix footprint_set and vulnerability_set options with parquet
footprint_set and vulnerability_set now correctly handle data provided in parquet format
<!--end_release_notes-->

Fixes Issue #1449.

Also, in light of the change to the vulnerability parquet filename by adding the `.parquet` extension (`vulnerability_dataset` to `vulnerability_dataset.parquet`), this PR changes the handling of the set suffixes for parquet file:
instead of naming a set `vulnerability_dataset.parquet_setname`, it is now expected to be `vulnerability_dataset_setname.parquet`)