### PR TITLE
Allow optional hazard or damage correlation value

### DIFF
--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -303,7 +303,7 @@ class GenerateFiles(ComputationStep):
         gul_inputs_df = get_gul_input_items(
             location_df,
             keys_df,
-            peril_correlation_group_df=map_data(data=model_settings),
+            peril_correlation_group_df=map_data(data=model_settings, logger=self.logger),
             correlations=correlations,
             exposure_profile=location_profile,
             damage_group_id_cols=damage_group_id_cols,

--- a/oasislmf/preparation/correlations.py
+++ b/oasislmf/preparation/correlations.py
@@ -7,7 +7,7 @@ from typing import Optional
 import pandas as pd
 
 
-def map_data(data: Optional[dict]) -> Optional[pd.DataFrame]:
+def map_data(data: Optional[dict], logger) -> Optional[pd.DataFrame]:
     """
     Maps data from the model settings to to have Peril ID, peril_correlation_group, and damage_correlation_value.
 
@@ -29,14 +29,16 @@ def map_data(data: Optional[dict]) -> Optional[pd.DataFrame]:
         if len(correlation_settings_df) > 0:
             # correlations_settings are defined
             if "damage_correlation_value" not in correlation_settings_df.columns:
-                raise ValueError(
+                logger.warning(
                     "Expect correlation settings in model settings file to contain a `damage_correlation_value` "
                     f"in each `peril_correlation_group` entry, got \n{correlation_settings}.")
+                correlation_settings_df["damage_correlation_value"] = 0
 
             if "hazard_correlation_value" not in correlation_settings_df.columns:
-                raise ValueError(
+                logger.warning(
                     "Expect correlation settings in model settings file to contain a `hazard_correlation_value` "
                     f"in each `peril_correlation_group` entry, got \n {correlation_settings}.")
+                correlation_settings_df["hazard_correlation_value"] = 0
 
         # merge allows duplicates of the "peril_correlation_group" in the supported perils
         # merge does not allow duplicates of the "peril_correlation_group" in the correlation settings

--- a/oasislmf/preparation/correlations.py
+++ b/oasislmf/preparation/correlations.py
@@ -29,15 +29,11 @@ def map_data(data: Optional[dict], logger) -> Optional[pd.DataFrame]:
         if len(correlation_settings_df) > 0:
             # correlations_settings are defined
             if "damage_correlation_value" not in correlation_settings_df.columns:
-                logger.warning(
-                    "Expect correlation settings in model settings file to contain a `damage_correlation_value` "
-                    f"in each `peril_correlation_group` entry, got \n{correlation_settings}.")
+                logger.info("Correlation settings: No `damage_correlation_value` found")
                 correlation_settings_df["damage_correlation_value"] = 0
 
             if "hazard_correlation_value" not in correlation_settings_df.columns:
-                logger.warning(
-                    "Expect correlation settings in model settings file to contain a `hazard_correlation_value` "
-                    f"in each `peril_correlation_group` entry, got \n {correlation_settings}.")
+                logger.info("Correlation settings: No `hazard_correlation_value` found")
                 correlation_settings_df["hazard_correlation_value"] = 0
 
         # merge allows duplicates of the "peril_correlation_group" in the supported perils

--- a/tests/preparation/test_correlations.py
+++ b/tests/preparation/test_correlations.py
@@ -23,14 +23,14 @@ class TestMapData(TestCase):
         pass
 
     def test_map_data(self):
-        mapped_data = map_data(data=self.model_settings)
+        mapped_data = map_data(data=self.model_settings, logger=None)
         self.assertEqual(EXPECTED_MAPPED_DATA, mapped_data.to_dict('records'))
 
     def test_get_correlation_input_items(self):
         gul_path = META_PATH + "gul_inputs_df.csv"
 
         gul_inputs_df = pd.read_csv(gul_path)
-        correlation_df = get_correlation_input_items(correlation_map_df=map_data(data=self.model_settings),
+        correlation_df = get_correlation_input_items(correlation_map_df=map_data(data=self.model_settings, logger=None),
                                                      gul_inputs_df=gul_inputs_df)
         correlation_df_check = pd.read_csv(f"{META_PATH}correlation_df.csv")
 


### PR DESCRIPTION
<!--start_release_notes-->
### Hazard and damage correlation values in model settings now optional
The correlation value for either damage or hazard is now optional and defaults to zero if not entered.
<!--end_release_notes-->

Solves Issue #1350.