### PR TITLE
Update OasisAPI client to poll analysis status using `run_mode`

### DIFF
--- a/oasislmf/platform_api/client.py
+++ b/oasislmf/platform_api/client.py
@@ -500,7 +500,7 @@ class APIClient(object):
                         logged_running = True
                         self.logger.info('Input Generation: Executing (id={})'.format(analysis_id))
 
-                    if 'sub_task_list' in analysis:
+                    if analysis.get('run_mode', '') == 'V2':
                         sub_tasks_list = self.analyses.sub_task_list(analysis_id).json()
                         with tqdm(total=len(sub_tasks_list),
                                   unit=' sub_task',
@@ -580,7 +580,7 @@ class APIClient(object):
                         logged_running = True
                         self.logger.info('Analysis Run: Executing (id={})'.format(analysis_id))
 
-                    if 'sub_task_list' in analysis:
+                    if analysis.get('run_mode', '') == 'V2':
                         sub_tasks_list = self.analyses.sub_task_list(analysis_id).json()
                         with tqdm(total=len(sub_tasks_list),
                                   unit=' sub_task',

--- a/tests/platform_api/test_client.py
+++ b/tests/platform_api/test_client.py
@@ -1324,8 +1324,8 @@ class APIClientTests(unittest.TestCase):
             sub_task_data = json.load(f)
 
         with responses.RequestsMock(assert_all_requests_are_fired=True, registry=OrderedRegistry) as rsps:
-            rsps.post(exec_url, json={"id": ID, "status": "INPUTS_GENERATION_QUEUED", "sub_task_list": "http://some-url"})
-            rsps.get(expected_url, json={"id": ID, "status": "INPUTS_GENERATION_STARTED", "sub_task_list": "http://some-url"})
+            rsps.post(exec_url, json={"id": ID, "status": "INPUTS_GENERATION_QUEUED", "sub_task_list": "http://some-url", 'run_mode': 'V2'})
+            rsps.get(expected_url, json={"id": ID, "status": "INPUTS_GENERATION_STARTED", "sub_task_list": "http://some-url", 'run_mode': 'V2'})
             rsps.get(sub_task_url, json=sub_task_data)
             rsps.get(sub_task_url, json=sub_task_data)
             rsps.get(expected_url, json={"id": ID, "status": "READY"})
@@ -1343,8 +1343,8 @@ class APIClientTests(unittest.TestCase):
             sub_task_data = json.load(f)
 
         with responses.RequestsMock(assert_all_requests_are_fired=True, registry=OrderedRegistry) as rsps:
-            rsps.post(exec_url, json={"id": ID, "status": "INPUTS_GENERATION_QUEUED", "sub_task_list": "http://some-url"})
-            rsps.get(expected_url, json={"id": ID, "status": "INPUTS_GENERATION_STARTED", "sub_task_list": "http://some-url"})
+            rsps.post(exec_url, json={"id": ID, "status": "INPUTS_GENERATION_QUEUED", "sub_task_list": "http://some-url", 'run_mode': 'V2'})
+            rsps.get(expected_url, json={"id": ID, "status": "INPUTS_GENERATION_STARTED", "sub_task_list": "http://some-url", 'run_mode': 'V2'})
             rsps.get(sub_task_url, json=sub_task_data)
             rsps.get(sub_task_url, json=sub_task_data)
             rsps.get(expected_url, json={"id": ID, "status": "INPUTS_GENERATION_CANCELLED"})
@@ -1439,8 +1439,8 @@ class APIClientTests(unittest.TestCase):
             sub_task_data = json.load(f)
 
         with responses.RequestsMock(assert_all_requests_are_fired=True, registry=OrderedRegistry) as rsps:
-            rsps.post(exec_url, json={"id": ID, "status": "RUN_QUEUED", "sub_task_list": "http://some-url"})
-            rsps.get(expected_url, json={"id": ID, "status": "RUN_STARTED", "sub_task_list": "http://some-url"})
+            rsps.post(exec_url, json={"id": ID, "status": "RUN_QUEUED", "sub_task_list": "http://some-url", 'run_mode': 'V2'})
+            rsps.get(expected_url, json={"id": ID, "status": "RUN_STARTED", "sub_task_list": "http://some-url", 'run_mode': 'V2'})
             rsps.get(sub_task_url, json=sub_task_data)
             rsps.get(sub_task_url, json=sub_task_data)
             rsps.get(expected_url, json={"id": ID, "status": "RUN_COMPLETED"})
@@ -1458,8 +1458,8 @@ class APIClientTests(unittest.TestCase):
             sub_task_data = json.load(f)
 
         with responses.RequestsMock(assert_all_requests_are_fired=True, registry=OrderedRegistry) as rsps:
-            rsps.post(exec_url, json={"id": ID, "status": "RUN_QUEUED", "sub_task_list": "http://some-url"})
-            rsps.get(expected_url, json={"id": ID, "status": "RUN_STARTED", "sub_task_list": "http://some-url"})
+            rsps.post(exec_url, json={"id": ID, "status": "RUN_QUEUED", "sub_task_list": "http://some-url", 'run_mode': 'V2'})
+            rsps.get(expected_url, json={"id": ID, "status": "RUN_STARTED", "sub_task_list": "http://some-url", 'run_mode': 'V2'})
             rsps.get(sub_task_url, json=sub_task_data)
             rsps.get(sub_task_url, json=sub_task_data)
             rsps.get(expected_url, json={"id": ID, "status": "RUN_CANCELLED"})


### PR DESCRIPTION
<!--start_release_notes-->
### Update OasisAPI client to poll analysis status using run_mode
With OasisPlatform **2.3.0**,  the `v2` endpoints can support both execution workflows (single server or distributed). 
Fix the OasisAPI client to check for the new `run_mode={v1| v2}` which waiting for an analysis to complete
<!--end_release_notes-->
