### PR TITLE
fix for zero samples

### DIFF
--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -309,7 +309,8 @@ class GenerateLossesDir(GenerateLossesBase):
                 'No valid output settings in: {}'.format(self.analysis_settings_json))
 
         # Load default samples if not set in analysis settings
-        if not analysis_settings.get('number_of_samples'):
+        # Additional check to avoid 0 samples being interpreted as false
+        if not analysis_settings.get('number_of_samples') and analysis_settings.get('number_of_samples') != 0:
             if not self.model_settings_json:
                 raise OasisException("'number_of_samples' not set in analysis_settings and no model_settings.json file provided for a default value.")
 


### PR DESCRIPTION
fixes #1471 

<!--start_release_notes-->
### Release notes feature title
Added check into generate losses to allow for zero samples in the analysis settings file. Previously this had been misinterpreting zero samples as boolean false, and assuming that number of samples was missing and so falling back on the default number.
<!--end_release_notes-->
