### PR TITLE
CI - Fix broken symlinks in test_generate_losses  (1.28.x)

### DIFF
--- a/tests/computation/test_generate_losses.py
+++ b/tests/computation/test_generate_losses.py
@@ -104,6 +104,7 @@ class TestGenLosses(ComputationChecker):
             'analysis_settings_json': self.tmp_files.get('analysis_settings_json').name,
             'oasis_files_dir': self.args_gen_files_gul['oasis_files_dir'],
             'model_data_dir': self.model_data_dir,
+            'model_run_dir': self.tmp_dirs.get('model_run_dir').name,
         }
 
     def test_losses__no_input__exception_raised(self):


### PR DESCRIPTION
<!--start_release_notes-->
### CI - Fix broken symlinks in test_generate_losses (1.28.x)
Symlinks using the new pytest package are broken for some tests in `test_generate_losses.py`. 
Fixed by running all of these checks in a temp `model_run_dir`
<!--end_release_notes-->
