### PR TITLE
Remove multiple definitions of footprint file format priorities

### DIFF
--- a/oasislmf/execution/bin.py
+++ b/oasislmf/execution/bin.py
@@ -40,10 +40,7 @@ from ..utils.log import oasis_log
 from ..utils.defaults import STATIC_DATA_FP
 from .files import TAR_FILE, INPUT_FILES, GUL_INPUT_FILES, IL_INPUT_FILES
 from .bash import leccalc_enabled, ord_enabled, ORD_LECCALC
-from oasislmf.pytools.getmodel.common import fp_format_priorities
-from oasislmf.pytools.getmodel.footprint import (
-    FootprintParquet, FootprintBinZ, FootprintBin, FootprintCsv
-)
+from oasislmf.pytools.getmodel.footprint import Footprint
 from oasislmf.pytools.getmodel.vulnerability import vulnerability_dataset, parquetvulnerability_meta_filename
 
 logger = logging.getLogger(__name__)
@@ -436,11 +433,7 @@ def set_footprint_set(setting_val, run_dir):
     :param run_dir: model run directory
     :type run_dir: string
     """
-    format_to_class = {
-        'parquet': FootprintParquet, 'binZ': FootprintBinZ,
-        'bin': FootprintBin, 'csv': FootprintCsv
-    }
-    priorities = [format_to_class[fmt] for fmt in fp_format_priorities if fmt in format_to_class]
+    priorities = Footprint.get_footprint_fmt_priorities()
     setting_val = str(setting_val)
 
     for footprint_class in priorities:

--- a/oasislmf/pytools/getmodel/footprint.py
+++ b/oasislmf/pytools/getmodel/footprint.py
@@ -68,6 +68,21 @@ class Footprint:
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self.stack.__exit__(exc_type, exc_value, exc_traceback)
 
+    @staticmethod
+    def get_footprint_fmt_priorities():
+        """
+        Get list of footprint file format classes in order of priority.
+
+        Returns: (list) footprint file format classes
+        """
+        format_to_class = {
+            'parquet': FootprintParquet, 'csv': FootprintCsv,
+            'binZ': FootprintBinZ, 'bin': FootprintBin,
+        }
+        priorities = [format_to_class[fmt] for fmt in fp_format_priorities if fmt in format_to_class]
+
+        return priorities
+
     @classmethod
     def load(
         cls,
@@ -98,13 +113,7 @@ class Footprint:
 
         Returns: (Union[FootprintBinZ, FootprintBin, FootprintCsv]) the loaded class
         """
-        format_to_class = {
-            'parquet': FootprintParquet, 'csv': FootprintCsv,
-            'binZ': FootprintBinZ, 'bin': FootprintBin,
-        }
-        priorities = [format_to_class[fmt] for fmt in fp_format_priorities if fmt in format_to_class]
-
-        for footprint_class in priorities:
+        for footprint_class in cls.get_footprint_fmt_priorities():
             for filename in footprint_class.footprint_filenames:
                 if (not storage.exists(filename)
                         or filename.rsplit('.', 1)[-1] in ignore_file_type):


### PR DESCRIPTION
<!--start_release_notes-->
### Remove multiple definitions of footprint file format priorities
The new static method `getmodel/footprint.py::Footprint::get_footprint_fmt_priorities()` can now be called from `execution/bin.py::set_footprint_set()` to get a list of footprint file format priorities. This removes the duplicate definition in this function. As before, the priority order is defined in `getmodel/common.py`.
<!--end_release_notes-->
