### PR TITLE
Fix CI default branches

### DIFF
--- a/.github/workflows/piwind-mdk.yml
+++ b/.github/workflows/piwind-mdk.yml
@@ -34,5 +34,5 @@ jobs:
     with:
       mdk_branch: ${{ github.ref }}
       mdk_run_type: ${{ github.event_name != 'workflow_dispatch' && 'ri' || inputs.mdk_run_type }}
-      piwind_branch: ${{ github.event_name != 'workflow_dispatch' && 'stable/2.3.x' || inputs.piwind_branch }}
-      ods_branch: ${{ github.event_name != 'workflow_dispatch' && 'stable/3.2.x' || inputs.ods_branch }}
+      piwind_branch: ${{ github.event_name != 'workflow_dispatch' && 'main' || inputs.piwind_branch }}
+      ods_branch: ${{ github.event_name != 'workflow_dispatch' && 'main' || inputs.ods_branch }}

--- a/.github/workflows/piwind-test.yml
+++ b/.github/workflows/piwind-test.yml
@@ -53,7 +53,7 @@ jobs:
     uses: OasisLMF/ODS_Tools/.github/workflows/build.yml@main
     secrets: inherit
     with:
-      ods_branch: ${{ github.event_name != 'workflow_dispatch' && 'stable/3.2.x' ||  inputs.ods_branch }}
+      ods_branch: ${{ github.event_name != 'workflow_dispatch' && 'main' ||  inputs.ods_branch }}
 
   platform1:
     if: ${{ ! failure() || ! cancelled() }}
@@ -61,11 +61,12 @@ jobs:
     secrets: inherit
     needs: [build, ods_tools]
     with:
-      piwind_branch: ${{ github.event_name != 'workflow_dispatch' && 'stable/2.3.x' || inputs.piwind_branch }}
+      piwind_branch: ${{ github.event_name != 'workflow_dispatch' && 'main' || inputs.piwind_branch }}
       oasislmf_package: ${{ needs.build.outputs.linux_pkg_filename }}
       oasislmf_branch: ''
       ods_package: ${{ needs.ods_tools.outputs.whl_filename }}
-      platform_version: ${{ github.event_name != 'workflow_dispatch' && '1-latest' ||  inputs.platform_1_version }}
+      platform_version: ${{ github.event_name != 'workflow_dispatch' && 'latest' ||  inputs.platform_1_version }}
+      pytest_opts: "--docker-compose=./docker/plat2-v2.docker-compose.yml"
       worker_api_ver: 'v1'
       storage_suffix: '_platform1'
 

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -35,7 +35,7 @@ jobs:
     uses: OasisLMF/ODS_Tools/.github/workflows/build.yml@main
     secrets: inherit
     with:
-      ods_branch: ${{ github.event_name != 'workflow_dispatch' && 'stable/3.2.x' ||  inputs.ods_branch }} # Enable 'ods-tools' build by default
+      ods_branch: ${{ github.event_name != 'workflow_dispatch' && 'main' ||  inputs.ods_branch }} # Enable 'ods-tools' build by default
 
   unittest:
     if: ${{ ! failure() || ! cancelled() }}


### PR DESCRIPTION
<!--start_release_notes-->
### Fix CI default branches
Tests on the `main` branch are failing because of the merge back from `stable/2.3.x` https://github.com/OasisLMF/OasisLMF/commit/9412ab02f274016390e70221736ee9e54ad273d8  reverting these changes to fix CI
<!--end_release_notes-->
