### PR TITLE
Extended field list for correlation groupings for disaggregated risks

### DIFF
--- a/oasislmf/preparation/gul_inputs.py
+++ b/oasislmf/preparation/gul_inputs.py
@@ -367,6 +367,11 @@ def get_gul_input_items(
 
         gul_inputs_reformatted_chunks.append(pd.concat(disagg_df_chunk))
 
+    # add risk_id to gul_inputs_df
+    gul_inputs_df[['risk_id', 'NumberOfRisks']] = gul_inputs_df[['building_id', 'NumberOfBuildings']]
+    gul_inputs_df.loc[gul_inputs_df['IsAggregate'] == 0, ['risk_id', 'NumberOfRisks']] = 1, 1
+    gul_inputs_df.loc[gul_inputs_df['NumberOfRisks'] == 0, 'NumberOfRisks'] = 1
+
     # concatenate all the unpacked chunks. Sort by index to preserve `item_id` order as in the original code
     gul_inputs_df = (
         pd.concat(gul_inputs_reformatted_chunks)

--- a/oasislmf/preparation/gul_inputs.py
+++ b/oasislmf/preparation/gul_inputs.py
@@ -367,11 +367,6 @@ def get_gul_input_items(
 
         gul_inputs_reformatted_chunks.append(pd.concat(disagg_df_chunk))
 
-    # add risk_id to gul_inputs_df
-    gul_inputs_df[['risk_id', 'NumberOfRisks']] = gul_inputs_df[['building_id', 'NumberOfBuildings']]
-    gul_inputs_df.loc[gul_inputs_df['IsAggregate'] == 0, ['risk_id', 'NumberOfRisks']] = 1, 1
-    gul_inputs_df.loc[gul_inputs_df['NumberOfRisks'] == 0, 'NumberOfRisks'] = 1
-
     # concatenate all the unpacked chunks. Sort by index to preserve `item_id` order as in the original code
     gul_inputs_df = (
         pd.concat(gul_inputs_reformatted_chunks)
@@ -386,6 +381,11 @@ def get_gul_input_items(
         **{'is_bi_coverage': 'bool'}
     }
     gul_inputs_df = set_dataframe_column_dtypes(gul_inputs_df, dtypes)
+
+    # add risk_id to gul_inputs_df
+    gul_inputs_df[['risk_id', 'NumberOfRisks']] = gul_inputs_df[['building_id', 'NumberOfBuildings']]
+    gul_inputs_df.loc[gul_inputs_df['IsAggregate'] == 0, ['risk_id', 'NumberOfRisks']] = 1, 1
+    gul_inputs_df.loc[gul_inputs_df['NumberOfRisks'] == 0, 'NumberOfRisks'] = 1
 
     # set 'disagg_id', `item_id` and `coverage_id`
     gul_inputs_df['item_id'] = factorize_ndarray(

--- a/oasislmf/preparation/gul_inputs.py
+++ b/oasislmf/preparation/gul_inputs.py
@@ -41,7 +41,9 @@ VALID_OASIS_GROUP_COLS = [
     'peril_id',
     'coverage_id',
     'coverage_type_id',
-    'peril_correlation_group'
+    'peril_correlation_group',
+    'building_id',
+    'risk_id'
 ]
 
 PERIL_CORRELATION_GROUP_COL = 'peril_correlation_group'

--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -472,9 +472,6 @@ def get_il_input_items(
     gul_inputs_df.rename(columns={'item_id': 'gul_input_id'}, inplace=True)
     # adjust tiv columns and name them as their coverage id
     gul_inputs_df.rename(columns=tiv_terms, inplace=True)
-    gul_inputs_df[['risk_id', 'NumberOfRisks']] = gul_inputs_df[['building_id', 'NumberOfBuildings']]
-    gul_inputs_df.loc[gul_inputs_df['IsAggregate'] == 0, ['risk_id', 'NumberOfRisks']] = 1, 1
-    gul_inputs_df.loc[gul_inputs_df['NumberOfRisks'] == 0, 'NumberOfRisks'] = 1
 
     # initialization
     agg_keys = set()

--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -472,6 +472,9 @@ def get_il_input_items(
     gul_inputs_df.rename(columns={'item_id': 'gul_input_id'}, inplace=True)
     # adjust tiv columns and name them as their coverage id
     gul_inputs_df.rename(columns=tiv_terms, inplace=True)
+    gul_inputs_df[['risk_id', 'NumberOfRisks']] = gul_inputs_df[['building_id', 'NumberOfBuildings']]
+    gul_inputs_df.loc[gul_inputs_df['IsAggregate'] == 0, ['risk_id', 'NumberOfRisks']] = 1, 1
+    gul_inputs_df.loc[gul_inputs_df['NumberOfRisks'] == 0, 'NumberOfRisks'] = 1
 
     # initialization
     agg_keys = set()


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Extended field list for correlation groupings for disaggregated risks

In order to add functionality to change the way hazard and damage can be correlated for risks which are disaggregated by NumberOfBuildings>1, we have added support for more internal Oasis fields 'risk_id' and 'building_id' which can be used in conjunction with PortNumber, AccNumber, LocNumber in (model_settings) data settings so that subrisk hazard and damage may be correlated or uncorrelated as specified by the model provider.

The usage of these fields to achieve specific correlation behaviour for disaggregated risks will be documented in https://oasislmf.github.io/sections/correlation.html and available in LTS - 2.3 and later.

Default data settings will not be changed to make use of these fields. The fields must be specified in data settings in model settings in order for them to affect correlation behaviour. 

## Usage example (model settings json)
```
    "data_settings": {
    "damage_group_fields": ["PortNumber", "AccNumber", "LocNumber","building_id"],     
    "hazard_group_fields": ["PortNumber", "AccNumber", "LocNumber", "building_id"]
    }

    "data_settings": {
    "damage_group_fields": ["PortNumber", "AccNumber", "LocNumber","risk_id"],     
    "hazard_group_fields": ["PortNumber", "AccNumber", "LocNumber", "risk_id"]
    }

    "data_settings": {
    "damage_group_fields": ["PortNumber", "AccNumber", "LocNumber","risk_id"],     
    "hazard_group_fields": ["PortNumber", "AccNumber", "LocNumber", "building_id"]
    }
```
Fixes #1491 
<!--end_release_notes-->
