### PR TITLE
Python 3.12 installation issue 

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -48,6 +48,7 @@ jobs:
           - { python-version: "3.9", pkg-version: "", upload-cov: false }
           - { python-version: "3.10", pkg-version: "", upload-cov: false }
           - { python-version: "3.11", pkg-version: "", upload-cov: false }
+          - { python-version: "3.12", pkg-version: "", upload-cov: false }
           - { python-version: "3.11", pkg-version: "", upload-cov: true }
 
     steps:

--- a/requirements-package.in
+++ b/requirements-package.in
@@ -6,7 +6,7 @@ fastparquet>=0.3.1
 msgpack
 numba>=0.57.0
 numexpr
-numpy<1.26,>=1.18
+numpy>=1.18
 ods-tools>=3.2.0
 oasis-data-manager>=0.1.1
 pandas>=1.0.3,!=1.1.0,!=1.1.1,<2.2.0


### PR DESCRIPTION
<!--start_release_notes-->
### Fixed Python 3.12 installation issue
* Unpinned Numpy 
* Added testing for Python 3.12

As outlined in https://github.com/OasisLMF/OasisLMF/issues/1499  The package pin `numpy<1.26` causes installation issues when running python version 3.12. Fixed by removing that numpy requirement.    

<!--end_release_notes-->
