### PR TITLE
fix pla reader

### DIFF
--- a/oasislmf/pytools/pla/streams.py
+++ b/oasislmf/pytools/pla/streams.py
@@ -54,7 +54,6 @@ def read_buffer(byte_mv, cursor, valid_buff, event_id, item_id, items_amps, plaf
                 break
             event_id, cursor = mv_read(byte_mv, cursor, oasis_int, oasis_int_size)
             item_id, cursor = mv_read(byte_mv, cursor, oasis_int, oasis_int_size)
-
             ##### do new item setup #####
             factor = plafactors.get((event_id, items_amps[item_id]), default_factor)
             ##########
@@ -70,13 +69,17 @@ class PlaReader(EventReader):
         self.default_factor = default_factor
         self.out_byte_mv = np.empty(PIPE_CAPACITY, dtype='b')
         self.out_cursor = np.empty(1, dtype='i4')
+
+        self.item_id = 0
+
         self.logger = logger
 
     def read_buffer(self, byte_mv, cursor, valid_buff, event_id, item_id):
-        return read_buffer(
-            byte_mv, cursor, valid_buff, event_id, item_id,
+        cursor, event_id, self.item_id, yield_event = read_buffer(
+            byte_mv, cursor, valid_buff, event_id, self.item_id,
             self.items_amps, self.plafactors, self.default_factor, self.out_byte_mv, self.out_cursor
         )
+        return cursor, event_id, self.item_id, yield_event
 
 
 def read_and_write_streams(

--- a/oasislmf/pytools/pla/streams.py
+++ b/oasislmf/pytools/pla/streams.py
@@ -70,16 +70,17 @@ class PlaReader(EventReader):
         self.out_byte_mv = np.empty(PIPE_CAPACITY, dtype='b')
         self.out_cursor = np.empty(1, dtype='i4')
 
+        self.event_id = 0
         self.item_id = 0
 
         self.logger = logger
 
     def read_buffer(self, byte_mv, cursor, valid_buff, event_id, item_id):
-        cursor, event_id, self.item_id, yield_event = read_buffer(
-            byte_mv, cursor, valid_buff, event_id, self.item_id,
+        cursor, self.event_id, self.item_id, yield_event = read_buffer(
+            byte_mv, cursor, valid_buff, self.event_id, self.item_id,
             self.items_amps, self.plafactors, self.default_factor, self.out_byte_mv, self.out_cursor
         )
-        return cursor, event_id, self.item_id, yield_event
+        return cursor, self.event_id, self.item_id, yield_event
 
 
 def read_and_write_streams(


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Fix plapy reader creating negative event in output
Plapy reader is a bit different from the other reader using the generic approach because it return all events at ones even if not finished.
This was not handle properly for big even. This fix remediate it by keeping in memory the last event and item id and updating the read and write memory view 

<!--end_release_notes-->
