### PR TITLE
Fix error handling for failed file loading in 'get_dataframe'

### DIFF
--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -441,6 +441,9 @@ def get_dataframe(
                         precise_float=(True if float_precision == 'high' else False),
                         encoding=use_encoding
                     )
+            except UnicodeDecodeError as e:
+                raise e   
+
             except (ValueError, OSError) as e:
                 error_msg = f'Failed to load "{src_fp}", ' if src_fp else f'Failed to load "{src_buf}", '
                 if empty_data_error_msg:

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -442,7 +442,7 @@ def get_dataframe(
                         encoding=use_encoding
                     )
             except UnicodeDecodeError as e:
-                raise e   
+                raise e
 
             except (ValueError, OSError) as e:
                 error_msg = f'Failed to load "{src_fp}", ' if src_fp else f'Failed to load "{src_buf}", '

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -466,7 +466,6 @@ def get_dataframe(
         else:
             raise OasisException('Failed to load DataFrame due to Encoding error', e)
 
-
     if len(df) == 0:
         raise OasisException(empty_data_error_msg)
 

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -413,33 +413,40 @@ def get_dataframe(
         memory_map = memory_map and (use_encoding == 'utf-8')
 
         if src_fp or src_buf:
-            if src_type == 'csv':
-                # Find flexible fields in loc file and set their data types to that of
-                # FlexiLocZZZ
-                if 'FlexiLocZZZ' in col_dtypes.keys():
-                    headers = list(pd.read_csv(src_fp, encoding=use_encoding, low_memory=low_memory).head(0))
-                    for flexiloc_col in filter(re.compile('^FlexiLoc').match, headers):
-                        col_dtypes[flexiloc_col] = col_dtypes['FlexiLocZZZ']
-                df = pd.read_csv(
-                    src_fp or src_buf,
-                    float_precision=float_precision,
-                    memory_map=memory_map,
-                    low_memory=low_memory,
-                    keep_default_na=False,
-                    na_values=na_values,
-                    dtype=col_dtypes,
-                    encoding=use_encoding,
-                    quotechar='"',
-                    skipinitialspace=True,
-                )
-            elif src_type == 'parquet':
-                df = pd.read_parquet(src_fp or src_buf)
-            elif src_type == 'json':
-                df = pd.read_json(
-                    src_fp or src_buf,
-                    precise_float=(True if float_precision == 'high' else False),
-                    encoding=use_encoding
-                )
+            try:
+                if src_type == 'csv':
+                    # Find flexible fields in loc file and set their data types to that of
+                    # FlexiLocZZZ
+                    if 'FlexiLocZZZ' in col_dtypes.keys():
+                        headers = list(pd.read_csv(src_fp, encoding=use_encoding, low_memory=low_memory).head(0))
+                        for flexiloc_col in filter(re.compile('^FlexiLoc').match, headers):
+                            col_dtypes[flexiloc_col] = col_dtypes['FlexiLocZZZ']
+                    df = pd.read_csv(
+                        src_fp or src_buf,
+                        float_precision=float_precision,
+                        memory_map=memory_map,
+                        low_memory=low_memory,
+                        keep_default_na=False,
+                        na_values=na_values,
+                        dtype=col_dtypes,
+                        encoding=use_encoding,
+                        quotechar='"',
+                        skipinitialspace=True,
+                    )
+                elif src_type == 'parquet':
+                    df = pd.read_parquet(src_fp or src_buf)
+                elif src_type == 'json':
+                    df = pd.read_json(
+                        src_fp or src_buf,
+                        precise_float=(True if float_precision == 'high' else False),
+                        encoding=use_encoding
+                    )
+            except (ValueError, OSError) as e:
+                error_msg = f'Failed to load "{src_fp}", ' if src_fp else f'Failed to load "{src_buf}", '
+                if empty_data_error_msg:
+                    error_msg += empty_data_error_msg
+                raise OasisException(error_msg, e)
+
         elif isinstance(src_data, list) and src_data:
             df = pd.DataFrame(data=src_data)
         elif isinstance(src_data, pd.DataFrame):
@@ -458,6 +465,7 @@ def get_dataframe(
                 encoding=detected_encoding)
         else:
             raise OasisException('Failed to load DataFrame due to Encoding error', e)
+
 
     if len(df) == 0:
         raise OasisException(empty_data_error_msg)


### PR DESCRIPTION
<!--start_release_notes-->
### Fix  error handling for failed file loading in 'get_dataframe'
In some cases a keys.csv file is created as an empty file, so no header.  This causes the following error trace:
[no-keys-return_no-catch.txt](https://github.com/OasisLMF/OasisLMF/files/15414735/no-keys-return_no-catch.txt)

Added exception a try catch to return the following message instead: 
```
Keys successful: <path>/input/keys.csv generated with 0 items
Keys errors: <path>/input/keys-errors.csv generated with 60 items
  0%|                                                                                                                   | 0/2 [00:00<?, ?it/s]
Failed to load "<path>/input/keys.csv", No successful lookup results found in the keys file - Check the `keys-errors.csv` file for details. 
 File path: <path>/input/keys-errors.csv, ValueError: cannot mmap an empty file

```

<!--end_release_notes-->
