### PR TITLE
Backport 1.27.x -Improve speed and memory usage of file preparation

### DIFF
--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -9,7 +9,6 @@ import json
 import os
 from pathlib import Path
 from typing import List
-import numpy as np
 import pandas as pd
 
 from oasislmf.computation.base import ComputationStep
@@ -235,12 +234,12 @@ class GenerateFiles(ComputationStep):
             # Assume empty file on read error.
             keys_errors_df = pd.DataFrame(columns=['locid'])
 
-        returned_locid_df = np.union1d(keys_errors_df['locid'], keys_df['locid'])
+        returned_locid = set(keys_errors_df['locid']).union(set(keys_df['locid']))
         del keys_errors_df
 
-        missing_ids = np.setdiff1d(location_df['loc_id'].unique(), returned_locid_df)
+        missing_ids = set(location_df['loc_id']).difference(returned_locid)
         if len(missing_ids) > 0:
-            raise OasisException(f'Lookup error: missing "loc_id" values from keys return: {missing_ids}')
+            raise OasisException(f'Lookup error: missing "loc_id" values from keys return: {list(missing_ids)}')
 
         # Columns from loc file to assign group_id
         model_damage_group_fields = []

--- a/oasislmf/preparation/gul_inputs.py
+++ b/oasislmf/preparation/gul_inputs.py
@@ -319,6 +319,7 @@ def get_gul_input_items(
         cov_type_group.loc[:, ['tiv'] + list(column_mapping_dict.values())]
         terms_found.update(column_mapping_dict.values())
         cov_type_group['coverage_type_id'] = cov_type
+<<<<<<< HEAD
         gul_inputs_reformatted_chunks.append(cov_type_group)
     # Concatenate chunks. Sort by index to preserve item_id order in generated outputs compared
     # to original code.
@@ -328,6 +329,28 @@ def get_gul_input_items(
     term_int_found = list(set(gul_inputs_df.columns).intersection(set(term_cols_ints + terms_ints)))
     gul_inputs_df[term_int_found] = gul_inputs_df[term_int_found].fillna(0)
     # Set default values and data types for BI coverage boolean, TIV, deductibles and limit
+=======
+        terms_found.update(cols_by_cov_type[cov_type]['column_mapping_dict'].values())
+        if do_disaggregation:
+            # if NumberOfBuildings == 0: still add one entry
+            disagg_df_chunk = (cov_type_group.reset_index()
+                               .join(pd.DataFrame({'building_id': range(1, max(number_of_buildings, 1) + 1)}), how='cross')
+                               .set_index('index'))
+        else:
+            disagg_df_chunk = cov_type_group.copy().assign(building_id=1)
+
+        gul_inputs_reformatted_chunks.append(disagg_df_chunk)
+
+    # concatenate all the unpacked chunks. Sort by index to preserve `item_id` order as in the original code
+    gul_inputs_df = (
+        pd.concat(gul_inputs_reformatted_chunks)
+        .fillna(value={c: 0 for c in terms_found})
+        .sort_index()
+        .reset_index(drop=True)
+        .fillna(value={c: 0 for c in set(gul_inputs_df.columns).intersection(set(term_cols_ints + terms_ints))})
+    )
+    # set default values and data types for BI coverage boolean, TIV, deductibles and limit
+>>>>>>> 728a710ff (improve perf of file preparation (#1509))
     dtypes = {
         **{t: 'uint8' for t in term_cols_ints + terms_ints},
         **{'is_bi_coverage': 'bool'}

--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -139,9 +139,20 @@ def set_calc_rule_ids(
         err_msg = 'Calculation Rule mapping error, non-matching keys:\n'
         no_match_keys = il_inputs_calc_rules_df.loc[il_inputs_calc_rules_df.calcrule_id == 0].id_key.unique()
 
+<<<<<<< HEAD
         err_msg += '   {}\n'.format(tuple(terms_indicators + types_and_codes))
         for key_id in no_match_keys:
             err_msg += '   {}\n'.format(key_id)
+=======
+    calcrule_ids = (
+        il_inputs_calc_rules_df[merge_col].reset_index()
+        .merge(calc_rules_df[merge_col + ['calcrule_id']].drop_duplicates(), how='left', on=merge_col)
+    ).set_index('index')['calcrule_id'].fillna(0)
+
+    if 0 in calcrule_ids.unique():
+        no_match_keys = il_inputs_calc_rules_df.loc[calcrule_ids == 0, ['PortNumber', 'AccNumber', 'LocNumber'] + merge_col].drop_duplicates()
+        err_msg = 'Calculation Rule mapping error, non-matching keys:\n{}'.format(no_match_keys)
+>>>>>>> 728a710ff (improve perf of file preparation (#1509))
         raise OasisException(err_msg)
 
     return il_inputs_calc_rules_df['calcrule_id'].values


### PR DESCRIPTION
<!--start_release_notes-->
### Improve speed and memory usage of file preparation - 1.27.x
PR https://github.com/OasisLMF/OasisLMF/pull/1509 tagged for backport to 1.27.x but cherry-pick looks messy ~ better to create a new PR targeting this version? 


<!--end_release_notes-->
