### PR TITLE
event ranges

### DIFF
--- a/oasislmf/execution/bin.py
+++ b/oasislmf/execution/bin.py
@@ -367,12 +367,12 @@ def get_event_range(event_range):
             rng = er.split('-')
             e_from = int(rng[0])
             e_to = int(rng[1])
-            lst_events.append(range(e_from,e_to+1))
+            lst_events.append(range(e_from, e_to + 1))
         else:
             e = int(er)
             lst_events.append(e)
             
-    return(lst_events)
+    return (lst_events)
 
 
 @oasis_log

--- a/oasislmf/execution/bin.py
+++ b/oasislmf/execution/bin.py
@@ -352,6 +352,7 @@ def _leccalc_selected(analysis_settings):
 
     return any([is_in_gul, is_in_il, is_in_ri])
 
+
 def get_event_range(event_range):
     """
     Parses event range string and returns a list of event ids.
@@ -371,7 +372,7 @@ def get_event_range(event_range):
         else:
             e = int(er)
             lst_events.append(e)
-            
+
     return (lst_events)
 
 

--- a/oasislmf/execution/bin.py
+++ b/oasislmf/execution/bin.py
@@ -352,6 +352,28 @@ def _leccalc_selected(analysis_settings):
 
     return any([is_in_gul, is_in_il, is_in_ri])
 
+def get_event_range(event_range):
+    """
+    Parses event range string and returns a list of event ids.
+
+    :param event_range: string representation of event range in format '1-5,10,89-100'
+    :type event_range: str
+    """
+    lst_event_range = event_range.split(",")
+    lst_events = []
+
+    for er in lst_event_range:
+        if '-' in er:
+            rng = er.split('-')
+            e_from = int(rng[0])
+            e_to = int(rng[1])
+            lst_events.append(range(e_from,e_to+1))
+        else:
+            e = int(er)
+            lst_events.append(e)
+            
+    return(lst_events)
+
 
 @oasis_log
 def prepare_run_inputs(analysis_settings, run_dir, model_storage: BaseStorage, ri=False):
@@ -367,9 +389,16 @@ def prepare_run_inputs(analysis_settings, run_dir, model_storage: BaseStorage, r
     try:
         model_settings = analysis_settings.get('model_settings', {})
         # Prepare events.bin
-        if analysis_settings.get('event_ids'):
+        if analysis_settings.get('event_ids') or analysis_settings.get('event_ranges'):
             # Create events file from user input
-            _create_events_bin(run_dir, analysis_settings.get('event_ids'))
+            event_ids = []
+            if analysis_settings.get('event_ids'):
+                event_ids.extend(analysis_settings.get('event_ids'))
+            if analysis_settings.get('event_ranges'):
+                event_range = get_event_range(analysis_settings.get('event_ranges'))
+                event_ids.extend(event_range)
+            event_ids = list(set(event_ids))
+            _create_events_bin(run_dir, event_ids)
         else:
             # copy selected event set from static
             _prepare_input_bin(run_dir, 'events', model_settings, model_storage, setting_key='event_set', ri=ri)

--- a/oasislmf/execution/bin.py
+++ b/oasislmf/execution/bin.py
@@ -368,7 +368,7 @@ def get_event_range(event_range):
             rng = er.split('-')
             e_from = int(rng[0])
             e_to = int(rng[1])
-            lst_events.append(range(e_from, e_to + 1))
+            lst_events.extend(range(e_from, e_to + 1))
         else:
             e = int(er)
             lst_events.append(e)


### PR DESCRIPTION
#1402 

<!--start_release_notes-->
### Support for ranges of events in analysis settings
Adding support for additional ranges of events in analysis settings, in addition to the list of event ids which can already be provided.

Event id ranges should be submitted using the new "event_ranges" option in analysis settings

The string data will take the format "1-4,8,89-94" which will be parsed and an event list created.

It can be used in combination with the existing list, and unique values will be established
<!--end_release_notes-->
