### PR TITLE
add post file gen and pre loss calculation step

### DIFF
--- a/oasislmf/cli/model.py
+++ b/oasislmf/cli/model.py
@@ -1,6 +1,8 @@
 __all__ = [
     'GenerateExposurePreAnalysisCmd',
     'GenerateKeysCmd',
+    'GeneratePostFileGenCmd',
+    'GeneratePrelossCmd',
     'GenerateLossesCmd',
     'GenerateLossesPartialCmd',
     'GenerateLossesOutputCmd',
@@ -21,6 +23,24 @@ class GenerateExposurePreAnalysisCmd(OasisComputationCommand):
     """
     formatter_class = RawDescriptionHelpFormatter
     computation_name = 'ExposurePreAnalysis'
+
+
+class GeneratePostFileGenCmd(OasisComputationCommand):
+    """
+    Generate a new EOD from original one by specifying a model specific pre-analysis hook for exposure modification
+    see ExposurePreAnalysis for more detail
+    """
+    formatter_class = RawDescriptionHelpFormatter
+    computation_name = 'PostFileGen'
+
+
+class GeneratePrelossCmd(OasisComputationCommand):
+    """
+    Generate a new EOD from original one by specifying a model specific pre-analysis hook for exposure modification
+    see ExposurePreAnalysis for more detail
+    """
+    formatter_class = RawDescriptionHelpFormatter
+    computation_name = 'PreLoss'
 
 
 class GenerateKeysCmd(OasisComputationCommand):
@@ -101,6 +121,8 @@ class ModelCmd(OasisBaseCommand):
         'generate-exposure-pre-analysis': GenerateExposurePreAnalysisCmd,
         'generate-keys': GenerateKeysCmd,
         'generate-oasis-files': GenerateOasisFilesCmd,
+        'generate-post-file-gen': GeneratePostFileGenCmd,
+        'generate-pre-loss': GeneratePrelossCmd,
         'generate-losses': GenerateLossesCmd,
         'generate-losses-chunk': GenerateLossesPartialCmd,
         'generate-losses-output': GenerateLossesOutputCmd,

--- a/oasislmf/computation/hooks/post_file_gen.py
+++ b/oasislmf/computation/hooks/post_file_gen.py
@@ -1,0 +1,104 @@
+__all__ = [
+    'PostFileGen'
+]
+
+import json
+import pathlib
+
+from ..base import ComputationStep
+from ...utils.data import get_exposure_data
+from ...utils.inputs import str2bool
+from ...utils.path import get_custom_module
+from ...utils.exceptions import OasisException
+
+
+class PostFileGen(ComputationStep):
+    """
+    Computation step that will be call just after oasis file generation.
+    On the platform it will be called on a single machine before the files are copied on the several worker for the loss calculation
+    Add the ability to specify a model specific step that will modify or expand on the loss calculation input file
+    """
+    step_params = [{'name': 'post_file_gen_module', 'required': True, 'is_path': True, 'pre_exist': True,
+                    'help': 'post file generation lookup module path'},
+                   {'name': 'post_file_gen_class_name', 'default': 'PostFileGen',
+                    'help': 'Name of the class to use for the pre loss calculation'},
+                   {'name': 'post_file_gen_setting_json', 'is_path': True, 'pre_exist': True,
+                    'help': 'post file generation config JSON file path'},
+                   {'name': 'oed_schema_info', 'is_path': True, 'pre_exist': True, 'help': 'path to custom oed_schema'},
+                   {'name': 'oed_location_csv', 'is_path': True, 'pre_exist': True, 'help': 'Source location CSV file path'},
+                   {'name': 'oed_accounts_csv', 'is_path': True, 'pre_exist': True, 'help': 'Source accounts CSV file path'},
+                   {'name': 'oed_info_csv', 'is_path': True, 'pre_exist': True, 'help': 'Reinsurance info. CSV file path'},
+                   {'name': 'oed_scope_csv', 'is_path': True, 'pre_exist': True, 'help': 'Reinsurance scope CSV file path'},
+                   {'name': 'check_oed', 'type': str2bool, 'const': True, 'nargs': '?', 'default': True, 'help': 'if True check input oed files'},
+                   {'name': 'oasis_files_dir', 'flag': '-o', 'is_path': True, 'pre_exist': False,
+                    'help': 'Path to the directory in which to generate the Oasis files'},
+                   {'name': 'location', 'type': str, 'nargs': '+', 'help': 'A set of locations to include in the files'},
+                   {'name': 'portfolio', 'type': str, 'nargs': '+', 'help': 'A set of portfolios to include in the files'},
+                   {'name': 'account', 'type': str, 'nargs': '+', 'help': 'A set of locations to include in the files'},
+                   {'name': 'base_df_engine', 'type': str, 'default': 'oasis_data_manager.df_reader.reader.OasisPandasReader',
+                    'help': 'The default dataframe reading engine to use when loading files'},
+                   {'name': 'exposure_df_engine', 'type': str, 'default': None,
+                    'help': 'The dataframe reading engine to use when loading exposure files'},
+                   {'name': 'model_df_engine', 'type': str, 'default': None, 'help': 'The dataframe reading engine to use when loading model files'},
+                   {'name': 'model_data_dir', 'flag': '-d', 'is_path': True, 'pre_exist': True, 'help': 'Model data directory path'},
+                   {'name': 'analysis_settings_json', 'flag': '-a', 'is_path': True, 'pre_exist': True,
+                    'help': 'Analysis settings JSON file path'},
+                   ]
+
+    run_dir_key = 'pre-loss'
+
+    def get_exposure_data_config(self):
+        return {
+            'location': self.oed_location_csv,
+            'account': self.oed_accounts_csv,
+            'ri_info': self.oed_info_csv,
+            'ri_scope': self.oed_scope_csv,
+            'oed_schema_info': self.oed_schema_info,
+            'check_oed': self.check_oed,
+            'use_field': True,
+            'location_numbers': self.location,
+            'portfolio_numbers': self.portfolio,
+            'account_numbers': self.account,
+            'base_df_engine': self.base_df_engine,
+            'exposure_df_engine': self.exposure_df_engine,
+        }
+
+    def run(self):
+        """
+        import post_file_gen_module and call the run method
+        """
+        exposure_data = get_exposure_data(self, add_internal_col=True)
+        kwargs = dict()
+
+        # If given a value for 'oasis_files_dir' then use that directly
+        if self.oasis_files_dir:
+            input_dir = self.oasis_files_dir
+        else:
+            input_dir = self.get_default_run_dir()
+            pathlib.Path(input_dir).mkdir(parents=True, exist_ok=True)
+
+        kwargs['exposure_data'] = exposure_data
+        kwargs['input_dir'] = input_dir
+        kwargs['model_data_dir'] = self.model_data_dir
+        kwargs['analysis_settings_json'] = self.analysis_settings_json
+        kwargs['logger'] = self.logger
+
+        if self.post_file_gen_setting_json:
+            with open(self.post_file_gen_setting_json) as post_file_gen_setting_file:
+                kwargs['post_file_gen_setting'] = json.load(post_file_gen_setting_file)
+        else:
+            kwargs['post_file_gen_setting'] = {}
+
+        _module = get_custom_module(self.post_file_gen_module, 'post file gen module path')
+
+        try:
+            _class = getattr(_module, self.post_file_gen_class_name)
+        except AttributeError as e:
+            raise OasisException(f"class {self.post_file_gen_class_name} "
+                                 f"is not defined in module {self.post_file_gen_module}") from e.__cause__
+
+        _class_return = _class(**kwargs).run()
+
+        return {
+            "class": _class_return
+        }

--- a/oasislmf/computation/hooks/pre_loss.py
+++ b/oasislmf/computation/hooks/pre_loss.py
@@ -1,0 +1,104 @@
+__all__ = [
+    'PreLoss'
+]
+
+import json
+import pathlib
+
+from ..base import ComputationStep
+from ...utils.data import get_exposure_data
+from ...utils.inputs import str2bool
+from ...utils.path import get_custom_module
+from ...utils.exceptions import OasisException
+
+
+class PreLoss(ComputationStep):
+    """
+    Computation step that will be call just before loss compuation.
+    On the platform it will be called on each machine performing the loss calculation,
+    Add the ability to specify a model specific step that will modify or expand on the loss calculation input file on each worker.
+    """
+    step_params = [{'name': 'pre_loss_module', 'required': True, 'is_path': True, 'pre_exist': True,
+                    'help': 'pre loss calculation lookup module path'},
+                   {'name': 'pre_loss_class_name', 'default': 'PreLoss',
+                    'help': 'Name of the class to use for the pre loss calculation'},
+                   {'name': 'pre_loss_setting_json', 'is_path': True, 'pre_exist': True,
+                    'help': 'pre loss calculation config JSON file path'},
+                   {'name': 'oed_schema_info', 'is_path': True, 'pre_exist': True, 'help': 'path to custom oed_schema'},
+                   {'name': 'oed_location_csv', 'is_path': True, 'pre_exist': True, 'help': 'Source location CSV file path'},
+                   {'name': 'oed_accounts_csv', 'is_path': True, 'pre_exist': True, 'help': 'Source accounts CSV file path'},
+                   {'name': 'oed_info_csv', 'is_path': True, 'pre_exist': True, 'help': 'Reinsurance info. CSV file path'},
+                   {'name': 'oed_scope_csv', 'is_path': True, 'pre_exist': True, 'help': 'Reinsurance scope CSV file path'},
+                   {'name': 'check_oed', 'type': str2bool, 'const': True, 'nargs': '?', 'default': True, 'help': 'if True check input oed files'},
+                   {'name': 'oasis_files_dir', 'flag': '-o', 'is_path': True, 'pre_exist': False,
+                    'help': 'Path to the directory in which to generate the Oasis files'},
+                   {'name': 'location', 'type': str, 'nargs': '+', 'help': 'A set of locations to include in the files'},
+                   {'name': 'portfolio', 'type': str, 'nargs': '+', 'help': 'A set of portfolios to include in the files'},
+                   {'name': 'account', 'type': str, 'nargs': '+', 'help': 'A set of locations to include in the files'},
+                   {'name': 'base_df_engine', 'type': str, 'default': 'oasis_data_manager.df_reader.reader.OasisPandasReader',
+                    'help': 'The default dataframe reading engine to use when loading files'},
+                   {'name': 'exposure_df_engine', 'type': str, 'default': None,
+                    'help': 'The dataframe reading engine to use when loading exposure files'},
+                   {'name': 'model_df_engine', 'type': str, 'default': None, 'help': 'The dataframe reading engine to use when loading model files'},
+                   {'name': 'model_data_dir', 'flag': '-d', 'is_path': True, 'pre_exist': True, 'help': 'Model data directory path'},
+                   {'name': 'analysis_settings_json', 'flag': '-a', 'is_path': True, 'pre_exist': True,
+                    'help': 'Analysis settings JSON file path'},
+                   ]
+
+    run_dir_key = 'pre-loss'
+
+    def get_exposure_data_config(self):
+        return {
+            'location': self.oed_location_csv,
+            'account': self.oed_accounts_csv,
+            'ri_info': self.oed_info_csv,
+            'ri_scope': self.oed_scope_csv,
+            'oed_schema_info': self.oed_schema_info,
+            'check_oed': self.check_oed,
+            'use_field': True,
+            'location_numbers': self.location,
+            'portfolio_numbers': self.portfolio,
+            'account_numbers': self.account,
+            'base_df_engine': self.base_df_engine,
+            'exposure_df_engine': self.exposure_df_engine,
+        }
+
+    def run(self):
+        """
+        import pre_loss_module and call the run method
+        """
+        exposure_data = get_exposure_data(self, add_internal_col=True)
+        kwargs = dict()
+
+        # If given a value for 'oasis_files_dir' then use that directly
+        if self.oasis_files_dir:
+            input_dir = self.oasis_files_dir
+        else:
+            input_dir = self.get_default_run_dir()
+            pathlib.Path(input_dir).mkdir(parents=True, exist_ok=True)
+
+        kwargs['exposure_data'] = exposure_data
+        kwargs['input_dir'] = input_dir
+        kwargs['model_data_dir'] = self.model_data_dir
+        kwargs['analysis_settings_json'] = self.analysis_settings_json
+        kwargs['logger'] = self.logger
+
+        if self.pre_loss_setting_json:
+            with open(self.pre_loss_setting_json) as pre_loss_setting_file:
+                kwargs['pre_loss_setting'] = json.load(pre_loss_setting_file)
+        else:
+            kwargs['pre_loss_setting'] = {}
+
+        _module = get_custom_module(self.pre_loss_module, 'pre loss calculation module path')
+
+        try:
+            _class = getattr(_module, self.pre_loss_class_name)
+        except AttributeError as e:
+            raise OasisException(f"class {self.pre_loss_class_name} "
+                                 f"is not defined in module {self.pre_loss_module}") from e.__cause__
+
+        _class_return = _class(**kwargs).run()
+
+        return {
+            "class": _class_return
+        }

--- a/oasislmf/computation/run/generate_files.py
+++ b/oasislmf/computation/run/generate_files.py
@@ -23,6 +23,8 @@ class GenerateOasisFiles(ComputationStep):
     step_params = [
         {'name': 'exposure_pre_analysis_module', 'required': False, 'is_path': True,
             'pre_exist': True, 'help': 'Exposure Pre-Analysis lookup module path'},
+        {'name': 'post_file_gen_module', 'required': False, 'is_path': True,
+         'pre_exist': True, 'help': 'post-file gen hook module path'},
     ]
     # Add params from each sub command not in 'step_params'
     chained_commands = [

--- a/oasislmf/computation/run/generate_files.py
+++ b/oasislmf/computation/run/generate_files.py
@@ -10,6 +10,7 @@ from tqdm import tqdm
 from ..base import ComputationStep
 from ..generate.files import GenerateFiles
 from ..hooks.pre_analysis import ExposurePreAnalysis
+from ..hooks.post_file_gen import PostFileGen
 from ...utils.data import get_exposure_data
 
 
@@ -25,6 +26,7 @@ class GenerateOasisFiles(ComputationStep):
     ]
     # Add params from each sub command not in 'step_params'
     chained_commands = [
+        PostFileGen,
         GenerateFiles,
         ExposurePreAnalysis,
     ]
@@ -63,6 +65,9 @@ class GenerateOasisFiles(ComputationStep):
             cmds = [(ExposurePreAnalysis, self.kwargs), (GenerateFiles, self.kwargs)]
         else:
             cmds = [(GenerateFiles, self.kwargs)]
+
+        if self.post_file_gen_module:
+            cmds += [(PostFileGen, self.kwargs)]
 
         with tqdm(total=len(cmds)) as pbar:
             for cmd in cmds:

--- a/oasislmf/computation/run/generate_losses.py
+++ b/oasislmf/computation/run/generate_losses.py
@@ -7,6 +7,7 @@ from tqdm import tqdm
 
 from ..base import ComputationStep
 from ..generate.losses import GenerateLosses
+from ..hooks.pre_loss import PreLoss
 from ..hooks.post_analysis import PostAnalysis
 
 
@@ -17,11 +18,14 @@ class GenerateOasisLosses(ComputationStep):
 
     # Override params
     step_params = [
+        {'name': 'pre_loss_module', 'required': False, 'is_path': True, 'pre_exist': True,
+         'help': 'Pre-Loss module path'},
         {'name': 'post_analysis_module', 'required': False, 'is_path': True, 'pre_exist': True,
          'help': 'Post-Analysis module path'},
     ]
     # Add params from each sub command not in 'step_params'
     chained_commands = [
+        PreLoss,
         GenerateLosses,
         PostAnalysis,
     ]
@@ -34,7 +38,11 @@ class GenerateOasisLosses(ComputationStep):
         self.kwargs['model_run_dir'] = self.model_run_dir
 
         # Run chain
-        cmds = [(GenerateLosses, self.kwargs)]
+        if self.pre_loss_module:
+            cmds = [(PreLoss, self.kwargs)]
+        else:
+            cmds = []
+        cmds += [(GenerateLosses, self.kwargs)]
         if self.post_analysis_module:
             cmds += [(PostAnalysis, self.kwargs)]
 

--- a/oasislmf/computation/run/model.py
+++ b/oasislmf/computation/run/model.py
@@ -13,6 +13,8 @@ from ..generate.files import GenerateFiles
 from ..generate.losses import GenerateLosses
 from ..hooks.pre_analysis import ExposurePreAnalysis
 from ..hooks.post_analysis import PostAnalysis
+from ..hooks.post_file_gen import PostFileGen
+from ..hooks.pre_loss import PreLoss
 
 from ...utils.data import get_exposure_data
 from ...utils.path import empty_dir
@@ -31,10 +33,16 @@ class RunModel(ComputationStep):
             'pre_exist': True, 'help': 'Exposure Pre-Analysis lookup module path'},
         {'name': 'post_analysis_module', 'required': False, 'is_path': True, 'pre_exist': True,
          'help': 'Post-Analysis module path'},
+        {'name': 'pre_loss_module', 'required': False, 'is_path': True,
+         'pre_exist': True, 'help': 'pre-loss hook module path'},
+        {'name': 'post_file_gen_module', 'required': False, 'is_path': True,
+         'pre_exist': True, 'help': 'post-file gen hook module path'},
     ]
     # Add params from each sub command not in 'step_params'
     chained_commands = [
         GenerateLosses,
+        PostFileGen,
+        PreLoss,
         GenerateFiles,
         ExposurePreAnalysis,
         PostAnalysis,
@@ -77,7 +85,12 @@ class RunModel(ComputationStep):
         cmds = []
         if self.exposure_pre_analysis_module:
             cmds += [(ExposurePreAnalysis, self.kwargs)]
-        cmds += [(GenerateFiles, self.kwargs), (GenerateLosses, self.kwargs)]
+        cmds += [(GenerateFiles, self.kwargs)]
+        if self.post_file_gen_module:
+            cmds += [(PostFileGen, self.kwargs)]
+        if self.pre_loss_module:
+            cmds += [(PreLoss, self.kwargs)]
+        cmds += [(GenerateLosses, self.kwargs)]
         if self.post_analysis_module:
             cmds += [(PostAnalysis, self.kwargs)]
 

--- a/oasislmf/manager.py
+++ b/oasislmf/manager.py
@@ -17,6 +17,8 @@ from oasislmf.computation.generate.losses import (GenerateLosses,
                                                   GenerateLossesPartial)
 from oasislmf.computation.helper.autocomplete import HelperTabComplete
 from oasislmf.computation.hooks.pre_analysis import ExposurePreAnalysis
+from oasislmf.computation.hooks.pre_loss import PreLoss
+from oasislmf.computation.hooks.post_file_gen import PostFileGen
 from oasislmf.computation.hooks.post_analysis import PostAnalysis
 from oasislmf.computation.run.exposure import RunExposure, RunFmTest
 from oasislmf.computation.run.generate_files import GenerateOasisFiles
@@ -34,6 +36,8 @@ class OasisManager(object):
         ExposurePreAnalysis,
         GenerateFiles,
         GenerateOasisFiles,
+        PostFileGen,
+        PreLoss,
         GenerateOasisLosses,
         GenerateKeys,
         GenerateKeysDeterministic,

--- a/tests/computation/test_run_generate_files.py
+++ b/tests/computation/test_run_generate_files.py
@@ -21,6 +21,7 @@ class TestGenerateFiles(ComputationChecker):
         cls.default_args = cls.manager._params_generate_oasis_files()
         cls.pre_hook_args = cls.manager._params_exposure_pre_analysis()
         cls.gen_files_args = cls.manager._params_generate_files()
+        cls.post_file_gen_args = cls.manager._params_post_file_gen()
 
     def setUp(self):
         # Tempfiles
@@ -42,6 +43,7 @@ class TestGenerateFiles(ComputationChecker):
         expt_combined_args = self.combine_args([
             self.pre_hook_args,
             self.gen_files_args,
+            self.post_file_gen_args
         ])
         self.assertEqual(expt_combined_args, self.default_args)
 

--- a/tests/computation/test_run_model.py
+++ b/tests/computation/test_run_model.py
@@ -23,6 +23,8 @@ class TestRunModel(ComputationChecker):
         cls.default_args = cls.manager._params_run_model()
         cls.pre_hook_args = cls.manager._params_exposure_pre_analysis()
         cls.gen_files_args = cls.manager._params_generate_files()
+        cls.post_file_gen_args = cls.manager._params_post_file_gen()
+        cls.pre_loss_args = cls.manager._params_pre_loss()
         cls.gen_loss_args = cls.manager._params_generate_losses()
         cls.post_hook_args = cls.manager._params_post_analysis()
 
@@ -50,6 +52,8 @@ class TestRunModel(ComputationChecker):
         expt_combined_args = self.combine_args([
             self.pre_hook_args,
             self.gen_files_args,
+            self.post_file_gen_args,
+            self.pre_loss_args,
             self.gen_loss_args,
             self.post_hook_args,
         ])


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### add post file gen and pre loss calculation step
Add the possibility for model developer to add two specific step in model run

- post file gen: part of generate file, happen after the oasis files are generated (single worker on the platform)
- pre loss : part of generate foll, happen before the loss are calculated (each loss calculation worker on the platform)

<!--end_release_notes-->
