### PR TITLE
fix effective deductible applied in minded calculation for calcrule 19

### DIFF
--- a/oasislmf/pytools/fm/policy_extras.py
+++ b/oasislmf/pytools/fm/policy_extras.py
@@ -384,7 +384,7 @@ def calcrule_19(policy, loss_out, loss_in, deductible, over_limit, under_limit):
         if effective_deductible + deductible[i] > policy['deductible_3'] > 0:
             deductible_over_max(i, loss_out, loss_in, deductible, over_limit, under_limit, policy['deductible_3'])
         elif effective_deductible + deductible[i] < policy['deductible_2']:
-            deductible_under_min(i, loss_out, loss_in, deductible, over_limit, under_limit, policy['deductible_2'], policy['deductible_1'])
+            deductible_under_min(i, loss_out, loss_in, deductible, over_limit, under_limit, policy['deductible_2'], effective_deductible)
         else:
             if loss_in[i] > effective_deductible:
                 loss_out[i] = loss_in[i] - effective_deductible

--- a/tests/pytools/fm/test_policy_extra.py
+++ b/tests/pytools/fm/test_policy_extra.py
@@ -314,8 +314,8 @@ def test_calcrule_19():
 
     loss_expected = np.array([10., 13., 20., 20., 25., 30., 0.75, 15., 50])
     deductible_expected = np.array([10., 10., 10., 20., 20., 20., 16.25, 15., 20])
-    over_limit_expected = np.array([0., 0., 0.25, 20., 15., 0., 0., 10., 10])
-    under_limit_expected = np.array([9.75, 16.75, 10., 0., 0., 5., 0.25, 15., 20.])
+    over_limit_expected = np.array([0., 0., 5, 20., 15., 0., 0., 10., 10])
+    under_limit_expected = np.array([5, 12, 10., 0., 0., 5., 0.25, 15., 20.])
 
     assert_array_almost_equal(loss_out, loss_expected)
     assert_array_almost_equal(deductible, deductible_expected)


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Fix issue in calcrule 19 when min deductible is triggered
When % of loss deductible is smaller than the minimum deductible, neither the minimum deductible nor the % of loss deductible gets applied. This overstates gross losses.
the deductible passed to the min deductible calculation was incorrect for calcrule 19, as we passed the percentage instead of the actual deductible, this fix the issue by passing the effective deductible for this calcrule.
<!--end_release_notes-->
