### PR TITLE
Fix Cartesian product issue for RI Fac contract

### DIFF
--- a/oasislmf/preparation/reinsurance_layer.py
+++ b/oasislmf/preparation/reinsurance_layer.py
@@ -238,7 +238,7 @@ def create_risk_level_profile_id(ri_df, profile_map_df, fm_profile_df, reins_typ
                         and row[f'{field}_valid'] and row[f'{field}_x'] != row[f'{field}_y']):
                     return False
             return True
-        profile_map_df.loc[np.unique(filter_df[filter_df.apply(_match, axis=1)]['index']), 'profile_id'] = PASSTHROUGH_PROFILE_ID
+        profile_map_df.loc[np.unique(filter_df.loc[filter_df.apply(_match, axis=1), 'index']), 'profile_id'] = PASSTHROUGH_PROFILE_ID
 
     # Risk level
     layer_filter = reins_type_filter

--- a/oasislmf/preparation/reinsurance_layer.py
+++ b/oasislmf/preparation/reinsurance_layer.py
@@ -225,13 +225,17 @@ def create_risk_level_profile_id(ri_df, profile_map_df, fm_profile_df, reins_typ
     if fm_level_id == RISK_LEVEL_ID:
         ri_filter_fields = RISK_LEVEL_ALL_FIELDS + [field for field in FILTER_LEVEL_EXTRA_FIELDS if field in ri_df]
         ri_filter_valid_fields = [field + '_valid' for field in ri_filter_fields]
+        merge_on = ['layer_id']
+        if reins_type in REINS_TYPE_EXACT_MATCH:
+            merge_on += RISK_LEVEL_FIELD_MAP[risk_level]
         filter_df = (these_profile_map_layers[these_profile_map_layers['level_id'] == FILTER_LEVEL_ID]
                      .reset_index()
-                     .merge(ri_df[reins_type_filter][ri_filter_fields + ri_filter_valid_fields + ['layer_id']], how='inner', on='layer_id'))
+                     .merge(ri_df[reins_type_filter][ri_filter_fields + ri_filter_valid_fields + ['layer_id']], how='inner', on=merge_on))
 
         def _match(row):
             for field in ri_filter_fields:
-                if row[f'{field}_valid'] and row[f'{field}_x'] != row[f'{field}_y']:
+                if (field not in merge_on
+                        and row[f'{field}_valid'] and row[f'{field}_x'] != row[f'{field}_y']):
                     return False
             return True
         profile_map_df.loc[np.unique(filter_df[filter_df.apply(_match, axis=1)]['index']), 'profile_id'] = PASSTHROUGH_PROFILE_ID

--- a/oasislmf/pytools/getmodel/common.py
+++ b/oasislmf/pytools/getmodel/common.py
@@ -65,11 +65,11 @@ Item = nb.from_dtype(np.dtype([('id', np.int32),
                                ]))
 
 Event_defintion = nb.from_dtype(np.dtype([('section_id', np.int32),
-                                ('return_period', np.int32),
-                                ('rp_from', np.int32),
-                                ('rp_to', np.int32),
-                                ('interpolation', np.int32)
-                                ]))
+                                          ('return_period', np.int32),
+                                          ('rp_from', np.int32),
+                                          ('rp_to', np.int32),
+                                          ('interpolation', np.int32)
+                                          ]))
 
 Hazard_case = nb.from_dtype(np.dtype([('section_id', np.int32),
                                       ('areaperil_id', areaperil_int),


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Fix Cartesian product issue for RI Fac contract
With the introduction of all the scope oed column in the filter process of RI, the Fac contract had to have part of it's logic move to the filter level, however contrary to the other type of contract, we only use 1 layer_id for all FAC, this created a Cartesian product during the merge between info and scope.
this PR add some logic to use the risk level column to merge on in addition to layer_id when contracts see to be exact match which is the case for FAC.

<!--end_release_notes-->
