### PR TITLE
Combus changes: 20240807

### DIFF
--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -103,7 +103,7 @@ class GenerateLossesBase(ComputationStep):
             'gulpy_random_generator': 1}
 
         for rule in rule_ranges:
-            rule_val = getattr(self, rule)
+            rule_val = int(getattr(self, rule))
             if (rule_val < 0) or (rule_val > rule_ranges[rule]):
                 raise OasisException(f'Error: {rule}={rule_val} - Not within valid ranges [0..{rule_ranges[rule]}]')
 

--- a/oasislmf/pytools/common/data.py
+++ b/oasislmf/pytools/common/data.py
@@ -3,7 +3,7 @@ import numba as nb
 import numpy as np
 import pandas as pd
 
-oasis_int = np.dtype(os.environ.get('OASIS_FLOAT', 'i4'))
+oasis_int = np.dtype(os.environ.get('OASIS_INT', 'i4'))
 nb_oasis_int = nb.from_dtype(oasis_int)
 oasis_int_size = oasis_int.itemsize
 

--- a/oasislmf/pytools/common/event_stream.py
+++ b/oasislmf/pytools/common/event_stream.py
@@ -209,7 +209,7 @@ def mv_write_delimiter(byte_mv, cursor) -> int:
         end of delimiter index
     """
     cursor = mv_write(byte_mv, cursor, oasis_int, oasis_int_size, 0)
-    cursor = mv_write(byte_mv, cursor, oasis_float, oasis_int_size, 0)
+    cursor = mv_write(byte_mv, cursor, oasis_float, oasis_float_size, 0)
     # print('end', cursor)
     return cursor
 


### PR DESCRIPTION

<!--start_release_notes-->
### Release notes feature title
BUG FIX: incorrect handling of user defined variables within OasisLMF
Changing the varaibles either manually or via environment variables casuing typing issues in the jitted numba function of pytools.
changes were made to fix these issues as they appeared. Results are now matching with:
    ENV OASIS_FLOAT=f8
    ENV AREAPERIL_TYPE=u8
    ENV AREAPERIL_INT=u8
Noting that no other testing wS done for other modules other than non IL gul calcuLations

BUG FIX: rule val if typed as string will cause a fault 
Whether a result of issues with input the issue can be resolved by retyping the rule_val.

<!--end_release_notes-->
