### PR TITLE
Fix exposure summary report - non covered peril reporting moved

### DIFF
--- a/oasislmf/lookup/builtin.py
+++ b/oasislmf/lookup/builtin.py
@@ -415,8 +415,9 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
 
             location = locations.join(split_df).merge(peril_groups_df)
             if model_perils_covered:
-                location.loc[~location['peril_id'].isin(model_perils_covered), ['status', 'message']
-                             ] = OASIS_KEYS_STATUS['noreturn']['id'], 'unsuported peril_id'
+                df_model_perils_covered = pd.Series(model_perils_covered)
+                df_model_perils_covered.name = 'model_perils_covered'
+                location = location.merge(df_model_perils_covered, left_on='peril_id', right_on='model_perils_covered')
             return location
         return fct
 

--- a/oasislmf/preparation/summaries.py
+++ b/oasislmf/preparation/summaries.py
@@ -903,7 +903,6 @@ def get_exposure_summary(
     df_summary = pd.concat(df_summary)
 
     # get all perils
-    exposure_df.to_csv('/tmp/exposure_df.csv',index=False)
     peril_groups_df = get_peril_groups_df()
     exposure_perils_df = exposure_df[['LocPerilsCovered']].drop_duplicates().merge(
         peril_groups_df, left_on='LocPerilsCovered', right_on='peril_group_id')

--- a/oasislmf/preparation/summaries.py
+++ b/oasislmf/preparation/summaries.py
@@ -903,11 +903,7 @@ def get_exposure_summary(
     df_summary = pd.concat(df_summary)
 
     # get all perils
-    peril_groups_df = get_peril_groups_df()
-    exposure_perils_df = exposure_df[['LocPerilsCovered']].drop_duplicates().merge(
-        peril_groups_df, left_on='LocPerilsCovered', right_on='peril_group_id')
-
-    peril_list = exposure_perils_df['peril_id'].drop_duplicates().to_list()
+    peril_list = keys_df['peril_id'].drop_duplicates().to_list()
 
     df_summary_peril = []
     for peril_id in peril_list:

--- a/oasislmf/preparation/summaries.py
+++ b/oasislmf/preparation/summaries.py
@@ -40,7 +40,6 @@ from ..utils.exceptions import OasisException
 from ..utils.log import oasis_log
 from ..utils.path import as_path
 from ..utils.status import OASIS_KEYS_STATUS, OASIS_KEYS_STATUS_MODELLED
-from ..utils.peril import get_peril_groups_df
 
 MAP_SUMMARY_DTYPES = {
     'loc_id': 'int',

--- a/oasislmf/preparation/summaries.py
+++ b/oasislmf/preparation/summaries.py
@@ -40,6 +40,7 @@ from ..utils.exceptions import OasisException
 from ..utils.log import oasis_log
 from ..utils.path import as_path
 from ..utils.status import OASIS_KEYS_STATUS, OASIS_KEYS_STATUS_MODELLED
+from ..utils.peril import get_peril_groups_df
 
 MAP_SUMMARY_DTYPES = {
     'loc_id': 'int',
@@ -902,7 +903,12 @@ def get_exposure_summary(
     df_summary = pd.concat(df_summary)
 
     # get all perils
-    peril_list = keys_df['peril_id'].drop_duplicates().to_list()
+    exposure_df.to_csv('/tmp/exposure_df.csv',index=False)
+    peril_groups_df = get_peril_groups_df()
+    exposure_perils_df = exposure_df[['LocPerilsCovered']].drop_duplicates().merge(
+        peril_groups_df, left_on='LocPerilsCovered', right_on='peril_group_id')
+
+    peril_list = exposure_perils_df['peril_id'].drop_duplicates().to_list()
 
     df_summary_peril = []
     for peril_id in peril_list:

--- a/tests/computation/data/common.py
+++ b/tests/computation/data/common.py
@@ -419,7 +419,7 @@ N2_LOC = """PortNumber,AccNumber,LocNumber,IsTenant,BuildingID,CountryCode,Latit
 """
 
 EXPECTED_KEYS = b'LocID,PerilID,CoverageTypeID,AreaPerilID,VulnerabilityID,AmplificationID\n1,WSS,1,1000,8,2\n1,WTC,1,500,2,1\n1,WSS,3,1000,11,2\n1,WTC,3,500,5,1\n'
-EXPECTED_ERROR = b'LocID,PerilID,CoverageTypeID,Status,Message\n1,WEC,1,noreturn,unsuported peril_id\n1,WEC,3,noreturn,unsuported peril_id\n'
+EXPECTED_ERROR = b'LocID,PerilID,CoverageTypeID,Status,Message'
 
 
 FAKE_IL_ITEMS_RETURN = pd.read_csv(os.path.join(os.path.dirname(__file__), 'il_inputs_df_return.csv'))

--- a/tests/computation/data/common.py
+++ b/tests/computation/data/common.py
@@ -419,7 +419,7 @@ N2_LOC = """PortNumber,AccNumber,LocNumber,IsTenant,BuildingID,CountryCode,Latit
 """
 
 EXPECTED_KEYS = b'LocID,PerilID,CoverageTypeID,AreaPerilID,VulnerabilityID,AmplificationID\n1,WSS,1,1000,8,2\n1,WTC,1,500,2,1\n1,WSS,3,1000,11,2\n1,WTC,3,500,5,1\n'
-EXPECTED_ERROR = b'LocID,PerilID,CoverageTypeID,Status,Message'
+EXPECTED_ERROR = b'LocID,PerilID,CoverageTypeID,Status,Message\n'
 
 
 FAKE_IL_ITEMS_RETURN = pd.read_csv(os.path.join(os.path.dirname(__file__), 'il_inputs_df_return.csv'))

--- a/tests/computation/test_generate_keys.py
+++ b/tests/computation/test_generate_keys.py
@@ -46,7 +46,7 @@ class TestGenKeys(ComputationChecker):
         self.write_json(self.tmp_files.get('lookup_complex_config_json'), MIN_RUN_SETTINGS)
 
     def test_keys__check_return(self):
-        expected_return = (self.min_args_output_set['keys_data_csv'], 4, self.min_args_output_set['keys_errors_csv'], 2)
+        expected_return = (self.min_args_output_set['keys_data_csv'], 4, self.min_args_output_set['keys_errors_csv'], 0)
         keys_return = self.manager.generate_keys(**self.min_args_output_set)
         keys_csv_data = self.read_file(self.min_args_output_set['keys_data_csv'])
         error_csv_data = self.read_file(self.min_args_output_set['keys_errors_csv'])

--- a/tests/model_preparation/meta_data/keys-errors.csv
+++ b/tests/model_preparation/meta_data/keys-errors.csv
@@ -1,13 +1,5 @@
 LocID,PerilID,CoverageTypeID,Status,Message
-1,WEC,1,noreturn,unsuported peril_id
-2,WEC,1,noreturn,unsuported peril_id
-3,WEC,1,noreturn,unsuported peril_id
-4,WEC,1,noreturn,unsuported peril_id
 4,WSS,1,fail,area_peril_id has an unknown id
 4,WTC,1,fail,area_peril_id has an unknown id
-1,WEC,3,noreturn,unsuported peril_id
-2,WEC,3,noreturn,unsuported peril_id
-3,WEC,3,noreturn,unsuported peril_id
-4,WEC,3,noreturn,unsuported peril_id
 4,WSS,3,fail,area_peril_id has an unknown id
 4,WTC,3,fail,area_peril_id has an unknown id


### PR DESCRIPTION
closes #1379

<!--start_release_notes-->
### Fix performance issues with get exposure summary
No Return keys were included in keys errors file, but this was ballooning to a huge size when AA1 peril code was used, since we would see no returns for all peril codes. This was causing the performance of the generate exposure summary report to degrade massively.

The fix removes the no-returns from the returned errors, but counts them in the exposure summary.
<!--end_release_notes-->
