### PR TITLE
drop duplicate il term lines before merging

### DIFF
--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -32,7 +32,7 @@ from oasislmf.utils.data import (factorize_array, factorize_ndarray,
                                  set_dataframe_column_dtypes)
 from oasislmf.utils.defaults import (OASIS_FILES_PREFIXES, SUMMARY_TOP_LEVEL_COLS, assign_defaults_to_il_inputs,
                                      get_default_accounts_profile, get_default_exposure_profile,
-                                     get_default_fm_aggregation_profile)
+                                     get_default_fm_aggregation_profile, SOURCE_IDX)
 from oasislmf.utils.exceptions import OasisException
 from oasislmf.utils.fm import (CALCRULE_ASSIGNMENT_METHODS, COVERAGE_AGGREGATION_METHODS,
                                DEDUCTIBLE_AND_LIMIT_TYPES, FML_ACCALL, STEP_TRIGGER_TYPES,

--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -609,6 +609,7 @@ def get_il_input_items(
                         group_df.rename(columns={ProfileElementName: term}, inplace=True)
                 level_df_list.append(group_df)
             level_df = pd.concat(level_df_list, copy=True)
+            level_df = level_df.drop_duplicates(subset=set(level_df.columns) - set(SOURCE_IDX.values()))
 
             if step_level:
                 # merge with gul_inputs_df needs to be based on 'steptriggertype' and 'coverage_type_id'


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Reduce memory usage in il generation step
Drop duplicated lines containing each specific level terms before merging with the input level do reduce memory consumption
<!--end_release_notes-->
