### PR TITLE
disable full_correlation if running gulmc

### DIFF
--- a/oasislmf/execution/bash.py
+++ b/oasislmf/execution/bash.py
@@ -1944,6 +1944,9 @@ def bash_params(
     if 'full_correlation' in analysis_settings:
         if _get_getmodel_cmd is None and bash_params['gul_item_stream']:
             full_correlation = analysis_settings['full_correlation']
+            if full_correlation and gulmc:
+                full_correlation = False
+                logger.info("full_correlation has been disable as it isn't compatible with gulmc, see oasislmf correlation documentation.")
     bash_params['full_correlation'] = full_correlation
 
     # Output depends on being enabled AND having at least one summaries section


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Disable full_correlation when running gulmc
Gulmc provide a more fine grained correlation feature and make full_correlation flag not useful and created an issue where the run would hang
This change disable full_correlation in that case fixing the hanging issue.
<!--end_release_notes-->
