### PR TITLE
Fix CI build system failures 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,14 +102,14 @@ jobs:
 
     - name: Download ktools build (Linux)
       if: inputs.ktools_branch != ''
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: Linux_x86_64
         path: ${{ github.workspace }}/
 
     - name: Download ktools build (Darwin)
       if: inputs.ktools_branch != ''
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: Darwin_x86_64
         path: ${{ github.workspace }}/
@@ -123,7 +123,7 @@ jobs:
         echo "PKG_SRC_PATH=${TAR_PKG}" >> $GITHUB_ENV
 
     - name: Store - source distribution
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: oasislmf-source-pkg
         path: ${{ env.PKG_SRC_PATH }}
@@ -144,7 +144,7 @@ jobs:
         echo "PKG_LINUX_PATH=${WHL_LINUX}" >> $GITHUB_ENV
 
     - name: Store - binary distribution (Linux)
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: oasislmf-bin-pkg_linux
         path: ${{ env.PKG_LINUX_PATH }}
@@ -167,7 +167,7 @@ jobs:
 
     - name: Store - binary distribution (Darwin)
       if: inputs.build_osx == 'true' || inputs.ktools_branch != ''
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: oasislmf-bin-pkg_darwin
         path: ${{ env.PKG_DARWIN_PATH }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -195,20 +195,20 @@ jobs:
           --output-path ./RELEASE.md
 
     - name: Download Source package
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: oasislmf-source-pkg
         path: ${{ github.workspace }}/
 
     - name: Download Linux package
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: oasislmf-bin-pkg_linux
         path: ${{ github.workspace }}/
 
     - name: Download OSX package
       if: needs.build.outputs.osx_pkg_filename != ''
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: oasislmf-bin-pkg_darwin
         path: ${{ github.workspace }}/

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Download package
         if: matrix.cfg.upload-cov != true
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4
         with:
           name: oasislmf-bin-pkg_linux
           path: ${{ github.workspace }}/
@@ -96,7 +96,7 @@ jobs:
 
       - name: download ods_tools
         if: needs.ods_tools.outputs.whl_filename != ''
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4
         with:
           name: bin_package
           path: ${{ github.workspace }}/

--- a/optional-package.in
+++ b/optional-package.in
@@ -1,5 +1,5 @@
 shapely>=1.3.0
-geopandas>=0.8.0
+geopandas>=0.14.4
 scikit-learn
 rtree>=0.8.3
 forex_python

--- a/optional-package.in
+++ b/optional-package.in
@@ -1,5 +1,6 @@
 shapely>=1.3.0
 geopandas>=0.8.0
+fiona<=1.9.6
 scikit-learn
 rtree>=0.8.3
 forex_python

--- a/optional-package.in
+++ b/optional-package.in
@@ -1,5 +1,5 @@
 shapely>=1.3.0
-geopandas>=0.14.4
+geopandas>=0.8.0
 scikit-learn
 rtree>=0.8.3
 forex_python


### PR DESCRIPTION
<!--start_release_notes-->
### Fix CI build system failures 
* Updated GH actions to use artifact v4
* Pinned Fiona package (the newer package has incompatibility with some older versions of Geopandas) 
update to geopandas `0.14.4` or pin fiona to version `1.9.6`  
<!--end_release_notes-->
