### PR TITLE
Set Ktools 3.12.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ except ImportError:
     from urllib2 import URLError
 
 
-KTOOLS_VERSION = '3.12.3'
+KTOOLS_VERSION = '3.12.4'
 
 SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
### Set Ktools 3.12.4
https://github.com/OasisLMF/ktools/releases/tag/v3.12.4

## ktools Notes

### Average Loss Convergence Table (ALCT) fix  - [(PR #390)](https://github.com/OasisLMF/ktools/pull/390)

- Changed the calculation of StandardError which is used for the confidence intervals for the AAL estimate to be equal to StandardErrorVuln from the ANOVA metrics
- Reintroduced the ANOVA fields from the first version of the report
- Set the lower and upper confidence threshold to zero where StandardError=0 (for SampleSize 1)
