### PR TITLE
Add check for alt_meanonly output request to conditional

### DIFF
--- a/oasislmf/execution/bin.py
+++ b/oasislmf/execution/bin.py
@@ -434,7 +434,7 @@ def prepare_run_inputs(analysis_settings, run_dir, model_storage: BaseStorage, r
 
             _prepare_input_bin(run_dir, 'occurrence', model_settings, model_storage, setting_key='event_occurrence_id', ri=ri)
         elif _calc_selected(analysis_settings, [
-            'pltcalc', 'aalcalc', 'aalcalcmeanonly', 'alt_period', 'elt_moment', 'elt_quantile',
+            'pltcalc', 'aalcalc', 'aalcalcmeanonly', 'alt_period', 'alt_meanonly', 'elt_moment', 'elt_quantile',
             'elt_sample', 'plt_moment', 'plt_quantile', 'plt_sample'
         ]):
             _prepare_input_bin(run_dir, 'occurrence', model_settings, model_storage, setting_key='event_occurrence_id', ri=ri)


### PR DESCRIPTION
Fix missing occurrence file error when alt_meanonly output requested

When only alt_meanonly output requested and an identifier is used to identify the occurrence file to be used, a symbolic link to that file is created in the run static directory. This fixes an issue where the symbolic link was not created in the aforementioned scenario.
