### PR TITLE
Fix: undo 100% correlation if no correlation setting provided in model settings

### DIFF
--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -181,7 +181,6 @@ class GenerateFiles(ComputationStep):
         location_profile = get_json(src_fp=self.profile_loc_json) if self.profile_loc_json else self.profile_loc
         accounts_profile = get_json(src_fp=self.profile_acc_json) if self.profile_acc_json else self.profile_acc
         oed_hierarchy = get_oed_hierarchy(location_profile, accounts_profile)
-        loc_grp = oed_hierarchy['locgrp']['ProfileElementName']
 
         fm_aggregation_profile = get_json(src_fp=self.profile_fm_agg_json) if self.profile_fm_agg_json else self.profile_fm_agg
 
@@ -307,11 +306,9 @@ class GenerateFiles(ComputationStep):
         damage_group_id_cols: List[str] = process_group_id_cols(group_id_cols=damage_group_id_cols,
                                                                 exposure_df_columns=location_df,
                                                                 has_correlation_groups=correlations)
-
         hazard_group_id_cols: List[str] = process_group_id_cols(group_id_cols=hazard_group_id_cols,
                                                                 exposure_df_columns=location_df,
                                                                 has_correlation_groups=correlations)
-
         gul_inputs_df = get_gul_input_items(
             location_df,
             keys_df,
@@ -343,7 +340,7 @@ class GenerateFiles(ComputationStep):
         gul_input_files = write_gul_input_files(
             gul_inputs_df,
             target_dir,
-            correlations_df=gul_inputs_df[CorrelationsData.COLUMNS] if correlations is True else None,
+            correlations_df=gul_inputs_df[CorrelationsData.COLUMNS],
             output_dir=self._get_output_dir(),
             oasis_files_prefixes=files_prefixes['gul'],
             chunksize=self.write_chunksize,

--- a/oasislmf/preparation/correlations.py
+++ b/oasislmf/preparation/correlations.py
@@ -20,7 +20,7 @@ def map_data(data: Optional[dict], logger) -> Optional[pd.DataFrame]:
         supported_perils = data.get("lookup_settings", {}).get("supported_perils", [])
         correlation_settings = data.get("correlation_settings", [])
 
-        for supported_peril in supported_perils:
+        for supported_peril in supported_perils:  # supported_perils is expected to be a list of dict
             supported_peril["peril_correlation_group"] = supported_peril.get("peril_correlation_group", 0)
 
         supported_perils_df = pd.DataFrame(supported_perils)
@@ -41,26 +41,3 @@ def map_data(data: Optional[dict], logger) -> Optional[pd.DataFrame]:
         if len(supported_perils_df) > 0 and len(correlation_settings_df) > 0:
             mapped_data = pd.merge(supported_perils_df, correlation_settings_df, on="peril_correlation_group")
             return mapped_data
-
-
-def get_correlation_input_items(gul_inputs_df: pd.DataFrame, correlation_map_df: pd.DataFrame) -> pd.DataFrame:
-    """
-    Gets the correlation values with the peril ID from the model_settings.
-
-    Args:
-        correlation_map_df: (pd.DataFrame) data from the model settings to to have Peril ID, peril_correlation_group,
-                                           and damage_correlation_value
-        gul_inputs_df: (pd.DataFrame) the data of the gul inputs to be mapped
-
-    Returns: (pd.DataFrame) the mapped data of correlations
-    """
-    correlation_df = (
-        gul_inputs_df
-        .merge(correlation_map_df, left_on='peril_id', right_on='id')
-        .reset_index()
-        .astype({"damage_correlation_value": "float32", "hazard_correlation_value": "float32"})
-        [["item_id", "peril_correlation_group", "damage_correlation_value", "hazard_group_id", "hazard_correlation_value"]]
-        .sort_values('item_id')
-    )
-
-    return correlation_df

--- a/oasislmf/preparation/gul_inputs.py
+++ b/oasislmf/preparation/gul_inputs.py
@@ -413,6 +413,8 @@ def get_gul_input_items(
     if correlations:
         # do merge with peril correlation df
         gul_inputs_df = gul_inputs_df.merge(peril_correlation_group_df, left_on='peril_id', right_on='id').reset_index()
+    else:
+        gul_inputs_df[["peril_correlation_group", "damage_correlation_value", "hazard_correlation_value"]] = 0
     gul_inputs_df["group_id"] = (
         pd.util.hash_pandas_object(
             gul_inputs_df.rename(columns=damage_group_id_cols_map)[sorted(list(damage_group_id_cols_map.values()))], index=False).to_numpy() >> 33
@@ -439,7 +441,7 @@ def get_gul_input_items(
         # disagg_id is needed for fm_summary_map
         ['is_bi_coverage', 'group_id', 'coverage_id', 'item_id', 'status', 'building_id', 'NumberOfBuildings', 'IsAggregate', 'LocPeril'] +
         tiv_cols +
-        (["peril_correlation_group", "damage_correlation_value", 'hazard_group_id', "hazard_correlation_value"] if correlations is True else [])
+        ["peril_correlation_group", "damage_correlation_value", 'hazard_group_id', "hazard_correlation_value"]
     )
 
     usecols = [col for col in usecols if col in gul_inputs_df]

--- a/tests/preparation/test_correlations.py
+++ b/tests/preparation/test_correlations.py
@@ -4,10 +4,7 @@ This file tests the mapping of the correlation data between supported perils and
 import os
 from unittest import TestCase, main
 
-import pandas as pd
-
-from oasislmf.preparation.correlations import (get_correlation_input_items,
-                                               map_data)
+from oasislmf.preparation.correlations import map_data
 from ods_tools.oed.setting_schema import ModelSettingSchema
 
 META_PATH = os.path.realpath(__file__).replace("test_correlations.py", "meta_data/")
@@ -23,36 +20,25 @@ class TestMapData(TestCase):
         pass
 
     def test_map_data(self):
+        expected_mapped_data = [
+            {
+                'id': 'WSS',
+                'desc': 'Single Peril: Storm Surge',
+                'peril_correlation_group': 1,
+                'damage_correlation_value': '0.7',
+                'hazard_correlation_value': '0.0',
+            },
+            {
+                'id': 'WTC',
+                'desc': 'Single Peril: Tropical Cyclone',
+                'peril_correlation_group': 2,
+                'damage_correlation_value': '0.5',
+                'hazard_correlation_value': '0.3',
+            },
+        ]
+
         mapped_data = map_data(data=self.model_settings, logger=None)
-        self.assertEqual(EXPECTED_MAPPED_DATA, mapped_data.to_dict('records'))
-
-    def test_get_correlation_input_items(self):
-        gul_path = META_PATH + "gul_inputs_df.csv"
-
-        gul_inputs_df = pd.read_csv(gul_path)
-        correlation_df = get_correlation_input_items(correlation_map_df=map_data(data=self.model_settings, logger=None),
-                                                     gul_inputs_df=gul_inputs_df)
-        correlation_df_check = pd.read_csv(f"{META_PATH}correlation_df.csv")
-
-        correlation_df_check.equals(correlation_df)
-
-
-EXPECTED_MAPPED_DATA = [
-    {
-        'id': 'WSS',
-        'desc': 'Single Peril: Storm Surge',
-        'peril_correlation_group': 1,
-        'damage_correlation_value': '0.7',
-        'hazard_correlation_value': '0.0',
-    },
-    {
-        'id': 'WTC',
-        'desc': 'Single Peril: Tropical Cyclone',
-        'peril_correlation_group': 2,
-        'damage_correlation_value': '0.5',
-        'hazard_correlation_value': '0.3',
-    },
-]
+        self.assertEqual(expected_mapped_data, mapped_data.to_dict('records'))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Fix: undo 100% correlation if no correlation setting provided in model settings
The hazard_group_id where not generated if the correlation settings were not provided, causing a 100% correlation across all location.
This fix assure the  hazard_group_id are generated and used correctly in gulmc.
<!--end_release_notes-->
