### PR TITLE
Fix/dynamic footprint intensity

### DIFF
--- a/oasislmf/pytools/getmodel/common.py
+++ b/oasislmf/pytools/getmodel/common.py
@@ -30,6 +30,13 @@ Event = nb.from_dtype(np.dtype([('areaperil_id', areaperil_int),
                                 ('probability', oasis_float)
                                 ]))
 
+EventDynamic = nb.from_dtype(np.dtype([('areaperil_id', areaperil_int),
+                                       ('intensity_bin_id', np.int32),
+                                       ('intensity', np.int32),
+                                       ('probability', oasis_float),
+                                       ('return_period', np.int32)
+                                       ]))
+
 EventCSV = nb.from_dtype(np.dtype([('event_id', np.int32),
                                    ('areaperil_id', areaperil_int),
                                    ('intensity_bin_id', np.int32),

--- a/oasislmf/pytools/getmodel/footprint.py
+++ b/oasislmf/pytools/getmodel/footprint.py
@@ -400,11 +400,15 @@ class FootprintParquetDynamic(Footprint):
             df_footprint['from_intensity'] = df_footprint['from_intensity'].fillna(0)
 
             if len(df_footprint.index) > 0:
-                df_footprint['intensity_bin_id'] = np.floor(df_footprint.from_intensity + (
+                df_footprint['intensity'] = np.floor(df_footprint.from_intensity + (
                     (df_footprint.to_intensity - df_footprint.from_intensity) * df_footprint.interpolation))
-                df_footprint['intensity_bin_id'] = df_footprint['intensity_bin_id'].astype('int')
+                df_footprint['intensity'] = df_footprint['intensity'].astype('int')
+                intensity_bin_dict = pd.read_csv('static/intensity_bin_dict.csv')
+                intensity_bin_dict.rename(columns={'intensity_bin': 'intensity_bin_id'}, inplace=True)
+                df_footprint = df_footprint.merge(intensity_bin_dict, on='intensity')
                 df_footprint['probability'] = 1
             else:
+                df_footprint.loc[:, 'intensity'] = []
                 df_footprint.loc[:, 'intensity_bin_id'] = []
                 df_footprint.loc[:, 'probability'] = []
 

--- a/oasislmf/pytools/getmodel/footprint.py
+++ b/oasislmf/pytools/getmodel/footprint.py
@@ -16,7 +16,7 @@ import numba as nb
 from oasis_data_manager.df_reader.config import clean_config, InputReaderConfig, get_df_reader
 from oasis_data_manager.df_reader.reader import OasisReader
 from oasis_data_manager.filestore.backends.base import BaseStorage
-from .common import (FootprintHeader, EventIndexBin, EventIndexBinZ, Event, EventCSV,
+from .common import (FootprintHeader, EventIndexBin, EventIndexBinZ, Event, EventCSV, EventDynamic,
                      footprint_filename, footprint_index_filename, zfootprint_filename, zfootprint_index_filename,
                      csvfootprint_filename, parquetfootprint_filename, parquetfootprint_meta_filename,
                      event_defintion_filename, hazard_case_filename, fp_format_priorities)
@@ -412,7 +412,21 @@ class FootprintParquetDynamic(Footprint):
                 df_footprint.loc[:, 'intensity_bin_id'] = []
                 df_footprint.loc[:, 'probability'] = []
 
-            numpy_data = self.prepare_df_data(data_frame=df_footprint[['areaperil_id', 'intensity_bin_id', 'probability', 'return_period']])
+            areaperil_id = df_footprint["areaperil_id"].to_numpy()
+            intensity_bin_id = df_footprint["intensity_bin_id"].to_numpy()
+            intensity = df_footprint["intensity"].to_numpy()
+            return_period = df_footprint["return_period"].to_numpy()
+            probability = df_footprint["probability"].to_numpy()
+
+            buffer = np.empty(len(areaperil_id), dtype=EventDynamic)
+            for x in range(0, len(buffer)):
+                buffer[x]['areaperil_id'] = areaperil_id[x]
+                buffer[x]['intensity_bin_id'] = intensity_bin_id[x]
+                buffer[x]['intensity'] = intensity[x]
+                buffer[x]['probability'] = probability[x]
+                buffer[x]['return_period'] = return_period[x]
+            numpy_data = np.array(buffer, dtype=EventDynamic)
+            
             return numpy_data
 
 

--- a/oasislmf/pytools/gulmc/common.py
+++ b/oasislmf/pytools/gulmc/common.py
@@ -57,7 +57,8 @@ oasis_float_to_int32_size = oasis_float.itemsize // np.int32().itemsize
 areaperil_int_to_int32_size = areaperil_int.itemsize // np.int32().itemsize
 
 haz_cdf_type = nb.from_dtype(np.dtype([('probability', oasis_float),
-                                       ('intensity_bin_id', np.int32)]))
+                                       ('intensity_bin_id', np.int32),
+                                       ('intensity', np.int32)]))
 
 ProbMean = nb.from_dtype(np.dtype([('prob_to', oasis_float),
                                    ('bin_mean', oasis_float)

--- a/oasislmf/pytools/gulmc/manager.py
+++ b/oasislmf/pytools/gulmc/manager.py
@@ -639,9 +639,11 @@ def compute_event_losses(event_id,
                 haz_cdf_record = haz_cdf[haz_cdf_ptr[hazcdf_i]:haz_cdf_ptr[hazcdf_i + 1]]
                 haz_cdf_prob = haz_cdf_record['probability']
                 haz_cdf_bin_id = haz_cdf_record['intensity_bin_id']
-                # adjust intensity in dynamic footprint
-                haz_cdf_bin_id = haz_cdf_bin_id - intensity_adjustment
-                haz_cdf_bin_id = np.where(haz_cdf_bin_id < 0, nb_int32(0), haz_cdf_bin_id)
+                if dynamic_footprint:
+                    # adjust intensity in dynamic footprint
+                    haz_cdf_intensity = haz_cdf_record['intensity']
+                    haz_cdf_intensity = haz_cdf_intensity - intensity_adjustment
+                    haz_cdf_intensity = np.where(haz_cdf_intensity < 0, nb_int32(0), haz_cdf_intensity)
 
                 Nhaz_bins = haz_cdf_ptr[hazcdf_i + 1] - haz_cdf_ptr[hazcdf_i]
 
@@ -959,7 +961,7 @@ def compute_event_losses(event_id,
 
                             # 2) get the hazard intensity bin id
                             if dynamic_footprint:
-                                haz_int_val = haz_cdf_bin_id[haz_bin_idx]
+                                haz_int_val = haz_cdf_intensity[haz_bin_idx]
                                 haz_int_bin_id = intensity_bin_dict[haz_int_val]
                             else:
                                 haz_int_bin_id = haz_cdf_bin_id[haz_bin_idx]

--- a/oasislmf/pytools/gulmc/manager.py
+++ b/oasislmf/pytools/gulmc/manager.py
@@ -383,7 +383,8 @@ def run(run_dir,
                     event_footprint, vuln_array,
                     areaperil_to_vulns_idx_dict,
                     areaperil_to_vulns_idx_array,
-                    areaperil_to_vulns)
+                    areaperil_to_vulns,
+                    dynamic_footprint)
 
                 if Nhaz_cdf_this_event == 0:
                     # no items to be computed for this event
@@ -1095,7 +1096,8 @@ def process_areaperils_in_footprint(event_footprint,
                                     vuln_array,
                                     areaperil_to_vulns_idx_dict,
                                     areaperil_to_vulns_idx_array,
-                                    areaperil_to_vulns):
+                                    areaperil_to_vulns,
+                                    dynamic_footprint):
     """
     Process all the areaperils in the footprint, filtering and retaining only those who have associated vulnerability functions,
     computing the hazard intensity cdf for each of those areaperil_id.
@@ -1164,6 +1166,8 @@ def process_areaperils_in_footprint(event_footprint,
                         cumsum += haz_pdf[cdf_start + haz_bin_i]
                         haz_cdf[cdf_start + haz_bin_i]['probability'] = cumsum
                         haz_cdf[cdf_start + haz_bin_i]['intensity_bin_id'] = event_footprint['intensity_bin_id'][last_areaperil_id_start + haz_bin_i]
+                        if dynamic_footprint:
+                            haz_cdf[cdf_start + haz_bin_i]['intensity'] = event_footprint['intensity'][last_areaperil_id_start + haz_bin_i]
 
                     # compute effective damageability cdf (internally called `eff_vuln`)
                     # for each vulnerability function associated to this areaperil_id, compute the product between
@@ -1220,6 +1224,8 @@ def process_areaperils_in_footprint(event_footprint,
             cumsum += haz_pdf[cdf_start + haz_bin_i]
             haz_cdf[cdf_start + haz_bin_i]['probability'] = cumsum
             haz_cdf[cdf_start + haz_bin_i]['intensity_bin_id'] = event_footprint['intensity_bin_id'][last_areaperil_id_start + haz_bin_i]
+            if dynamic_footprint:
+                haz_cdf[cdf_start + haz_bin_i]['intensity'] = event_footprint['intensity'][last_areaperil_id_start + haz_bin_i]
 
         # compute effective damageability cdf (internally called `eff_vuln`)
         # for each vulnerability function associated to this areaperil_id, compute the product between

--- a/oasislmf/pytools/gulmc/manager.py
+++ b/oasislmf/pytools/gulmc/manager.py
@@ -82,7 +82,7 @@ def get_dynamic_footprint_adjustments(input_path):
         numpy array with itemid and adjustment factors
     """
     adjustments_fn = os.path.join(input_path, 'item_adjustments.csv')
-    if os.path.isfile('item_adjustments.csv'):
+    if os.path.isfile(adjustments_fn):
         adjustments_tb = np.loadtxt(adjustments_fn, dtype=ItemAdjustment, delimiter=",", skiprows=1, ndmin=1)
     else:
         items_fp = os.path.join(input_path, 'items.csv')


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

Closes #1591 

The effective vulnerability CDF used to generate type 1 losses is created before compute_event_losses is called (which is where intensities are adjusted and mapped to bins). FootprintParquetDynamic has been updated to return both intensity and intensity bin, so the intensity bin can be used to create the effective vulnerability CDF, rather than the physical intensity

Type 1 losses **do not** account for intensity adjustments with this implementation. This will require some additional refactoring to move the creation of the effective vulnerability CDF to inside compute_event_losses
