### PR TITLE
Fixes for CI testing stable 1.28.x

### DIFF
--- a/.github/workflows/piwind-test.yml
+++ b/.github/workflows/piwind-test.yml
@@ -81,5 +81,5 @@ jobs:
       ods_package: ${{ needs.ods_tools.outputs.whl_filename }}
       platform_version: ${{ github.event_name != 'workflow_dispatch' && 'latest' ||  inputs.platform_2_version }}
       pytest_opts: "--docker-compose=./docker/plat2-v2.docker-compose.yml"
-      worker_api_ver: 'v2'
+      worker_api_ver: 'v1'
       storage_suffix: '_platform2'

--- a/requirements-package.in
+++ b/requirements-package.in
@@ -6,7 +6,7 @@ fastparquet>=0.3.1
 msgpack
 numba>=0.55.1
 numexpr
-numpy<1.24,>=1.18
+numpy>=1.18
 ods-tools>=3.1.5,<3.2.0
 pandas>=1.0.3,!=1.1.0,!=1.1.1,<2.2.0
 pyarrow>=3.0.0


### PR DESCRIPTION
<!--start_release_notes-->
### Fixes for CI testing stable 1.28.x
* Remove numpy max version pin and fix plat2 testing
<!--end_release_notes-->
