### PR TITLE
fixes error message for missing PolInceptionDate

### DIFF
--- a/oasislmf/preparation/reinsurance_layer.py
+++ b/oasislmf/preparation/reinsurance_layer.py
@@ -251,7 +251,11 @@ def create_risk_level_profile_id(ri_df, profile_map_df, fm_profile_df, reins_typ
                     error_msg = "Error: ReinsInceptionDate/ReinsExpiryDate missing, cannot use AttachmentBasis [RA]. Please check the ri_info file"
                     raise OasisException(error_msg)
                 elif row["PolInceptionDate"] == "":
-                    acc_info = {field: row[f'{field}_x'] for field in RISK_LEVEL_FIELD_MAP[oed.REINS_RISK_LEVEL_ACCOUNT]}
+                    acc_info = {
+                        field: row[f'{field}_x'] if f'{field}_x' in row else row[f'{field}']
+                        for field in RISK_LEVEL_FIELD_MAP[oed.REINS_RISK_LEVEL_ACCOUNT]
+                        if f'{field}_x' in row or f'{field}' in row
+                    }
                     error_msg = f"Error: PolInceptionDate missing for {acc_info}, cannot use AttachmentBasis [RA]. Please check the account file"
                     raise OasisException(error_msg)
                 else:


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### fixes error message for missing PolInceptionDate
For RA based reinsurance introduced in 2.3.11 https://github.com/OasisLMF/OasisLMF/pull/1576
Solution is to look for both non '_x' and '_x' variants of these column numbers in the row if they exist and output them.
```python
acc_info = {
    field: row[f'{field}_x'] if f'{field}_x' in row else row[f'{field}']
    for field in RISK_LEVEL_FIELD_MAP[oed.REINS_RISK_LEVEL_ACCOUNT]
    if f'{field}_x' in row or f'{field}' in row
}
```

Should output the correct error message as shown in the example
```
Error: PolInceptionDate missing for {'PortNumber': '1', 'AccNumber': 'A11111'}, cannot use AttachmentBasis [RA]. Please check the account file
```
<!--end_release_notes-->