### PR TITLE
Fix testing failures (API Client) 

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -31,6 +31,6 @@ jobs:
       - name: Build
         run: ./docs/build.sh
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './docs/build/html/'

--- a/requirements.in
+++ b/requirements.in
@@ -12,4 +12,4 @@ pytest-cov
 pytest-ignore-flaky
 sphinx-autoapi
 tox
-responses
+responses<=0.25.3


### PR DESCRIPTION
<!--start_release_notes-->
### Fix testing failures (API Client) 
Objected returned from a mocked API post has changed between versions of the `responses`
Pinning to `responses<=0.25.3` for now, but test should be updated later
<!--end_release_notes-->
