### PR TITLE
test: Improvements for test execution

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -107,13 +107,13 @@ jobs:
           pip uninstall ods_tools -y
           pip install ${{ needs.ods_tools.outputs.whl_filename }}
 
-      - name: run pytest (JIT enabled)
+      - name: run unit tests (JIT enabled)
         if: matrix.cfg.upload-cov != true
-        run: pytest -p no:flaky --ignore=fm_testing_tool --ignore=validation --cov-config=tox.ini --cov=oasislmf --cov-report=xml --cov-report=term
+        run: make unittests_jit
 
-      - name: run pytest (JIT disabled)
+      - name: run unit tests (JIT disabled)
         if: matrix.cfg.upload-cov == true
-        run: pytest -p no:flaky --ignore=fm_testing_tool --ignore=validation --cov-config=tox.ini --cov=oasislmf --cov-report=xml --cov-report=term --gul-rtol 1e-3 --gul-atol 1e-3
+        run: make unittests_nojit
         env:
           NUMBA_DISABLE_JIT: 1
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,77 @@
+SHELL := /bin/bash
+
+REPO := https://github.com/OasisLMF/OasisLMF
+
+PACKAGE_NAME := oasislmf
+BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+HEAD := $(shell git rev-parse --short=8 HEAD)
+PACKAGE_VERSION := $(shell grep __version__ oasislmf/__init__.py | cut -d '=' -f 2 | xargs)
+
+ROOT := $(PWD)
+
+TESTS_ROOT := $(ROOT)/tests
+
+DOCS_ROOT := $(PROJECT_ROOT)/docs
+DOCS_BUILD := $(DOCS_ROOT)/_build
+DOCS_BUILD_HTML := $(DOCS_ROOT)/_build/html
+
+
+# Make everything (possible)
+all:
+
+# Housekeeping
+clean:
+	@echo "\n$(PACKAGE_NAME)[$(BRANCH)@$(HEAD)]: Deleting all temporary files\n"
+	rm -fr docs/_build/* .pytest_cache *.pyc *__pycache__* ./dist/* ./build/* *.egg-info*
+
+# A simple version check for the installed package (local, sdist or wheel)
+version_check:
+	@echo "\n$(PACKAGE_NAME)[$(BRANCH)@$(HEAD)]: Checking installed package version (if it is installed)\n"
+	python3 -c "import os; os.chdir('oasislmf'); from __init__ import __version__; print(__version__); os.chdir('../')"
+
+version_extract:
+	echo "$(PACKAGE_VERSION)"
+
+unittests_jit: clean
+	@echo "\n$(PACKAGE_NAME)[$(BRANCH)@$(HEAD)]: Running unit tests (with JIT) + measuring coverage\n"
+	cd "$(PROJECT_ROOT)" && \
+	python3 -m pytest \
+				-p no:flaky \
+				--cache-clear \
+				--capture=no \
+				--code-highlight=yes \
+				--color=yes \
+				--cov-config=tox.ini \
+				--cov=oasislmf \
+				--cov-report=xml \
+				--cov-report=term-missing:skip-covered \
+				--dist worksteal \
+				--ignore=fm_testing_tool \
+				--ignore=validation \
+				--numprocesses=auto \
+				--tb=native \
+				--verbosity=3 \
+				tests
+
+unittests_nojit: clean
+	@echo "\n$(PACKAGE_NAME)[$(BRANCH)@$(HEAD)]: Running unit tests (no JIT) + measuring coverage\n"
+	cd "$(PROJECT_ROOT)" && \
+	python3 -m pytest \
+				-p no:flaky \
+				--cache-clear \
+				--capture=no \
+				--code-highlight=yes \
+				--color=yes \
+				--cov-config=tox.ini \
+				--cov=oasislmf \
+				--cov-report=xml \
+				--cov-report=term-missing:skip-covered \
+				--dist worksteal \
+				--ignore=fm_testing_tool \
+				--ignore=validation \
+				--numprocesses=auto \
+				--tb=native \
+				--verbosity=3 \
+				--gul-rtol 1e-3 \
+				--gul-atol 1e-3 \
+				tests

--- a/requirements.in
+++ b/requirements.in
@@ -10,6 +10,7 @@ pip-tools>=2.0.2
 pytest
 pytest-cov
 pytest-ignore-flaky
+pytest-xdist
 sphinx-autoapi
 tox
 responses<=0.25.3

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,23 @@ omit =
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
-commands = pytest -p no:flaky --ignore=fm_testing_tool --ignore=validation --cov-config=tox.ini --cov=oasislmf --cov-report=xml --cov-report=term {posargs}
-#$commands = pytest -p no:flaky --ignore=fm_testing_tool --ignore=validation --cov-config=tox.ini --cov=oasislmf {posargs} --doctest-modules
+commands = pytest -p no:flaky \
+            --cache-clear \
+            --capture=no \
+            --code-highlight=yes \
+            --color=yes \
+            --cov-config=tox.ini \
+            --cov=oasislmf \
+            --cov-report=xml \
+            --cov-report=term-missing:skip-covered \
+            --dist worksteal \
+            --ignore=fm_testing_tool \
+            --ignore=validation \
+            --numprocesses=auto \
+            --tb=native \
+            --verbosity=3 \
+            {posargs}
+
 setenv =
     COV_CORE_SOURCE={toxinidir}/oasislmf
     COV_CORE_CONFIG={toxinidir}/setup.cfg


### PR DESCRIPTION
@sambles I'm requesting a review for this evaluation PR with the following changes:

* Speed up unit tests, which currently seem to be sequentially run and take up to 30 minutes in the pipeline, by distributing the load across multiple (available) physical CPUs on the runner, using [pytest-xdist](https://pytest-xdist.readthedocs.io/en/stable/distribution.html), which has been added to `requirements.in`. This is implemented by using the `-n/--numprocesses auto` pytest flag combined with `--dist worksteal` to ensure the load is distributed as evenly as possible among all available physical CPUs. The use of `-n logical` would enable a load distribution over available logical CPUs, but `auto` has been preferred here. This should, ideally, reduce the overall runtime by a factor of about N, where N is the number of physical CPUs. (Not sure what the speedup factor would be for logical CPUs, due to hyperthreading issues.) An additional improvement, **not included**, is to use an environment variable to set`auto` (for physical CPU distribution) or `logical` (for logical CPU distribution), depending on the platform and/or runner. 

* A Makefile with targets to run unit tests, with JIT enabled (`make unittests_jit`) and JIT disabled (`make unittests_nojit`), plus updating the `unittest.yml` workflow to use these Makefile targets in test execution. The same Makefile targets can be used to run the tests locally in a more compact way.

* Code coverage configuration updated to include branches in measurement: this may reduce overall coverage because it exposes missing branches. This is the recommended approach.

* Other minor improvements include the display of missing source line numbers in the code coverage report (source lines in the `cov` target not covered by test cases), while skipping covered lines, with `--cov-report=term-missing:skip-covered`, setting the verbosity of test execution output to level 3 (`--verbosity=3`), and also ensuring code highlighting (`--code-highlight=yes`) and colorisation (`--color=yes`) in the output.