### PR TITLE
specify parquet folder to improve footprint read time

### DIFF
--- a/oasislmf/pytools/getmodel/footprint.py
+++ b/oasislmf/pytools/getmodel/footprint.py
@@ -333,10 +333,13 @@ class FootprintParquet(Footprint):
 
         Returns: (np.array[Event]) the event that was extracted
         """
-        reader = self.get_df_reader("footprint.parquet", filters=[("event_id", "==", event_id)])
-
-        numpy_data = self.prepare_df_data(data_frame=reader.as_pandas())
-        return numpy_data
+        dir_path = f"footprint.parquet/event_id={event_id}/"
+        if self.storage.exists(dir_path):
+            reader = self.get_df_reader(dir_path)
+            numpy_data = self.prepare_df_data(data_frame=reader.as_pandas())
+            return numpy_data
+        else:
+            return np.empty(0, dtype=Event)
 
 
 class FootprintParquetDynamic(Footprint):


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Improve parquet footprint performance
specify the event folder when reading footprint parquet file. 
The parquet S3 interface is quite slow to filter by event even if it is partition by event.
This change improve greatly the performance by targeting the relevant folder when retrieving a footprint event  

This help to partially solve https://github.com/OasisLMF/OasisLMF/issues/1600
<!--end_release_notes-->
