### PR TITLE
Fix workaround for failing data null string tests 

### DIFF
--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -27,8 +27,11 @@ from oasislmf.utils.data import (PANDAS_DEFAULT_NULL_VALUES, factorize_array,
 from oasislmf.utils.exceptions import OasisException
 
 
-# for now excluded "nan" as it breaks the current loading from csv
-text = lambda *args, **kwargs: _text(*args, **kwargs).filter(lambda e: e != "nan")
+# Excluded all "nan" Strings as it breaks the testing
+#
+#  This is a workaround for fragile tests, these are generally not very good or meaningful and should be
+#  removed or rewritten.
+text = lambda *args, **kwargs: _text(*args, **kwargs).filter(lambda e: e not in PANDAS_DEFAULT_NULL_VALUES)
 
 
 def arrays_are_identical(expected, result):
@@ -594,8 +597,8 @@ class TestGetDataframe(TestCase):
             expected.columns = expected.columns.str.lower()
 
             result = get_dataframe(src_fp=fp.name, non_na_cols=non_na_cols)
-
             pd.testing.assert_frame_equal(result, expected)
+
         finally:
             os.remove(fp.name)
 


### PR DESCRIPTION
<!--start_release_notes-->
### Fix workaround for failing data null string tests 
fix for https://github.com/OasisLMF/OasisLMF/issues/1651
<!--end_release_notes-->
