### PR TITLE
fix for  empty geopandas df sjoin not supported in geopandas 1.x

### DIFF
--- a/oasislmf/lookup/builtin.py
+++ b/oasislmf/lookup/builtin.py
@@ -505,24 +505,25 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
             else:
                 gdf_loc = gpd.GeoDataFrame(locations, columns=locations.columns)
 
-            gdf_loc["loc_geometry"] = gdf_loc.apply(lambda row: Point(row["longitude"], row["latitude"]),
-                                                    axis=1,
-                                                    result_type='reduce')
-            gdf_loc = gdf_loc.set_geometry('loc_geometry')
+            if not gdf_loc.empty:
+                gdf_loc["loc_geometry"] = gdf_loc.apply(lambda row: Point(row["longitude"], row["latitude"]),
+                                                        axis=1,
+                                                        result_type='reduce')
+                gdf_loc = gdf_loc.set_geometry('loc_geometry')
 
-            gdf_loc = gpd.sjoin(gdf_loc, gdf_area_peril, 'left')
+                gdf_loc = gpd.sjoin(gdf_loc, gdf_area_peril, 'left')
 
-            if nearest_neighbor_min_distance > 0:
-                gdf_loc_na = gdf_loc.loc[gdf_loc['index_right'].isna()]
+                if nearest_neighbor_min_distance > 0:
+                    gdf_loc_na = gdf_loc.loc[gdf_loc['index_right'].isna()]
 
-                if gdf_loc_na.shape[0]:
-                    gdf_area_peril.set_geometry('center', inplace=True)
-                    nearest_neighbor_df = nearest_neighbor(gdf_loc_na, gdf_area_peril, return_dist=True)
+                    if gdf_loc_na.shape[0]:
+                        gdf_area_peril.set_geometry('center', inplace=True)
+                        nearest_neighbor_df = nearest_neighbor(gdf_loc_na, gdf_area_peril, return_dist=True)
 
-                    gdf_area_peril.set_geometry(base_geometry_name, inplace=True)
-                    valid_nearest_neighbor = nearest_neighbor_df['distance'] <= nearest_neighbor_min_distance
-                    common_col = list(set(gdf_loc_na.columns) & set(nearest_neighbor_df.columns))
-                    gdf_loc.loc[valid_nearest_neighbor.index, common_col] = nearest_neighbor_df.loc[valid_nearest_neighbor, common_col]
+                        gdf_area_peril.set_geometry(base_geometry_name, inplace=True)
+                        valid_nearest_neighbor = nearest_neighbor_df['distance'] <= nearest_neighbor_min_distance
+                        common_col = list(set(gdf_loc_na.columns) & set(nearest_neighbor_df.columns))
+                        gdf_loc.loc[valid_nearest_neighbor.index, common_col] = nearest_neighbor_df.loc[valid_nearest_neighbor, common_col]
             if not null_gdf_loc.empty:
                 gdf_loc = pd.concat([gdf_loc, null_gdf_loc])
             self.set_id_columns(gdf_loc, id_columns)


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### fix for empty geopandas df sjoin not supported in geopandas 1.x
this fix an issue that can come up if a part location dataframe has no lat long and the lookup use rtree built in
In geopandas 1.0.1, empty dataframe are not suported input of sjoin and raise the error
`  File "/home/ubuntu/venv/lib/python3.12/site-packages/shapely/strtree.py", line 271, in query
    indices = self._tree.query(geometry, predicate)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Array should be of object dtype
`
<!--end_release_notes-->
