### PR TITLE
Improve loading and memory usage of Aggregate Vulnerability

### DIFF
--- a/oasislmf/pytools/gulmc/aggregate.py
+++ b/oasislmf/pytools/gulmc/aggregate.py
@@ -10,8 +10,6 @@ import pandas as pd
 from numba import njit
 from numba.typed import Dict, List
 from numba.types import int32 as nb_int32
-from numba.types import uint32 as nb_uint32
-from numba.types import float32 as nb_float32
 
 from oasis_data_manager.filestore.backends.base import BaseStorage
 from oasislmf.pytools.common.data import areaperil_int, nb_areaperil_int, nb_oasis_float

--- a/oasislmf/pytools/gulmc/aggregate.py
+++ b/oasislmf/pytools/gulmc/aggregate.py
@@ -24,7 +24,7 @@ AGG_VULN_WEIGHTS_VAL_TYPE = nb.types.float32
 AggregateVulnerability = nb.from_dtype(np.dtype([('aggregate_vulnerability_id', np.int32),
                                                  ('vulnerability_id', np.int32), ]))
 
-VulnerabilityWeight = nb.from_dtype(np.dtype([('areaperil_id', np.int32),
+VulnerabilityWeight = nb.from_dtype(np.dtype([('areaperil_id', areaperil_int),
                                               ('vulnerability_id', np.int32),
                                               ('weight', np.float32)]))
 

--- a/oasislmf/pytools/gulmc/aggregate.py
+++ b/oasislmf/pytools/gulmc/aggregate.py
@@ -143,16 +143,21 @@ def process_aggregate_vulnerability(aggregate_vulnerability):
 
 
 @nb.njit(cache=True)
-def process_vulnerability_weights(areaperil_dict, aggregate_weights, agg_vuln_to_vuln_id):
+def process_vulnerability_weights(areaperil_dict, vuln_dict, aggregate_weights):
     """Rearrange vulnerability weights from tabular format to a map between (areaperil_id, vulnerability_id) and the vulnerability weight.
+    note: in areaperil_dict, there is no aggregate vulnerability, if one is present in items,
+        the dis-aggregated detailed vuln_in are in areaperil_dict
 
     Args:
         areaperil_dict: dict of areaperil to dict of vuln_id to 0 (0 represent the index but is not set yet)
+        vuln_dict: vuln_dict (Tuple[Dict[int, int]): vulnerability dictionary.
         aggregate_weights (np.array[VulnerabilityWeight]): vulnerability weights table.
+
         agg_vuln_to_vuln_id (dict[int, list[int]]): map of aggregate vulnerability id to list of vulnerability ids.
 
     Returns:
-        dict[AGG_VULN_WEIGHTS_KEY_TYPE, AGG_VULN_WEIGHTS_VAL_TYPE]: map of areaperil_id, vulnerability id to weight.
+        dict[AGG_VULN_WEIGHTS_KEY_TYPE, AGG_VULN_WEIGHTS_VAL_TYPE]: map between the areaperil id and the index where the vulnerability function
+          is stored in `vuln_array` and the vulnerability weight.
     """
     areaperil_vuln_id_to_weight = gen_empty_areaperil_vuln_ids_to_weights()
 
@@ -161,16 +166,14 @@ def process_vulnerability_weights(areaperil_dict, aggregate_weights, agg_vuln_to
 
     for areaperil_id in areaperil_dict:
         for vuln_id in areaperil_dict[areaperil_id]:
-            if vuln_id in agg_vuln_to_vuln_id:
-                for relevant_vuln_id in agg_vuln_to_vuln_id[vuln_id]:
-                    areaperil_vuln_id_to_weight[nb_areaperil_int(areaperil_id), nb_int32(relevant_vuln_id)] = nb_oasis_float(0)
-            else:
-                areaperil_vuln_id_to_weight[nb_areaperil_int(areaperil_id), nb_int32(vuln_id)] = nb_oasis_float(0)
+            areaperil_vuln_id_to_weight[(nb_areaperil_int(areaperil_id), vuln_dict[vuln_id])] = nb_oasis_float(0)
 
     for i in range(len(aggregate_weights)):
         rec = aggregate_weights[i]
-        if (nb_areaperil_int(rec['areaperil_id']), nb_int32(rec['vulnerability_id'])) in areaperil_vuln_id_to_weight:
-            areaperil_vuln_id_to_weight[nb_areaperil_int(rec['areaperil_id']), nb_int32(rec['vulnerability_id'])] = nb_oasis_float(rec['weight'])
+        if rec['vulnerability_id'] in vuln_dict:
+            key = (nb_areaperil_int(rec['areaperil_id']), vuln_dict[rec['vulnerability_id']])
+            if key in areaperil_vuln_id_to_weight:
+                areaperil_vuln_id_to_weight[key] = nb_oasis_float(rec['weight'])
 
     return areaperil_vuln_id_to_weight
 
@@ -195,31 +198,3 @@ def map_agg_vuln_ids_to_agg_vuln_idxs(agg_vulns, agg_vuln_to_vuln_id, vuln_dict)
         agg_vuln_to_vuln_idxs[agg] = List([vuln_dict[vuln] for vuln in agg_vuln_to_vuln_id[agg]])
 
     return agg_vuln_to_vuln_idxs
-
-
-@njit(cache=True)
-def map_areaperil_vuln_id_to_weight_to_areaperil_vuln_idx_to_weight(areaperil_to_vulns, areaperil_vuln_id_to_weight, vuln_dict):
-    """Make map between aggregate vulnerability id and the list of sub-vulnerability ids of which they are composed, where the
-    value of the sub-vulnerability id is the internal pointer (i.e., the index, startinf from 0) to the dense array where they are stored,
-    not the vulnerability id (which starts from 1).
-
-    Args:
-        areaperil_to_vulns (List[int32])
-        areaperil_vuln_id_to_weight (dict[AGG_VULN_WEIGHTS_KEY_TYPE, AGG_VULN_WEIGHTS_VAL_TYPE]): map of areaperil_id, vulnerability id to weight.
-        vuln_dict (Tuple[Dict[int, int]): vulnerability dictionary.
-
-    Returns:
-        dict[AGG_VULN_WEIGHTS_KEY_TYPE, AGG_VULN_WEIGHTS_VAL_TYPE]: map between the areaperil id and the index where the vulnerability function 
-          is stored in `vuln_array` and the vulnerability weight.
-    """
-    areaperil_vuln_idx_to_weight = Dict.empty(AGG_VULN_WEIGHTS_KEY_TYPE, AGG_VULN_WEIGHTS_VAL_TYPE)
-
-    if len(areaperil_vuln_id_to_weight) > 0:
-        for ap in areaperil_to_vulns:
-            for vuln in areaperil_to_vulns[ap]:
-                if tuple((ap, vuln)) in areaperil_vuln_id_to_weight:
-                    # if the weights file contains this definition, add this entry to the map.
-                    # otherwise, the weight of this (areaperil_id, vulnerability_id) is assumed to be zero during loss calculation.
-                    areaperil_vuln_idx_to_weight[tuple((ap, vuln_dict[vuln]))] = areaperil_vuln_id_to_weight[tuple((ap, vuln))]
-
-    return areaperil_vuln_idx_to_weight

--- a/oasislmf/pytools/gulmc/manager.py
+++ b/oasislmf/pytools/gulmc/manager.py
@@ -199,9 +199,6 @@ def run(run_dir,
                 f"Vulnerability weights file not found at {model_storage.get_storage_url('', print_safe=True)[1]}"
             )
 
-        # create map of weights by (areaperil_id, vuln_id)
-        areaperil_vuln_id_to_weight = process_vulnerability_weights(aggregate_weights, agg_vuln_to_vuln_id)
-
         logger.debug('import items and correlations tables')
         # since items and correlations have the same granularity (one row per item_id) we merge them on `item_id`.
         correlations_tb = read_correlations(input_path, ignore_file_type)
@@ -257,6 +254,7 @@ def run(run_dir,
         agg_vuln_to_vuln_idxs = map_agg_vuln_ids_to_agg_vuln_idxs(used_agg_vuln_ids, agg_vuln_to_vuln_id, vuln_dict)
 
         # remap (areaperil, vuln_id) to weights to (areaperil, vuln_idx) to weights
+        areaperil_vuln_id_to_weight = process_vulnerability_weights(areaperil_dict, aggregate_weights, agg_vuln_to_vuln_id)
         areaperil_vuln_idx_to_weight = map_areaperil_vuln_id_to_weight_to_areaperil_vuln_idx_to_weight(
             areaperil_dict, areaperil_vuln_id_to_weight, vuln_dict)
 

--- a/oasislmf/pytools/gulmc/manager.py
+++ b/oasislmf/pytools/gulmc/manager.py
@@ -31,7 +31,6 @@ from oasislmf.pytools.gul.random import (compute_norm_cdf_lookup, compute_norm_i
 from oasislmf.pytools.gul.utils import binary_search
 from oasislmf.pytools.gulmc.aggregate import (
     map_agg_vuln_ids_to_agg_vuln_idxs,
-    map_areaperil_vuln_id_to_weight_to_areaperil_vuln_idx_to_weight,
     process_aggregate_vulnerability, process_vulnerability_weights, read_aggregate_vulnerability,
     read_vulnerability_weights)
 from oasislmf.pytools.gulmc.common import (AREAPERIL_TO_EFF_VULN_KEY_TYPE,
@@ -253,10 +252,8 @@ def run(run_dir,
         # agg_vuln_to_vuln_idxs can contain less aggregate vulnerability ids compared to agg_vuln_to_vuln_id
         agg_vuln_to_vuln_idxs = map_agg_vuln_ids_to_agg_vuln_idxs(used_agg_vuln_ids, agg_vuln_to_vuln_id, vuln_dict)
 
-        # remap (areaperil, vuln_id) to weights to (areaperil, vuln_idx) to weights
-        areaperil_vuln_id_to_weight = process_vulnerability_weights(areaperil_dict, aggregate_weights, agg_vuln_to_vuln_id)
-        areaperil_vuln_idx_to_weight = map_areaperil_vuln_id_to_weight_to_areaperil_vuln_idx_to_weight(
-            areaperil_dict, areaperil_vuln_id_to_weight, vuln_dict)
+        # load weight for relevant areaperil_id vuln_id combination
+        areaperil_vuln_idx_to_weight = process_vulnerability_weights(areaperil_dict, vuln_dict, aggregate_weights)
 
         # set up streams
         if file_out is None or file_out == '-':


### PR DESCRIPTION
…nerability

<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Improve loading and memory usage of Aggregate Vulnerability
During the loading of the aggregate weight, all possible combination of areaperil and vulnerability where loaded.
This change use the item areaperil and vulnerability as filter to only load relevant weight
<!--end_release_notes-->

note:
Also convert the loading function to numba for extra time performance.
Locally on Bangladesh model, the total gulmc time went from more than 4 min to 9 seconds
