### PR TITLE
add keys in error for loc_id not modelled

### DIFF
--- a/oasislmf/lookup/builtin.py
+++ b/oasislmf/lookup/builtin.py
@@ -584,12 +584,18 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
             split_df.index = split_df.index.droplevel(-1)
             split_df.name = 'peril_group_id'
 
-            location = locations.join(split_df).merge(peril_groups_df)
+            peril_locations = locations.join(split_df).merge(peril_groups_df)
             if model_perils_covered:
                 df_model_perils_covered = pd.Series(model_perils_covered)
                 df_model_perils_covered.name = 'model_perils_covered'
-                location = location.merge(df_model_perils_covered, left_on='peril_id', right_on='model_perils_covered')
-            return location
+                peril_locations = peril_locations.merge(df_model_perils_covered, left_on='peril_id', right_on='model_perils_covered')
+
+            not_covered_location = locations[~locations['loc_id'].isin(peril_locations['loc_id'])]
+            if not not_covered_location.empty:
+                not_covered_location['status'] = OASIS_KEYS_STATUS['notatrisk']
+                not_covered_location['message'] = not_covered_location[perils_covered_column].astype(str) + " have no perils modelled"
+                peril_locations = pd.concat([peril_locations, not_covered_location], ignore_index=True)
+            return peril_locations
         return fct
 
     @staticmethod


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Fix error when no peril is modelled from peril covered
When checking that all loc_id where processed after lookup, an error was arising when an exposure had only peril covered that was not modelled.
This change adds the loc_id to the error key file with message:
perils_covered + " have no perils modelled"

<!--end_release_notes-->
