### PR TITLE
use equi-weight as default for vuln blending

### DIFF
--- a/oasislmf/pytools/gulmc/manager.py
+++ b/oasislmf/pytools/gulmc/manager.py
@@ -870,27 +870,15 @@ def compute_event_losses(event_id,
 
                             # cache the weights and compute the total weights
                             tot_weights = 0.
-                            used_weights = []
+                            used_weights = np.zeros(len(agg_vulns_idx), dtype=np.float64)
                             for j, vuln_i in enumerate(agg_vulns_idx):
                                 if (areaperil_id, vuln_i) in areaperil_vuln_idx_to_weight:
-                                    weight = np.float64(areaperil_vuln_idx_to_weight[(areaperil_id, vuln_i)])
-                                else:
-                                    weight = np.float64(0.)
-
-                                used_weights.append(weight)
-                                tot_weights += weight
+                                    used_weights[j] = np.float64(areaperil_vuln_idx_to_weight[(areaperil_id, vuln_i)])
+                                    tot_weights += used_weights[j]
 
                             if tot_weights == 0.:
-                                print("Impossible to compute the cdf of the following aggregate vulnerability_id because individual weights are all zero.\n"
-                                      "Please double check the weights table for the areaperil_id listed below.")
-                                print("aggregate vulnerability_id=", vulnerability_id)
-                                print("individual vulnerability_ids=", agg_vulns_idx)
-                                print("item_id=", item_id)
-                                print("event=", event_id)
-                                print("areaperil_id=", areaperil_id)
-                                print()
-                                raise ValueError(
-                                    "Impossible to compute the cdf of an aggregate vulnerability_id because individual weights are all zero.")
+                                used_weights[:] = 1
+                                tot_weights = used_weights.shape[0]
 
                             # compute the weighted cdf
                             damage_bin_i = nb_int32(0)


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Use equi-weight as default for vuln blending
Apply default rule, all vuln_id under an aggregated vulnerability have the same weight (=1), if no weight is provided instead of raising an error

<!--end_release_notes-->
