### PR TITLE
fix/forex-python_url

### DIFF
--- a/tests/computation/test_generate_files.py
+++ b/tests/computation/test_generate_files.py
@@ -1,6 +1,7 @@
 import pathlib
 import os
 import logging
+import re
 import responses
 
 from unittest import mock
@@ -150,7 +151,12 @@ class TestGenFiles(ComputationChecker):
             "datetime": "2018-10-10"
         }
 
-        responses.get(url='https://theforexapi.com/api/2018-10-10?base=GBP&symbols=JPY&rtype=fpy', json={'rates': {"JPY": 180.4}})
+        responses.add(
+            responses.GET,
+            re.compile(r'https://(theforexapi|theratesapi)\.com/api/.*'),
+            json={'rates': {"JPY": 180.4}},
+            status=200
+        )
         mock_get_il_items.return_value = FAKE_IL_ITEMS_RETURN
         currency_config_file = self.tmp_files.get('currency_conversion_json')
         self.write_json(currency_config_file, currency_config)


### PR DESCRIPTION


<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### fix/forex-python_url
the forex-python library was recently updates after 4 years to switch from theforexapi.com to theratesapi.com, which causes one of our test cases to fail.
updates responses url search to search for old and new forex-python api urls
<!--end_release_notes-->
