### PR TITLE
Remove generation of unused random samples in gulmc

### DIFF
--- a/oasislmf/pytools/gulmc/manager.py
+++ b/oasislmf/pytools/gulmc/manager.py
@@ -456,11 +456,21 @@ def run(run_dir,
                     byte_mv
                 )
 
-                # generation of "base" random values for hazard intensity and vulnerability sampling
-                haz_rndms_base = generate_rndm(haz_seeds[:hazard_rng_index], sample_size)
-                vuln_rndms_base = generate_rndm(vuln_seeds[:rng_index], sample_size)
-                haz_eps_ij = generate_rndm(haz_corr_seeds, sample_size, skip_seeds=1)
-                damage_eps_ij = generate_rndm(damage_corr_seeds, sample_size, skip_seeds=1)
+
+                # since these are never used outside of a sample > 0 branch we can remove the need to 
+                # generate (and potentially allocate) the random values. As at 2.3.5 the sampling method 
+                # for random values accounts for 25% of the runtime of the losses step not including 
+                # the get_event despite having a sample size of 0. 
+                haz_rndms_base = np.empty((hazard_rng_index, sample_size), dtype='float64')
+                vuln_rndms_base = np.empty((rng_index, sample_size), dtype='float64')
+                haz_eps_ij = np.empty((haz_corr_seeds, sample_size), dtype='float64')
+                damage_eps_ij = np.empty((damage_corr_seeds, sample_size), dtype='float64')
+                if sample_size > 0:
+                    # generation of "base" random values for hazard intensity and vulnerability sampling
+                    haz_rndms_base = generate_rndm(haz_seeds[:hazard_rng_index], sample_size) 
+                    vuln_rndms_base = generate_rndm(vuln_seeds[:rng_index], sample_size) 
+                    haz_eps_ij = generate_rndm(haz_corr_seeds, sample_size, skip_seeds=1) 
+                    damage_eps_ij = generate_rndm(damage_corr_seeds, sample_size, skip_seeds=1)
 
                 # create vulnerability cdf cache
                 cached_vuln_cdfs = np.zeros((Nvulns_cached, compute_info['Ndamage_bins_max']), dtype=oasis_float)


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Remove generation of unused random samples in gulmc when sample_size is 0 
The gulmc calculation for each event before calculating losses generates a set of random numbers. 
Since these are never used outside of a sample > 0 branch we can remove the need to generate (and potentially allocate - currently failing to jit compile if set to None) the random values. 

As at 2.3.5 the sampling method for random values accounts for 25% of the runtime of the losses step not including get_event despite having a sample size of 0. This has likely increased proportionaly with the increase in random numbers being generated in 2.4.x.

<!--end_release_notes-->
