### PR TITLE
fix/lecpy `bin` tests assert equality with rounding

### DIFF
--- a/tests/pytools/lecpy/test_lecpy.py
+++ b/tests/pytools/lecpy/test_lecpy.py
@@ -4,6 +4,7 @@ import pandas as pd
 from tempfile import TemporaryDirectory
 
 import numpy as np
+from oasislmf.pytools.lec.data import EPT_dtype
 from oasislmf.pytools.lec.manager import main
 
 TESTS_ASSETS_DIR = Path(__file__).parent.parent.parent.joinpath("assets").joinpath("test_lecpy")
@@ -70,8 +71,9 @@ def case_runner(sub_folder, test_name, out_ext="csv", use_return_period=False):
                 actual_ept_data = pd.read_parquet(actual_ept)
                 pd.testing.assert_frame_equal(expected_ept_data, actual_ept_data)
             if out_ext == "bin":
-                with open(expected_ept, 'rb') as f1, open(actual_ept, 'rb') as f2:
-                    assert f1.read() == f2.read()
+                expected_ept_data = pd.DataFrame(np.fromfile(expected_ept, dtype=EPT_dtype))
+                actual_ept_data = pd.DataFrame(np.fromfile(actual_ept, dtype=EPT_dtype))
+                pd.testing.assert_frame_equal(expected_ept_data, actual_ept_data)
         except Exception as e:
             error_path.mkdir(exist_ok=True)
             shutil.copyfile(actual_ept, Path(error_path, ept_outfile_name))
@@ -90,8 +92,9 @@ def case_runner(sub_folder, test_name, out_ext="csv", use_return_period=False):
                 actual_psept_data = pd.read_parquet(actual_psept)
                 pd.testing.assert_frame_equal(expected_psept_data, actual_psept_data)
             if out_ext == "bin":
-                with open(expected_psept, 'rb') as f1, open(actual_psept, 'rb') as f2:
-                    assert f1.read() == f2.read()
+                expected_ept_data = pd.DataFrame(np.fromfile(expected_ept, dtype=EPT_dtype))
+                actual_ept_data = pd.DataFrame(np.fromfile(actual_ept, dtype=EPT_dtype))
+                pd.testing.assert_frame_equal(expected_ept_data, actual_ept_data)
         except Exception as e:
             error_path.mkdir(exist_ok=True)
             shutil.copyfile(actual_psept, Path(error_path, psept_outfile_name))

--- a/tests/pytools/lecpy/test_lecpy.py
+++ b/tests/pytools/lecpy/test_lecpy.py
@@ -4,7 +4,7 @@ import pandas as pd
 from tempfile import TemporaryDirectory
 
 import numpy as np
-from oasislmf.pytools.lec.data import EPT_dtype
+from oasislmf.pytools.lec.data import EPT_dtype, PSEPT_dtype
 from oasislmf.pytools.lec.manager import main
 
 TESTS_ASSETS_DIR = Path(__file__).parent.parent.parent.joinpath("assets").joinpath("test_lecpy")
@@ -92,9 +92,9 @@ def case_runner(sub_folder, test_name, out_ext="csv", use_return_period=False):
                 actual_psept_data = pd.read_parquet(actual_psept)
                 pd.testing.assert_frame_equal(expected_psept_data, actual_psept_data)
             if out_ext == "bin":
-                expected_ept_data = pd.DataFrame(np.fromfile(expected_ept, dtype=EPT_dtype))
-                actual_ept_data = pd.DataFrame(np.fromfile(actual_ept, dtype=EPT_dtype))
-                pd.testing.assert_frame_equal(expected_ept_data, actual_ept_data)
+                expected_psept_data = pd.DataFrame(np.fromfile(expected_psept, dtype=PSEPT_dtype))
+                actual_psept_data = pd.DataFrame(np.fromfile(actual_psept, dtype=PSEPT_dtype))
+                pd.testing.assert_frame_equal(expected_psept_data, actual_psept_data)
         except Exception as e:
             error_path.mkdir(exist_ok=True)
             shutil.copyfile(actual_psept, Path(error_path, psept_outfile_name))


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### fix/lecpy `bin` tests assert equality with rounding
- comparing bytes of binary files does not account for rounding
- loads `bin` files as dataframes instead to confirm equality
<!--end_release_notes-->
