### PR TITLE
fix level_id when an extra account level is needed

### DIFF
--- a/oasislmf/preparation/gul_inputs.py
+++ b/oasislmf/preparation/gul_inputs.py
@@ -269,8 +269,10 @@ def get_gul_input_items(
 
     # make query to retain only rows with positive TIV for each coverage type, e.g.: (coverage_type_id == 1 and BuildingsTIV > 0.0) or (...)
     positive_TIV_query = " or ".join(
-        map(lambda cov_type: f"(coverage_type_id == {cov_type} and {tiv_terms[cov_type]} > 0.0)", gul_inputs_df.coverage_type_id.unique()))
-
+        (f"(coverage_type_id == {cov_type} and {tiv_terms[cov_type]} > 0.0)" for cov_type in gul_inputs_df.coverage_type_id.unique()
+         if tiv_terms[cov_type] in gul_inputs_df))
+    if len(positive_TIV_query) == 0:
+        raise OasisException("No TIV columns were found in Exposure files")
     gul_inputs_df[tiv_col].fillna(0, inplace=True)  # convert null T&C values to 0
     gul_inputs_df.query(positive_TIV_query, inplace=True)  # remove rows with TIV=null or TIV=0
 

--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -778,7 +778,7 @@ def get_il_input_items(
                                                             .union(set(useful_cols).difference(set(gul_inputs_df.columns)))
                                                             .intersection(accounts_df.columns))])
             level_df['orig_level_id'] = level_id
-            level_df['level_id'] = len(il_inputs_df_list) + 2
+            level_df['level_id'] = len(il_inputs_df_list) + 1
             level_df['agg_id'] = factorize_ndarray(level_df.loc[:, agg_key].values, col_idxs=range(len(agg_key)))[0]
             prev_level_df['to_agg_id'] = (prev_level_df[['gul_input_id']]
                                           .merge(level_df.drop_duplicates(subset=['gul_input_id'])[['gul_input_id', 'agg_id']])['agg_id'])


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Fix issue with invalid level id value when pass-through policy layer is needed for top level agggregation
In order to support the correct value for fm a1 allocation rule, some portfolio need an extra pass-through level to aggregate all location into one agg_id. In this case the level_id was incorrect leading to a KeyError in the financial module in the create-financial-structure-files step.
Also fix an issue with optional TIV columns
<!--end_release_notes-->
