### PR TITLE
use pd explode to split peril covered columns

### DIFF
--- a/oasislmf/lookup/builtin.py
+++ b/oasislmf/lookup/builtin.py
@@ -236,10 +236,10 @@ class PerilCoveredDeterministicLookup(AbstractBasicKeyLookup):
         model_perils_covered = np.unique(pd.DataFrame({'peril_group_id': self.config['model_perils_covered']})
                                          .merge(peril_groups_df)['peril_id'])
         peril_covered_column = 'LocPerilsCovered' if 'LocPerilsCovered' in locations.columns else 'PolPerilsCovered'
-        split_df = locations[peril_covered_column].str.split(';').apply(pd.Series).stack()
-        split_df.index = split_df.index.droplevel(-1)
-        split_df.name = 'peril_group_id'
-        keys_df = locations.join(split_df).merge(peril_groups_df)[['loc_id', 'peril_id']]
+
+        locations['peril_group_id'] = locations[peril_covered_column].str.split(';')
+        keys_df = locations.explode('peril_group_id').drop_duplicates().merge(peril_groups_df)[['loc_id', 'peril_id']]
+        locations.drop(columns='peril_group_id')
 
         coverage_df = pd.DataFrame({'coverage_type': self.config['supported_oed_coverage_types']}, dtype='Int32')
         keys_df = keys_df.sort_values('loc_id', kind='stable').merge(coverage_df, how="cross")
@@ -581,11 +581,10 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
             else:
                 raise OasisException('missing PerilsCovered column in location')
 
-            split_df = locations[perils_covered_column].astype(str).str.split(';').apply(pd.Series).stack()
-            split_df.index = split_df.index.droplevel(-1)
-            split_df.name = 'peril_group_id'
+            locations['peril_group_id'] = locations[perils_covered_column].str.split(';')
+            peril_locations = locations.explode('peril_group_id').drop_duplicates().merge(peril_groups_df)
+            locations.drop(columns='peril_group_id')
 
-            peril_locations = locations.join(split_df).merge(peril_groups_df)
             if model_perils_covered:
                 df_model_perils_covered = pd.Series(model_perils_covered)
                 df_model_perils_covered.name = 'model_perils_covered'


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### small performance improvement for builtin lookup function split_loc_perils_covered
use pd explode function instead of pd series stack() and drop level to split the peril columns into multiple peril lines.
Test on Piwind full portfolio shows that the key file generation go from around 1.8 s to 0.9 s
<!--end_release_notes-->
