### PR TITLE
remove top level duplicate before xref merge to avoid massive cartesian product

### DIFF
--- a/oasislmf/preparation/summaries.py
+++ b/oasislmf/preparation/summaries.py
@@ -97,7 +97,8 @@ calculated_summary_cols = {'is_property_damage': is_property_damage}
 
 
 def get_xref_df(il_inputs_df):
-    top_level_layers_df = il_inputs_df.loc[il_inputs_df['level_id'] == il_inputs_df['level_id'].max(), ['top_agg_id'] + SUMMARY_TOP_LEVEL_COLS]
+    top_level_layers_df = il_inputs_df.loc[il_inputs_df['level_id'] == il_inputs_df['level_id'].max(),
+                                           ['top_agg_id'] + SUMMARY_TOP_LEVEL_COLS].drop_duplicates()
     bottom_level_layers_df = il_inputs_df[il_inputs_df['level_id'] == 0]
     bottom_level_layers_df.drop(columns=SUMMARY_TOP_LEVEL_COLS, inplace=True)
     return (merge_dataframes(bottom_level_layers_df, top_level_layers_df, join_on=['top_agg_id'])


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### fix get_xref_df memory consumption issue
remove duplicated lines representing the top fm level to avoid issue with memory consumption due to cartesian product of those duplicated lines.
This product happens for each policy layer account that had no term creating OOM error in big empty account exposure

<!--end_release_notes-->
