### PR TITLE
support for mac M2 multiprocessing lookup

### DIFF
--- a/oasislmf/lookup/factory.py
+++ b/oasislmf/lookup/factory.py
@@ -29,10 +29,8 @@ from .builtin import Lookup as NewLookup
 
 try:
     import billiard as multiprocessing
-    from billiard import cpu_count, Queue, Process
 except ImportError:
     import multiprocessing
-    from multiprocessing import cpu_count, Queue, Process
 
 from queue import Empty, Full
 

--- a/oasislmf/lookup/factory.py
+++ b/oasislmf/lookup/factory.py
@@ -541,7 +541,7 @@ class BasicKeyServer:
         else:
             config_dir = self.config_dir
 
-        pool_count = num_cores if num_cores > 0 else cpu_count()
+        pool_count = num_cores if num_cores > 0 else multiprocessing.cpu_count()
         if num_partitions > 0:
             part_count = num_partitions
         else:


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### support for mac m2 in lookup multiprocessing
Apply suggested change to support mac m2 architecture in multiprocessing lookup.
- use multiprocessing.get_context("fork") to create a context object that will create the queue and process
- make target function module function instead of static method to avoid pickle error.
<!--end_release_notes-->
