### PR TITLE
bypass amplification.bin load in pla when uniform factor is provided

### DIFF
--- a/oasislmf/pytools/pla/manager.py
+++ b/oasislmf/pytools/pla/manager.py
@@ -40,8 +40,13 @@ def run(
         os.path.join(run_dir, static_path),
     )
 
-    items_amps = read_amplifications(input_path)
-    plafactors = get_post_loss_amplification_factors(model_storage, secondary_factor, uniform_factor)
+    if uniform_factor > 0:
+        items_amps = None
+        plafactors  = None
+    else:
+        items_amps = read_amplifications(input_path)
+        plafactors = get_post_loss_amplification_factors(model_storage, secondary_factor)
+
 
     # Set default factor should post loss amplification factor be missing
     default_factor = 1.0 if uniform_factor == 0.0 else uniform_factor

--- a/oasislmf/pytools/pla/structure.py
+++ b/oasislmf/pytools/pla/structure.py
@@ -16,7 +16,7 @@ from .common import PLAFACTORS_FILE
 logger = logging.getLogger(__name__)
 
 
-def get_post_loss_amplification_factors(storage: BaseStorage, secondary_factor, uniform_factor, ignore_file_type=set()):
+def get_post_loss_amplification_factors(storage: BaseStorage, secondary_factor, ignore_file_type=set()):
     """
     Get Post Loss Amplification (PLA) factors mapped to event ID-item ID pair.
     Returns empty dictionary if uniform factor to apply across all losses has
@@ -39,17 +39,11 @@ def get_post_loss_amplification_factors(storage: BaseStorage, secondary_factor, 
         storage: (BaseStorage) the storage connector for fetching the model data
         secondary_factor (float): secondary factor to apply to post loss
           amplification
-        uniform_factor (float): uniform factor to apply across all losses
         ignore_file_type: set(str) file extension to ignore when loading
 
     Returns:
         plafactors (dict): event ID-item ID pairs mapped to amplification IDs
     """
-    if uniform_factor > 0.0:
-        return Dict.empty(
-            key_type=types.UniTuple(types.int64, 2), value_type=types.float64
-        )
-
     input_files = set(storage.listdir())
     if PLAFACTORS_FILE in input_files and 'bin' not in ignore_file_type:
         plafactors = read_lossfactors(storage.root_dir, set(["csv"]), PLAFACTORS_FILE)

--- a/tests/pytools/pla/test_plapy.py
+++ b/tests/pytools/pla/test_plapy.py
@@ -283,7 +283,7 @@ class TestPostLossAmplification(TestCase):
         second_uni_out = NamedTemporaryFile(prefix='plaseconduni')
         run(
             run_dir='.', file_in=self.gul_in.name, file_out=second_uni_out.name,
-            input_path='input', static_path='static',
+            input_path='input_nowhere', static_path='static_nowhere',
             secondary_factor=self.second_factor, uniform_factor=self.uni_factor
         )
 


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### bypass amplification.bin load in post loss amplification when uniform factor is provided
When a uniform factor is provided, amplification.bin load is not needed. This remove this step and allow user to provide this factor without the need to create the amplification.bin file
<!--end_release_notes-->
