### PR TITLE
fix/trailing slash missing for `settings_template` endpoint

### DIFF
--- a/oasislmf/platform_api/client.py
+++ b/oasislmf/platform_api/client.py
@@ -223,7 +223,7 @@ class SettingTemplatesBaseEndpoint(object):
         self.url_resource = url_resource
 
     def _build_url(self, model_pk, ID=None):
-        url_components = [self.url_endpoint, str(model_pk), 'setting_templates']
+        url_components = [self.url_endpoint, str(model_pk), 'setting_templates/']
         if ID is not None:
             url_components += [str(ID)]
 

--- a/tests/platform_api/test_client.py
+++ b/tests/platform_api/test_client.py
@@ -718,7 +718,7 @@ class SettingTemplatesBaseEndpointTest(unittest.TestCase):
     def test_buil_url__no_id(self):
         model_pk = 123
         expected_url = '{}/{}/{}/'.format(self.url_endpoint, model_pk,
-                                               'setting_templates')
+                                          'setting_templates')
         result = self.api__noresource._build_url(model_pk)
         self.assertEqual(result, expected_url)
 
@@ -735,7 +735,7 @@ class SettingTemplatesBaseEndpointTest(unittest.TestCase):
     @given(model_pk=st.integers(min_value=1), ID=st.integers(min_value=1))
     def test_get__model_id(self, model_pk, ID):
         expected_url = '{}/{}/{}/{}'.format(self.url_endpoint, model_pk,
-                                               'setting_templates', ID)
+                                            'setting_templates', ID)
         responses.get(url=expected_url, json=[])
         logger = logging.getLogger(__name__)
         logger.info(f'expected_url: {expected_url}')
@@ -747,7 +747,7 @@ class SettingTemplatesBaseEndpointTest(unittest.TestCase):
     @given(model_pk=st.integers(min_value=1))
     def test_get(self, model_pk):
         expected_url = '{}/{}/{}/'.format(self.url_endpoint, model_pk,
-                                         'setting_templates')
+                                          'setting_templates')
         responses.get(url=expected_url, json=[])
 
         rsp = self.api__noresource.get(model_pk)

--- a/tests/platform_api/test_client.py
+++ b/tests/platform_api/test_client.py
@@ -694,11 +694,12 @@ class SettingTemplatesBaseEndpointTest(unittest.TestCase):
         assert responses, 'responses package required to run'
         self.url_endpoint = 'http://example.com/api'
         self.session = create_api_session(self.url_endpoint)
-        self.url_resource = 'resource'
+        self.url_resource = 'resource/'
         self.headers = {
             'accept': 'application/json',
             'content-type': 'application/json',
         }
+        self.api__noresource = SettingTemplatesBaseEndpoint(self.session, self.url_endpoint)
         self.api = SettingTemplatesBaseEndpoint(self.session, self.url_endpoint, self.url_resource)
         responses.start()
 
@@ -714,8 +715,15 @@ class SettingTemplatesBaseEndpointTest(unittest.TestCase):
         result = self.api._build_url(model_pk, ID)
         self.assertEqual(result, expected_url)
 
+    def test_buil_url__no_id(self):
+        model_pk = 123
+        expected_url = '{}/{}/{}/'.format(self.url_endpoint, model_pk,
+                                               'setting_templates')
+        result = self.api__noresource._build_url(model_pk)
+        self.assertEqual(result, expected_url)
+
     @given(model_pk=st.integers(min_value=1), ID=st.integers(min_value=1))
-    def test_get_resource(self, model_pk, ID):
+    def test_get__resource(self, model_pk, ID):
         expected_url = '{}/{}/{}/{}/{}'.format(self.url_endpoint, model_pk,
                                                'setting_templates', ID,
                                                self.url_resource)
@@ -724,15 +732,25 @@ class SettingTemplatesBaseEndpointTest(unittest.TestCase):
         rsp = self.api.get(model_pk, ID)
         self.assertEqual(rsp.url, expected_url)
 
+    @given(model_pk=st.integers(min_value=1), ID=st.integers(min_value=1))
+    def test_get__model_id(self, model_pk, ID):
+        expected_url = '{}/{}/{}/{}'.format(self.url_endpoint, model_pk,
+                                               'setting_templates', ID)
+        responses.get(url=expected_url, json=[])
+        logger = logging.getLogger(__name__)
+        logger.info(f'expected_url: {expected_url}')
+
+        rsp = self.api__noresource.get(model_pk, ID)
+        logger.info(f'rsp_url: {rsp.url}')
+        self.assertEqual(rsp.url, expected_url)
+
     @given(model_pk=st.integers(min_value=1))
     def test_get(self, model_pk):
-        expected_url = '{}/{}/{}'.format(self.url_endpoint, model_pk,
+        expected_url = '{}/{}/{}/'.format(self.url_endpoint, model_pk,
                                          'setting_templates')
         responses.get(url=expected_url, json=[])
 
-        self.api.url_resource = None
-        rsp = self.api.get(model_pk)
-        self.api.url_resource = 'resource'
+        rsp = self.api__noresource.get(model_pk)
         self.assertEqual(rsp.url, expected_url)
 
     @given(model_pk=st.integers(min_value=1), ID=st.integers(min_value=1), data=st.dictionaries(keys=st.text(), values=st.text()))


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### fix/trailing slash missing for `setting_templates`endpoint
- trailing slash missing when no `ID` provided
- add tests to check for trailing slash
<!--end_release_notes-->
