### PR TITLE
add cyber perils to hardcoded AA1 list of perils

### DIFF
--- a/oasislmf/utils/peril.py
+++ b/oasislmf/utils/peril.py
@@ -46,7 +46,7 @@ PRL_GRP_ZZ1 = 'ZZ1'
 PRL_GRP_CC1 = 'CC1'
 
 PERIL_GROUPS = OrderedDict({
-    'all': {'id': PRL_GRP_AA1, 'desc': 'All perils', 'peril_ids': [PRL_QEQ, PRL_QFF, PRL_QTS, PRL_QSL, PRL_QLS, PRL_QLF, PRL_WTC, PRL_WEC, PRL_WSS, PRL_ORF, PRL_OSF, PRL_XSL, PRL_XTD, PRL_XHL, PRL_ZSN, PRL_ZIC, PRL_ZFZ, PRL_BFR, PRL_BBF, PRL_MNT, PRL_MTR, PRL_XLT, PRL_ZST, PRL_BSK]},
+    'all': {'id': PRL_GRP_AA1, 'desc': 'All perils', 'peril_ids': [PRL_QEQ, PRL_QFF, PRL_QTS, PRL_QSL, PRL_QLS, PRL_QLF, PRL_WTC, PRL_WEC, PRL_WSS, PRL_ORF, PRL_OSF, PRL_XSL, PRL_XTD, PRL_XHL, PRL_ZSN, PRL_ZIC, PRL_ZFZ, PRL_BFR, PRL_BBF, PRL_MNT, PRL_MTR, PRL_XLT, PRL_ZST, PRL_BSK, PRL_CSB, PRL_CPD]},
     'wildfire w/ smoke': {'id': PRL_GRP_BB1, 'desc': 'Wildfire with smoke', 'peril_ids': [PRL_BBF, PRL_BSK]},
     'terrorism': {'id': PRL_GRP_MM1, 'desc': 'Terrorism', 'peril_ids': [PRL_MNT, PRL_MTR]},
     'flood w/o storm surge': {'id': PRL_GRP_OO1, 'desc': 'Flood w/o storm surge', 'peril_ids': [PRL_ORF, PRL_OSF]},


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### add cyber perils to hardcoded AA1 list of perils
Allow exposure run to work without the need to specify cyber perils in --model-perils-covered
<!--end_release_notes-->
