### PR TITLE
bypass amplification.bin load in pla when uniform factor is provided (backport)

### DIFF
--- a/oasislmf/pytools/pla/manager.py
+++ b/oasislmf/pytools/pla/manager.py
@@ -42,8 +42,12 @@ def run(
         os.path.join(run_dir, static_path),
     )
 
-    items_amps = get_items_amplifications(input_path)
-    plafactors = get_post_loss_amplification_factors(model_storage, secondary_factor, uniform_factor)
+    if uniform_factor > 0:
+        items_amps = None
+        plafactors = None
+    else:
+        items_amps = get_items_amplifications(input_path)
+        plafactors = get_post_loss_amplification_factors(model_storage, secondary_factor)
 
     # Set default factor should post loss amplification factor be missing
     default_factor = 1.0 if uniform_factor == 0.0 else uniform_factor

--- a/oasislmf/pytools/pla/streams.py
+++ b/oasislmf/pytools/pla/streams.py
@@ -62,6 +62,36 @@ def read_buffer(byte_mv, cursor, valid_buff, event_id, item_id, items_amps, plaf
     return cursor, event_id, item_id, 1
 
 
+@nb.jit(nopython=True, cache=True)
+def read_buffer_uniform(byte_mv, cursor, valid_buff, event_id, item_id, items_amps, plafactors, default_factor, out_byte_mv, out_cursor):
+    while True:
+        if item_id:
+            if valid_buff - cursor < (oasis_int_size + oasis_float_size):
+                break
+            sidx, cursor = mv_read(byte_mv, cursor, oasis_int, oasis_int_size)
+            if sidx:
+                loss, _ = mv_read(byte_mv, cursor, oasis_float, oasis_float_size)
+                loss = 0 if np.isnan(loss) else loss
+
+                ###### do loss read ######
+                cursor = mv_write(byte_mv, cursor, oasis_float, oasis_float_size, loss * default_factor)
+                ##########
+
+            else:
+                ##### do item exit ####
+                ##########
+                cursor += oasis_float_size
+                item_id = 0
+        else:
+            if valid_buff - cursor < 2 * oasis_int_size:
+                break
+            event_id, cursor = mv_read(byte_mv, cursor, oasis_int, oasis_int_size)
+            item_id, cursor = mv_read(byte_mv, cursor, oasis_int, oasis_int_size)
+    out_byte_mv[:cursor] = byte_mv[:cursor]
+    out_cursor[0] = cursor
+    return cursor, event_id, item_id, 1
+
+
 class PlaReader(EventReader):
     def __init__(self, items_amps, plafactors, default_factor):
         self.items_amps = items_amps
@@ -73,10 +103,15 @@ class PlaReader(EventReader):
         self.event_id = 0
         self.item_id = 0
 
+        if self.items_amps is None and self.plafactors is None:
+            self.reader = read_buffer_uniform
+        else:
+            self.reader = read_buffer
+
         self.logger = logger
 
     def read_buffer(self, byte_mv, cursor, valid_buff, event_id, item_id):
-        cursor, self.event_id, self.item_id, yield_event = read_buffer(
+        cursor, self.event_id, self.item_id, yield_event = self.reader(
             byte_mv, cursor, valid_buff, self.event_id, self.item_id,
             self.items_amps, self.plafactors, self.default_factor, self.out_byte_mv, self.out_cursor
         )

--- a/oasislmf/pytools/pla/structure.py
+++ b/oasislmf/pytools/pla/structure.py
@@ -107,7 +107,7 @@ def fill_post_loss_amplification_factors(
     return event_id, count, plafactors
 
 
-def get_post_loss_amplification_factors(storage: BaseStorage, secondary_factor, uniform_factor, ignore_file_type=set()):
+def get_post_loss_amplification_factors(storage: BaseStorage, secondary_factor, ignore_file_type=set()):
     """
     Get Post Loss Amplification (PLA) factors mapped to event ID-item ID pair.
     Returns empty dictionary if uniform factor to apply across all losses has
@@ -130,7 +130,6 @@ def get_post_loss_amplification_factors(storage: BaseStorage, secondary_factor, 
         storage: (BaseStorage) the storage connector for fetching the model data
         secondary_factor (float): secondary factor to apply to post loss
           amplification
-        uniform_factor (float): uniform factor to apply across all losses
         ignore_file_type: set(str) file extension to ignore when loading
 
     Returns:
@@ -139,8 +138,6 @@ def get_post_loss_amplification_factors(storage: BaseStorage, secondary_factor, 
     plafactors = Dict.empty(
         key_type=types.UniTuple(types.int64, 2), value_type=types.float64
     )
-    if uniform_factor > 0.0:
-        return plafactors
 
     input_files = set(storage.listdir())
     if LOSS_FACTORS_FILE_NAME in input_files and 'bin' not in ignore_file_type:

--- a/tests/pytools/pla/test_plapy.py
+++ b/tests/pytools/pla/test_plapy.py
@@ -285,7 +285,7 @@ class TestPostLossAmplification(TestCase):
         second_uni_out = NamedTemporaryFile(prefix='plaseconduni')
         run(
             run_dir='.', file_in=self.gul_in.name, file_out=second_uni_out.name,
-            input_path='input', static_path='static',
+            input_path='input_nowhere', static_path='static_nowhere',
             secondary_factor=self.second_factor, uniform_factor=self.uni_factor
         )
 


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### bypass amplification.bin load in post loss amplification when uniform factor is provided
When a uniform factor is provided, amplification.bin load is not needed. This PR remove this step and allow user to provide a uniform factor without the need to create the amplification.bin file
<!--end_release_notes-->
