### PR TITLE
add environment variables and coerce into integers

### DIFF
--- a/oasislmf/lookup/factory.py
+++ b/oasislmf/lookup/factory.py
@@ -316,8 +316,8 @@ class BasicKeyServer:
         ('message', 'Message')
     ])
 
-    min_bloc_size = int(os.environ.get('KEY_FILE_MIN_BLOC_SIZE', 1000))
-    max_bloc_size = int(os.environ.get('KEY_FILE_MAX_BLOC_SIZE', 10000))
+    min_bloc_size = int(os.environ.get('OASIS_MIN_BLOC_SIZE', 1000))
+    max_bloc_size = int(os.environ.get('OASIS_MAX_BLOC_SIZE', 10000))
 
     def __init__(self, config, config_dir=None, user_data_dir=None, output_dir=None):
         self.config = config


### PR DESCRIPTION
#1810 - Issue

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Environment Variable Overrides for min/max_bloc_size
Add environment variables to override the min/max_bloc_size in the BasicKeyServer
<!--end_release_notes-->
