### PR TITLE
Fixed merging analyses computation_settings on the platform

### DIFF
--- a/oasislmf/computation/base.py
+++ b/oasislmf/computation/base.py
@@ -141,7 +141,7 @@ class ComputationStep:
         computation_settings.add_settings(func_args, ROOT_USER_ROLE)
         for settings_info in cls.get_params(param_type="settings"):
             setting_fp = func_args.get(settings_info["name"])
-            if setting_fp:
+            if setting_fp and pathlib.Path(setting_fp).exists():
                 new_settings = settings_info["loader"](setting_fp)
                 computation_settings.add_settings(
                     new_settings.pop("computation_settings", {}), {'admin'}


### PR DESCRIPTION
<!--start_release_notes-->
### Fixed merging analyses computation_settings on the platform
The computation_settings sections in analyses and model settings are not pickup and merged by the platform. 
Fixed so it works the same way as MDK   
<!--end_release_notes-->

> Note: we might want to do something better with `USER_ROLE` so **admin** accounts can do this but not normal users?

  

