### PR TITLE
Pandas 3.0.0 causing tests to  break

### DIFF
--- a/requirements-package.in
+++ b/requirements-package.in
@@ -9,7 +9,7 @@ numexpr
 numpy>=1.18
 ods-tools>=4.0.5
 oasis-data-manager>=0.1.1
-pandas>=1.0.3,!=1.1.0,!=1.1.1
+pandas>=1.0.3,!=1.1.0,!=1.1.1,!=3.0.0
 pyarrow>=15.0.0
 pytz
 requests-toolbelt


### PR DESCRIPTION
New release of pandas 3.0.0 has issues causing unit tests to break
Tests failing on main: https://github.com/OasisLMF/OasisLMF/actions/runs/21244839588/job/61131485051
Pandas 3: https://pandas.pydata.org/docs/whatsnew/v3.0.0.html