### PR TITLE
fixup parquet key file exposure run

### DIFF
--- a/oasislmf/computation/run/exposure.py
+++ b/oasislmf/computation/run/exposure.py
@@ -99,8 +99,7 @@ class RunExposure(ComputationStep):
             os.makedirs(run_dir)
 
         # 1. Create Deterministic keys file
-        keys_fp = os.path.join(run_dir, 'keys.csv')
-        GenerateKeysDeterministic(**{**self.kwargs, **{"keys_data_path": keys_fp, "exposure_data": exposure_data}}).run()
+        keys_fp = GenerateKeysDeterministic(**{**self.kwargs, **{"exposure_data": exposure_data}}).run()[0]
 
         # 2. Start Oasis files generation
         GenerateFiles(


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
<!--end_release_notes-->
### Summary
- Fixed `RunExposure` hardcoding `keys.csv` path, which broke parquet key file support

### Changes
- Use the keys file path returned by `GenerateKeysDeterministic().run()` instead of hardcoding `keys.csv`
- This ensures the correct format (parquet or csv) is used downstream