### PR TITLE
CI Fix - testinstall ods/piwind from last stable, not main

### DIFF
--- a/.github/workflows/piwind-mdk.yml
+++ b/.github/workflows/piwind-mdk.yml
@@ -34,5 +34,5 @@ jobs:
     with:
       mdk_branch: ${{ github.ref }}
       mdk_run_type: ${{ github.event_name != 'workflow_dispatch' && 'ri' || inputs.mdk_run_type }}
-      piwind_branch: ${{ github.event_name != 'workflow_dispatch' && 'main' || inputs.piwind_branch }}
-      ods_branch: ${{ github.event_name != 'workflow_dispatch' && 'main' || inputs.ods_branch }}
+      piwind_branch: ${{ github.event_name != 'workflow_dispatch' && 'stable/2.4.x' || inputs.piwind_branch }}
+      ods_branch: ${{ github.event_name != 'workflow_dispatch' && 'stable/4.0.x' || inputs.ods_branch }}

--- a/.github/workflows/piwind-test.yml
+++ b/.github/workflows/piwind-test.yml
@@ -53,7 +53,7 @@ jobs:
     uses: OasisLMF/ODS_Tools/.github/workflows/build.yml@main
     secrets: inherit
     with:
-      ods_branch: ${{ github.event_name != 'workflow_dispatch' && 'main' ||  inputs.ods_branch }}
+      ods_branch: ${{ github.event_name != 'workflow_dispatch' && 'stable/4.0.x' ||  inputs.ods_branch }}
 
   platform1:
     if: ${{ ! failure() || ! cancelled() }}
@@ -61,7 +61,7 @@ jobs:
     secrets: inherit
     needs: [build, ods_tools]
     with:
-      piwind_branch: ${{ github.event_name != 'workflow_dispatch' && 'main' || inputs.piwind_branch }}
+      piwind_branch: ${{ github.event_name != 'workflow_dispatch' && 'stable/2.4.x' || inputs.piwind_branch }}
       oasislmf_package: ${{ needs.build.outputs.linux_pkg_filename }}
       oasislmf_branch: ''
       ods_package: ${{ needs.ods_tools.outputs.whl_filename }}
@@ -76,7 +76,7 @@ jobs:
     secrets: inherit
     needs: [build, ods_tools]
     with:
-      piwind_branch: ${{ github.event_name != 'workflow_dispatch' && 'main' || inputs.piwind_branch }}
+      piwind_branch: ${{ github.event_name != 'workflow_dispatch' && 'stable/2.4.x' || inputs.piwind_branch }}
       oasislmf_package: ${{ needs.build.outputs.linux_pkg_filename }}
       oasislmf_branch: ''
       ods_package: ${{ needs.ods_tools.outputs.whl_filename }}

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -35,7 +35,7 @@ jobs:
     uses: OasisLMF/ODS_Tools/.github/workflows/build.yml@main
     secrets: inherit
     with:
-      ods_branch: ${{ github.event_name != 'workflow_dispatch' && 'main' ||  inputs.ods_branch }} # Enable 'ods-tools' build by default
+      ods_branch: ${{ github.event_name != 'workflow_dispatch' && 'stable/4.0.x' ||  inputs.ods_branch }} # Enable 'ods-tools' build by default
 
   unittest:
     if: ${{ ! failure() || ! cancelled() }}


### PR DESCRIPTION
<!--start_release_notes-->
### CI Fix - testinstall ods/piwind from last stable, not main
Need to test with prev versions not current development 
<!--end_release_notes-->
