### PR TITLE
latest docker tag repaced with 2.5

### DIFF
--- a/.github/workflows/piwind-test.yml
+++ b/.github/workflows/piwind-test.yml
@@ -58,7 +58,7 @@ jobs:
       oasislmf_package: ${{ needs.build.outputs.linux_pkg_filename }}
       oasislmf_branch: ''
       ods_package: ${{ needs.ods_tools.outputs.whl_filename }}
-      platform_version: ${{ github.event_name != 'workflow_dispatch' && 'latest' ||  inputs.platform_1_version }}
+      platform_version: ${{ github.event_name != 'workflow_dispatch' && '2.5' ||  inputs.platform_1_version }}
       pytest_opts: "--docker-compose=./docker/plat2-v2.docker-compose.yml"
       worker_api_ver: 'v1'
       storage_suffix: '_platform1'
@@ -73,7 +73,7 @@ jobs:
       oasislmf_package: ${{ needs.build.outputs.linux_pkg_filename }}
       oasislmf_branch: ''
       ods_package: ${{ needs.ods_tools.outputs.whl_filename }}
-      platform_version: ${{ github.event_name != 'workflow_dispatch' && 'latest' ||  inputs.platform_2_version }}
+      platform_version: ${{ github.event_name != 'workflow_dispatch' && '2.5' ||  inputs.platform_2_version }}
       pytest_opts: "--docker-compose=./docker/plat2-v2.docker-compose.yml"
       worker_api_ver: 'v2'
       storage_suffix: '_platform2'


### PR DESCRIPTION
<!--start_release_notes-->
### latest docker tag repaced with 2.5
`2.5` is now the latest set of images from `2.5.x` oasis stable, same with `2.4` --> `2.4.x` when they release
<!--end_release_notes-->
