### PR TITLE
Fix typos and incorrect CLI docstrings

### DIFF
--- a/oasislmf/__init__.py
+++ b/oasislmf/__init__.py
@@ -53,7 +53,7 @@ class MyImport(MetaPathFinder):
     """
 
     def __init__(self):
-        self.depricated_modules = {
+        self.deprecated_modules = {
             "model_execution": "execution",
             "model_preparation": "preparation",
             "api": "platform",
@@ -64,14 +64,14 @@ class MyImport(MetaPathFinder):
         import_path = fullname.split(".", 1)
         if fullname.startswith("oasislmf") and len(import_path) > 1:
             import_path = import_path[1]
-            for deprecated in self.depricated_modules:
+            for deprecated in self.deprecated_modules:
                 if deprecated == import_path or import_path.startswith(deprecated + '.'):
                     with warnings.catch_warnings():
                         warnings.simplefilter("always")
                         warnings.warn(
-                            f"imports from 'oasislmf.{deprecated}' are deprecated. Import by using 'oasislmf.{self.depricated_modules[deprecated]}' instead."
+                            f"imports from 'oasislmf.{deprecated}' are deprecated. Import by using 'oasislmf.{self.deprecated_modules[deprecated]}' instead."
                         )
-                    import_path = import_path.replace(deprecated, self.depricated_modules[deprecated])
+                    import_path = import_path.replace(deprecated, self.deprecated_modules[deprecated])
 
             return spec_from_loader(fullname, MyLoader(import_path))
 

--- a/oasislmf/cli/model.py
+++ b/oasislmf/cli/model.py
@@ -28,8 +28,8 @@ class GenerateExposurePreAnalysisCmd(OasisComputationCommand):
 
 class GeneratePostFileGenCmd(OasisComputationCommand):
     """
-    Generate a new EOD from original one by specifying a model specific pre-analysis hook for exposure modification
-    see ExposurePreAnalysis for more detail
+    Run a post file generation hook to modify or expand the generated Oasis files
+    before loss calculation.
     """
     formatter_class = RawDescriptionHelpFormatter
     computation_name = 'PostFileGen'
@@ -37,8 +37,7 @@ class GeneratePostFileGenCmd(OasisComputationCommand):
 
 class GeneratePrelossCmd(OasisComputationCommand):
     """
-    Generate a new EOD from original one by specifying a model specific pre-analysis hook for exposure modification
-    see ExposurePreAnalysis for more detail
+    Run a pre-loss hook on each worker to modify input files before loss calculation.
     """
     formatter_class = RawDescriptionHelpFormatter
     computation_name = 'PreLoss'
@@ -63,8 +62,7 @@ class GenerateOasisFilesCmd(OasisComputationCommand):
 
 class GenerateLossesCmd(OasisComputationCommand):
     """
-    Generates the standard Oasis GUL input files + optionally the IL/FM input
-    files and the RI input files.
+    Run loss calculations with optional pre-loss and post-analysis hooks.
     """
     formatter_class = RawDescriptionHelpFormatter
     computation_name = 'GenerateOasisLosses'
@@ -72,7 +70,7 @@ class GenerateLossesCmd(OasisComputationCommand):
 
 class GenerateLossesPartialCmd(OasisComputationCommand):
     """
-    Distributed Oasis CMD: desc todo
+    Runs a single analysis event chunk.
     """
     formatter_class = RawDescriptionHelpFormatter
     computation_name = 'GenerateLossesPartial'
@@ -80,7 +78,7 @@ class GenerateLossesPartialCmd(OasisComputationCommand):
 
 class GenerateLossesOutputCmd(OasisComputationCommand):
     """
-    Distributed Oasis CMD: desc todo
+    Runs the output reports generation on a set of event chunks.
     """
     formatter_class = RawDescriptionHelpFormatter
     computation_name = 'GenerateLossesOutput'

--- a/oasislmf/computation/base.py
+++ b/oasislmf/computation/base.py
@@ -224,4 +224,4 @@ class ComputationStep:
 
     def run(self):
         """method that will be call by all the interface to execute the computation step"""
-        raise NotImplemented(f'Methode run must be implemented in {self.__class__.__name__}')
+        raise NotImplementedError(f'Method run must be implemented in {self.__class__.__name__}')


### PR DESCRIPTION
There was a typo in init.py where "deprecated" was spelled "depricated" in a variable name. Also spotted that base.py was raising NotImplemented instead of NotImplementedError. They look similar but NotImplemented is a special constant used for operator overloading, not an exception.

Fixed a typo "Methode", in there too. Also, several CLI command docstrings in model.py were either placeholder text saying "desc todo" or had been copy pasted from the wrong command, so users would see incorrect help text.