### PR TITLE
fix/oidc_header_fix

### DIFF
--- a/oasislmf/platform_api/session.py
+++ b/oasislmf/platform_api/session.py
@@ -71,6 +71,7 @@ class APISession(Session):
         if self.auth_type == "token":
             self.tkn_access = self.auth_credentials["access_token"]
             self.tkn_refresh = self.auth_credentials["refresh_token"]
+            self.headers['authorization'] = 'Bearer {}'.format(self.tkn_access)
             return
         try:
             url = urljoin(self.url_base, 'access_token/')


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### fix/oidc_header_fix
Sets "authorization" header in request for access_token, was missing when auth_type was token. 
required for https://github.com/OasisLMF/OasisPythonUI/pull/49 to work with authentik
<!--end_release_notes-->
