### PR TITLE
use bin file in exposure run

### DIFF
--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -754,7 +754,8 @@ class GenerateLossesDeterministic(ComputationStep):
         move_bin(self.oasis_files_dir, output_dir)
 
         # Generate an items and coverages dataframe and set column types (important!!)
-        cov_df = pd.DataFrame(load_as_ndarray(self.output_dir, 'coverages', np.dtype([tiv_dtype[0:2]]), must_exist=True)).reset_index(names="coverage_id")
+        cov_df = pd.DataFrame(load_as_ndarray(self.output_dir, 'coverages', np.dtype(
+            [tiv_dtype[0:2]]), must_exist=True)).reset_index(names="coverage_id")
         cov_df["coverage_id"] += 1
         items = merge_dataframes(
             pd.DataFrame(load_as_ndarray(self.output_dir, 'items', items_dtype, must_exist=True)),


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### fix items.csv read issue in exposure run
Use item and coverage bin file to read from when doing exposure run
<!--end_release_notes-->
