### PR TITLE
feat: Native Apple Silicon (macOS arm64) installation support

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -1,0 +1,89 @@
+# Workflow to validate oasislmf installation and basic functionality on macOS ARM64
+#
+# This runs on every PR and push to main to catch macOS-specific regressions.
+# It is intentionally lightweight — install + smoke test only — to keep CI costs low.
+
+name: macOS ARM64 Smoke Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - stable**
+  workflow_dispatch:
+
+jobs:
+  macos-arm64-install:
+    runs-on: macos-14  # Apple Silicon (M1) runner
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Verify ARM64 architecture
+        run: |
+          python -c "import platform; arch = platform.machine(); print(f'Architecture: {arch}'); assert arch == 'arm64', f'Expected arm64, got {arch}'"
+
+      - name: Install oasislmf from source
+        run: |
+          pip install --upgrade pip
+          pip install -e .
+
+      - name: Run validation script
+        run: python scripts/validate_install.py
+
+      - name: Smoke test - CLI entry point
+        run: oasislmf --help
+
+      - name: Smoke test - import and version
+        run: |
+          python -c "
+          import oasislmf
+          print(f'Version: {oasislmf.__version__}')
+
+          # Verify key submodules import
+          from oasislmf.pytools.fm.cli import main as fm_main
+          from oasislmf.pytools.gulpy import main as gul_main
+          from oasislmf.execution.bin import check_conversion_tools
+          print('All key submodules imported successfully')
+          "
+
+      - name: Smoke test - numba JIT compilation
+        run: |
+          python -c "
+          import numpy as np
+          from numba import njit
+
+          @njit
+          def test_jit(x):
+              return x * 2.0 + 1.0
+
+          result = test_jit(np.float64(21.0))
+          assert result == 43.0, f'JIT test failed: expected 43.0, got {result}'
+          print('numba JIT compilation works on ARM64')
+          "
+
+      - name: Smoke test - core numerical stack
+        run: |
+          python -c "
+          import numpy as np
+          import pandas as pd
+          import scipy
+          import pyarrow
+          import fastparquet
+
+          # Basic operations to verify native code works
+          arr = np.random.rand(1000)
+          df = pd.DataFrame({'values': arr})
+          assert len(df) == 1000
+          print(f'numpy {np.__version__}, pandas {pd.__version__}, scipy {scipy.__version__}')
+          print(f'pyarrow {pyarrow.__version__}, fastparquet {fastparquet.__version__}')
+          print('Core numerical stack works on ARM64')
+          "

--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ celerybeat-schedule
 
 # virtualenv
 .venv
+.venv-*
 venv/
 ENV/
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The reusable libraries are organised into several sub-packages, the most relevan
 
 Starting from 1st January 2019, Pandas will no longer be supporting Python 2. As Pandas is a key dependency of the MDK we are **dropping Python 2 (2.7) support** as of this release (1.3.4). The last version which still supports Python 2.7 is version `1.3.3` (published 12/03/2019).
 
-Also for this release (and all future releases) a **minimum of Python 3.9 is required**.
+Also for this release (and all future releases) a **minimum of Python 3.10 is required**.
 
 
 ## Installation
@@ -82,6 +82,19 @@ Alternatively you can install the latest development version using:
 You can also install from a specific branch `<branch name>` using:
 
     pip install [-v] git+{https,ssh}://git@github.com/OasisLMF/OasisLMF.git@<branch name>#egg=oasislmf
+
+### macOS Apple Silicon (M1/M2/M3/M4)
+
+OasisLMF installs natively on Apple Silicon Macs via `pip install oasislmf`. Ensure you have:
+
+- **Python 3.10+** (the system Python on macOS is 3.9 — install via `brew install python@3.12` or pyenv)
+- **macOS 12 (Monterey) or later** (required for scipy ARM64 wheels)
+
+For optional geospatial extras (`pip install oasislmf[extra]`), also install:
+
+    brew install spatialindex geos
+
+See [docs/installation_for_mac.md](docs/installation_for_mac.md) for full details, troubleshooting, and ktools information.
 
 ## Enable Bash completion
 

--- a/docs/installation_for_mac.md
+++ b/docs/installation_for_mac.md
@@ -1,80 +1,209 @@
+# Installation on macOS (including Apple Silicon)
 
-# Installation for Mac ARM64
+## Overview
 
-When it comes to installing OasisLMF on Mac ARM64, the pre-complied binaries are not available. Therefore, the 
-installation process is a bit more complicated and the compilation needs to be local. The following steps are required 
-to install OasisLMF on Mac ARM64:
+OasisLMF is a pure Python package. Starting from version 2.5.x, `pip install oasislmf`
+works natively on Apple Silicon (M1/M2/M3/M4) Macs without Rosetta 2 emulation.
 
-First we clone the [ktools](https://github.com/OasisLMF/ktools) repo with the following command:
+All compiled dependencies (numpy, scipy, numba, pandas, pyarrow, etc.) publish
+pre-built ARM64 macOS wheels on PyPI.
 
-```bash
-git clone https://github.com/OasisLMF/ktools.git
-```
+## Prerequisites
 
-Before we run anything, we need to ensure that the following dependencies are installed:
+### Python 3.10+
 
-```bash
-brew install \
-    autoconf \
-    automake \
-    libtool \
-    zlib-ng
-```
+OasisLMF requires Python 3.10 or later. The system Python on macOS is typically 3.9,
+so you will need to install a newer version.
 
-We then move into the ktools directory with `cd ktools` and run the following commands:
+**Option A — Homebrew (recommended):**
 
 ```bash
-./autogen.sh
+brew install python@3.12
 ```
 
-We then configure the ktools with the following command:
+**Option B — pyenv:**
 
 ```bash
-./configure --enable-osx --enable-o3 --prefix=<BIN_PATH>
+brew install pyenv
+pyenv install 3.12
+pyenv local 3.12
 ```
-We could use something like ```$HOME/ktools/bin``` as the ```<BIN_PATH>```.
-We then run the checks and installation with the following command:
+
+Verify your Python version:
 
 ```bash
-make check
-make install
+python3 --version
+# Must show 3.10 or later
 ```
 
-We then have to package our compiled binary files with the command below:
+### System Libraries (for optional extras only)
+
+If you plan to use the `[extra]` dependencies (geopandas, shapely, rtree, scikit-learn),
+install the required C libraries:
 
 ```bash
-tar -zcvf ../../<OS_PLATFORM>.tar.gz ./
+brew install spatialindex geos
 ```
 
-We then move back to the root directory (`cd ..`) and clone the [oasislmf](https://github.com/OasisLMF/OasisLMF) 
-repository, move into the oasislmf directory and run the following commands:
+These are **not required** for the core `oasislmf` package.
+
+## Installation
+
+### Standard install
+
+```bash
+# Create a virtual environment (recommended)
+python3 -m venv oasis-env
+source oasis-env/bin/activate
+
+# Install oasislmf
+pip install oasislmf
+```
+
+### Install with optional geospatial extras
+
+```bash
+pip install oasislmf[extra]
+```
+
+### Install from source (development)
 
 ```bash
 git clone https://github.com/OasisLMF/OasisLMF.git
 cd OasisLMF
+
+python3 -m venv .venv
+source .venv/bin/activate
+
 pip install pip-tools
+pip-compile requirements.in -o requirements.txt
+pip install -r requirements.txt
+pip install -e .
 ```
 
-We are now ready to install the oasislmf package with the following command:
+## Post-install Validation
+
+Run the validation script to confirm everything is working:
 
 ```bash
-export OASISLMF_KTOOLS_BIN_PATH=<BIN_PATH>
-python setup.py install bdist_wheel --plat-name <OS_PLATFORM>
+python scripts/validate_install.py
 ```
 
-We then have to ensure that the required packages are installed with the following command:
+Or verify with a quick import check:
 
 ```bash
-pip install -r requirements-package.in
+python -c "import oasislmf; print(f'oasislmf {oasislmf.__version__} installed successfully')"
 ```
 
-If we want to install the extras needed we can run the following command:
+Run the CLI to confirm entry points work:
 
 ```bash
-pip install -r optional-package.in
+oasislmf --help
 ```
 
-## Tool Development
+## ktools (External C Binaries)
 
-We aim to build tools that automate such processes. We are currently developing the 
-[water seller](https://github.com/OasisLMF/water_seller) tool that automates the tasks. 
+As of OasisLMF 2.5.x, ktools binaries are **no longer bundled** with the Python
+package. OasisLMF includes Python-based replacements for the core ktools kernels:
+
+| Python tool | Replaces (ktools) | Purpose |
+|-------------|-------------------|---------|
+| `gulpy`     | `gulcalc`         | Ground-up loss calculation |
+| `gulmc`     | `gulcalc`         | GUL with Monte Carlo sampling |
+| `fmpy`      | `fmcalc`          | Financial module calculation |
+| `summarypy` | `summarycalc`     | Summary calculation |
+| `plapy`     | `placalc`         | Post-loss amplification |
+| `katpy`     | `kat`             | Concatenation tool |
+| `eltpy`     | `eltcalc`         | Event loss table |
+| `pltpy`     | `pltcalc`         | Period loss table |
+| `aalpy`     | `aalcalc`         | Average annual loss |
+| `lecpy`     | `leccalc`         | Loss exceedance curve |
+
+For most workflows, the Python-based tools are sufficient and no ktools
+installation is needed.
+
+### Building ktools from source (optional)
+
+If you need the original C-based ktools for performance or compatibility:
+
+```bash
+# Install build dependencies
+brew install autoconf automake libtool zlib-ng
+
+# Clone and build ktools
+git clone https://github.com/OasisLMF/ktools.git
+cd ktools
+./autogen.sh
+./configure --enable-osx --enable-o3 --prefix=$HOME/ktools-bin
+make check
+make install
+
+# Add to PATH
+export PATH="$HOME/ktools-bin/bin:$PATH"
+```
+
+## Troubleshooting
+
+### "No matching distribution found for oasislmf"
+
+Your Python version is likely too old. OasisLMF requires Python 3.10+:
+
+```bash
+python3 --version
+```
+
+### numba / llvmlite installation failure
+
+If numba fails to install, ensure you're using Python 3.10-3.13 and pip 23+:
+
+```bash
+pip install --upgrade pip
+pip install numba
+```
+
+If building from source is attempted (shouldn't happen with pip ≥23 on arm64),
+you may need:
+
+```bash
+brew install llvm
+```
+
+### scipy requires macOS 12+
+
+SciPy's ARM64 wheels require macOS 12.0 (Monterey) or later. If you're on an
+older macOS version, upgrade your OS or use Rosetta 2 emulation.
+
+### rtree / libspatialindex not found
+
+This only affects the `[extra]` optional dependencies:
+
+```bash
+brew install spatialindex
+pip install oasislmf[extra]
+```
+
+### Multiprocessing errors
+
+OasisLMF uses `fork` context for multiprocessing, which differs from macOS's
+default `spawn`. This is handled automatically since version 2.5.x. If you
+encounter multiprocessing issues with custom model lookups, ensure your lookup
+functions are defined at module level (not as class static methods or lambdas).
+
+## Known Limitations
+
+- **ktools C binaries** are not distributed via pip for macOS ARM64. Use the
+  Python-based kernel tools or build ktools from source.
+- **macOS < 12 (Monterey)**: scipy ARM64 wheels require macOS 12+.
+- **Python 3.14+**: not yet tested. Use Python 3.10–3.13.
+
+## Architecture Verification
+
+To confirm you're running native ARM64 (not Rosetta 2 emulation):
+
+```bash
+python3 -c "import platform; print(platform.machine())"
+# Should print: arm64
+```
+
+If it prints `x86_64`, your Python is running under Rosetta 2. Install a native
+ARM64 Python via Homebrew or pyenv.

--- a/oasislmf/execution/bin.py
+++ b/oasislmf/execution/bin.py
@@ -25,7 +25,6 @@ import glob
 import logging
 import os
 import shutil
-import shutilwhich
 import subprocess
 import tarfile
 import pandas as pd
@@ -685,7 +684,7 @@ def check_conversion_tools(il=False):
 
     for input_file in input_files:
         tool = input_file['conversion_tool']
-        if shutilwhich.which(tool) is None:
+        if shutil.which(tool) is None:
             error_message = "Failed to find conversion tool: {}".format(tool)
             logging.error(error_message)
             raise OasisException(error_message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ classifiers = [
     "Operating System :: Unix",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.10"
 

--- a/requirements-package.in
+++ b/requirements-package.in
@@ -1,6 +1,5 @@
 anytree>=2.4.3
 argparsetree>=0.0.5
-chainmap
 chardet
 fastparquet>=0.3.1
 msgpack
@@ -15,7 +14,6 @@ pytz
 requests-toolbelt
 requests>=2.20.0
 scipy
-shutilwhich
 tabulate>=0.8.2
 tblib
 tqdm

--- a/scripts/validate_install.py
+++ b/scripts/validate_install.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Post-install validation for oasislmf.
+
+Checks that the package and its key dependencies are importable and
+reports platform/architecture information for debugging.
+
+Usage:
+    python -m scripts.validate_install
+    # or after install:
+    python scripts/validate_install.py
+
+Exit codes:
+    0 - all checks passed
+    1 - one or more checks failed
+"""
+import importlib
+import platform
+import sys
+
+REQUIRED_MODULES = [
+    ("oasislmf", "oasislmf core"),
+    ("numpy", "numerical computing"),
+    ("pandas", "data manipulation"),
+    ("scipy", "scientific computing"),
+    ("numba", "JIT compilation"),
+    ("pyarrow", "columnar data / Parquet"),
+    ("fastparquet", "Parquet file support"),
+    ("numexpr", "numerical expressions"),
+    ("msgpack", "binary serialization"),
+]
+
+OPTIONAL_MODULES = [
+    ("shapely", "geometry operations (extra)"),
+    ("geopandas", "geospatial data (extra)"),
+    ("sklearn", "machine learning (extra)"),
+    ("rtree", "spatial indexing (extra)"),
+]
+
+
+def check_module(name, description):
+    """Try to import a module and return (success, version_or_error)."""
+    try:
+        mod = importlib.import_module(name)
+        version = getattr(mod, "__version__", getattr(mod, "version", "unknown"))
+        return True, version
+    except ImportError as exc:
+        return False, str(exc)
+
+
+def main():
+    print("=" * 60)
+    print("OasisLMF Installation Validation")
+    print("=" * 60)
+    print()
+    print(f"Python:       {sys.version}")
+    print(f"Platform:     {platform.platform()}")
+    print(f"Machine:      {platform.machine()}")
+    print(f"Architecture: {platform.architecture()[0]}")
+    print()
+
+    failed = False
+
+    print("--- Required Dependencies ---")
+    for name, desc in REQUIRED_MODULES:
+        ok, info = check_module(name, desc)
+        status = "OK" if ok else "FAIL"
+        print(f"  [{status:>4}] {name:<16} {info:<24} ({desc})")
+        if not ok:
+            failed = True
+
+    print()
+    print("--- Optional Dependencies (extras) ---")
+    for name, desc in OPTIONAL_MODULES:
+        ok, info = check_module(name, desc)
+        status = "OK" if ok else "SKIP"
+        print(f"  [{status:>4}] {name:<16} {info:<24} ({desc})")
+
+    print()
+
+    # Check oasislmf version specifically
+    try:
+        import oasislmf
+        print(f"oasislmf version: {oasislmf.__version__}")
+    except Exception:
+        pass
+
+    # Check for ktools binaries (informational)
+    import shutil
+    ktools_cmds = ["eve", "getmodel", "gulcalc", "fmcalc", "summarycalc"]
+    ktools_found = [cmd for cmd in ktools_cmds if shutil.which(cmd)]
+    ktools_missing = [cmd for cmd in ktools_cmds if not shutil.which(cmd)]
+
+    print()
+    print("--- ktools binaries (external, optional) ---")
+    if ktools_found:
+        print(f"  Found:   {', '.join(ktools_found)}")
+    if ktools_missing:
+        print(f"  Missing: {', '.join(ktools_missing)}")
+    if not ktools_found:
+        print("  (ktools not found on PATH — needed only for C-based execution kernels)")
+        print("  (Python-based kernels gulpy/fmpy/gulmc work without ktools)")
+
+    print()
+    if failed:
+        print("RESULT: FAIL — some required dependencies could not be imported.")
+        print("        Check the errors above and install missing packages.")
+        return 1
+    else:
+        print("RESULT: PASS — oasislmf is correctly installed.")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/data.py
+++ b/tests/data.py
@@ -24,8 +24,7 @@ __all__ = [
 import string
 
 from itertools import chain
-from chainmap import ChainMap
-from collections import OrderedDict
+from collections import ChainMap, OrderedDict
 
 import pandas as pd
 


### PR DESCRIPTION
### Release notes feature title
  Native Apple Silicon (macOS arm64) installation support

  OasisLMF now installs cleanly on Apple Silicon Macs via `pip install oasislmf` with Python 3.10+. Removed legacy
   Python 2 polyfill dependencies (`shutilwhich`, `chainmap`), rewrote macOS installation documentation to reflect
   current reality (ktools removed from package in #1836), added macOS ARM64 CI smoke tests, and added a
  post-install validation script.

  ### Summary of changes

  - **Remove legacy polyfills**: Removed `shutilwhich` and `chainmap` from `requirements-package.in`. Replaced
  `shutilwhich.which()` with stdlib `shutil.which()` in `oasislmf/execution/bin.py`. Replaced `from chainmap
  import ChainMap` with `from collections import ChainMap` in `tests/data.py`. Both are Python 2 backports
  unnecessary on Python 3.10+.

  - **Rewrite macOS installation docs**: The previous `docs/installation_for_mac.md` described a defunct ktools
  binary bundling workflow using `OASISLMF_KTOOLS_BIN_PATH` — an environment variable never implemented in code.
  Replaced with accurate instructions covering prerequisites, pip install, troubleshooting, ktools-as-optional,
  and architecture verification.

  - **Add macOS ARM64 CI**: New `.github/workflows/test-macos.yml` runs on `macos-14` (Apple Silicon M1) GitHub
  runners with Python 3.10 and 3.12. Validates architecture, install, CLI, imports, numba JIT compilation, and
  core numerical stack.

  - **Add validation script**: `scripts/validate_install.py` checks all required and optional dependencies,
  reports platform info, and verifies ktools binary availability.

  - **Update packaging metadata**: Added Python 3.11/3.12/3.13 classifiers to `pyproject.toml`. Added `.venv-*` to
   `.gitignore`.

  - **Update README.md**: Added Apple Silicon installation section. Corrected minimum Python version from 3.9 to
  3.10 (matching `pyproject.toml`).

  ### Validated on
  - macOS 15.7.3, Apple Silicon (arm64), Python 3.12.13
  - Clean `pip install` from built wheel — zero failures
  - All compiled deps (numpy, scipy, numba, pandas, pyarrow, fastparquet, numexpr, msgpack) resolve to native
  arm64 wheels
  - numba JIT compilation works on ARM64
  - No changes to Linux install path