### PR TITLE
CI adjustment for External PR's

### DIFF
--- a/.github/workflows/piwind-test-v1.yml
+++ b/.github/workflows/piwind-test-v1.yml
@@ -41,11 +41,6 @@ jobs:
       images_exist: ${{ steps.check.outputs.images_exist }}
       platform_sha: ${{ steps.check.outputs.platform_sha }}
     steps:
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Check if platform images already exist
         id: check
         run: |

--- a/.github/workflows/piwind-test-v2.yml
+++ b/.github/workflows/piwind-test-v2.yml
@@ -41,11 +41,6 @@ jobs:
       images_exist: ${{ steps.check.outputs.images_exist }}
       platform_sha: ${{ steps.check.outputs.platform_sha }}
     steps:
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Check if platform images already exist
         id: check
         run: |


### PR DESCRIPTION
<!--start_release_notes-->
### CI adjustment for External PR's 
docker login fails for external PR's, it shouldn't be needed to check for existing test images
<!--end_release_notes-->
