### PR TITLE
Correct timestamps that were off by one hour

### DIFF
--- a/oasislmf/lookup/builtin.py
+++ b/oasislmf/lookup/builtin.py
@@ -967,7 +967,7 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
 
         def h3_lookup(locations):
             valid = locations['latitude'].notna() & locations['longitude'].notna()
-            locations['h3_int64'] = 0 #  0 correponds to an invalid H3 index
+            locations['h3_int64'] = 0  # 0 correponds to an invalid H3 index
 
             if valid.any():
                 locations.loc[valid, 'h3_int64'] = [

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -41,7 +41,8 @@ import warnings
 from datetime import datetime
 from pathlib import Path
 
-from ods_tools.oed import fill_empty, OedExposure, OdsException, AnalysisSettingHandler, ModelSettingHandler
+from ods_tools.oed import (AnalysisSettingHandler, ModelSettingHandler,
+                           OdsException, OedExposure, fill_empty)
 from ods_tools.oed.oed_schema import OedSchema
 
 try:
@@ -52,16 +53,15 @@ except ImportError:
 import logging
 from typing import List, Optional
 
+import chardet
 import numpy as np
 import pandas as pd
 import pytz
-import chardet
 from chardet import UniversalDetector
 from tabulate import tabulate
 
-from oasislmf.utils.defaults import SOURCE_IDX, SAR_ID
+from oasislmf.utils.defaults import SAR_ID, SOURCE_IDX
 from oasislmf.utils.exceptions import OasisException
-
 
 logger = logging.getLogger(__name__)
 
@@ -690,7 +690,7 @@ def get_timestamp(thedate=datetime.now(), fmt='%Y%m%d%H%M%S'):
     return thedate.strftime(fmt)
 
 
-def get_utctimestamp(thedate=datetime.utcnow(), fmt='%Y-%b-%d %H:%M:%S'):
+def get_utctimestamp(thedate=datetime.now(), fmt='%Y-%b-%d %H:%M:%S'):
     """
     Get a UTC timestamp string from a ``datetime.datetime`` object
 
@@ -1140,6 +1140,11 @@ def fill_na_with_categoricals(df, fill_value):
             fill_value[col_name] = value
             if value not in col.cat.categories:
                 df[col_name] = col.cat.add_categories([value])
+
+    # Note that the following lines do not work properly with Pandas 1.1.0/1.1.1, due to a bug
+    # related to fillna and categorical dtypes. This bug should be fixed in >1.1.2.
+    # https://github.com/pandas-dev/pandas/issues/35731
+    df.fillna(value=fill_value, inplace=True)
 
     # Note that the following lines do not work properly with Pandas 1.1.0/1.1.1, due to a bug
     # related to fillna and categorical dtypes. This bug should be fixed in >1.1.2.

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -1145,8 +1145,3 @@ def fill_na_with_categoricals(df, fill_value):
     # related to fillna and categorical dtypes. This bug should be fixed in >1.1.2.
     # https://github.com/pandas-dev/pandas/issues/35731
     df.fillna(value=fill_value, inplace=True)
-
-    # Note that the following lines do not work properly with Pandas 1.1.0/1.1.1, due to a bug
-    # related to fillna and categorical dtypes. This bug should be fixed in >1.1.2.
-    # https://github.com/pandas-dev/pandas/issues/35731
-    df.fillna(value=fill_value, inplace=True)


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->
https://github.com/OasisLMF/OasisLMF/issues/1936

<!--start_release_notes-->
### Correct timestamps in directory names
Previously, losses and input generation directories could have a timestamp that was one hour behind the actual time the model was run due to incorrect handling of timezones. These directories are now named correctly with a UTC timestamp.
<!--end_release_notes-->
