### PR TITLE
Fix #1936: correct UTC timestamps in get_utctimestamp

### DIFF
--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -690,12 +690,21 @@ def get_timestamp(thedate=datetime.now(), fmt='%Y%m%d%H%M%S'):
     return thedate.strftime(fmt)
 
 
-def get_utctimestamp(thedate=datetime.utcnow(), fmt='%Y-%b-%d %H:%M:%S'):
+def get_utctimestamp(thedate=None, fmt='%Y-%b-%d %H:%M:%S'):
     """
-    Get a UTC timestamp string from a ``datetime.datetime`` object
+    Get a UTC timestamp string from a ``datetime.datetime`` object.
 
-    :param thedate: ``datetime.datetime`` object
-    :type thedate: datetime.datetime
+    When ``thedate`` is omitted, the current UTC time is used. A naive
+    ``datetime`` (no ``tzinfo``) is interpreted as UTC, matching the
+    function's name; a tz-aware ``datetime`` is converted to UTC before
+    formatting. This avoids the CPython gotcha that
+    ``naive.astimezone(utc)`` interprets naive datetimes as *local*
+    time, which caused run-directory timestamps to drift by the local
+    UTC offset on non-UTC hosts (issue #1936).
+
+    :param thedate: ``datetime.datetime`` object. If ``None`` (the
+        default), ``datetime.now(pytz.utc)`` is used.
+    :type thedate: datetime.datetime or None
 
     :param fmt: Timestamp format string, default is "%Y-%b-%d %H:%M:%S"
     :type fmt: str
@@ -703,6 +712,10 @@ def get_utctimestamp(thedate=datetime.utcnow(), fmt='%Y-%b-%d %H:%M:%S'):
     :return: UTC timestamp string
     :rtype: str
     """
+    if thedate is None:
+        thedate = datetime.now(pytz.utc)
+    elif thedate.tzinfo is None:
+        thedate = thedate.replace(tzinfo=pytz.utc)
     return thedate.astimezone(pytz.utc).strftime(fmt)
 
 

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -3,6 +3,7 @@ import io
 import json
 import os
 import string
+import time
 from collections import OrderedDict
 from datetime import datetime
 from unittest import TestCase
@@ -1337,18 +1338,100 @@ class TestGetTimestamp(TestCase):
 
         self.assertEqual(result, expected)
 
-    # Windows does not support converting datetimes after 3001-01-01T20:59:59
-    @settings(max_examples=10, deadline=None)
-    @given(
-        dt=datetimes(min_value=datetime.now(),
-                     max_value=datetime(3001, 1, 1)),
-        fmt=just('%Y-%b-%d %H:%M:%S')
-    )
-    def test_get_utctimestamp(self, dt, fmt):
-        expected = dt.astimezone(pytz.utc).strftime(fmt)
-        result = get_utctimestamp(dt, fmt=fmt)
 
-        self.assertEqual(result, expected)
+class TestGetUtctimestamp(TestCase):
+    """Semantic tests for ``get_utctimestamp`` (issue #1936).
+
+    The previous test in this file asserted
+    ``get_utctimestamp(dt) == dt.astimezone(pytz.utc).strftime(fmt)``,
+    which is exactly the function body — so both sides shared the same
+    bug and the test passed for all the wrong reasons. These tests assert
+    the user-visible contract instead: the function returns a UTC
+    wall-clock string for the passed datetime, regardless of the local
+    timezone of the process.
+    """
+
+    # A known wall-clock: 2026-03-05 00:30:00 UTC == 01:30:00 Europe/Zurich
+    # (CET, UTC+1, still in standard time). Chosen so that a timezone
+    # handling bug flips both the hour AND the date, which is exactly the
+    # symptom reported in issue #1936.
+    _SAMPLE_UTC = datetime(2026, 3, 5, 0, 30, 0, tzinfo=pytz.utc)
+    _SAMPLE_ZURICH = _SAMPLE_UTC.astimezone(pytz.timezone('Europe/Zurich'))
+    _RUN_DIR_FMT = '%Y%m%d%H%M%S'
+
+    def test_utc_aware_input_returns_utc_wallclock(self):
+        # A tz-aware UTC datetime must be rendered with its own wall-clock,
+        # not shifted by the process's local offset.
+        result = get_utctimestamp(self._SAMPLE_UTC, fmt=self._RUN_DIR_FMT)
+        self.assertEqual(result, '20260305003000')
+
+    def test_non_utc_aware_input_is_converted(self):
+        # Passing the same instant as a tz-aware Europe/Zurich datetime
+        # must produce the same UTC wall-clock string.
+        result = get_utctimestamp(self._SAMPLE_ZURICH, fmt=self._RUN_DIR_FMT)
+        self.assertEqual(result, '20260305003000')
+
+    def test_default_argument_is_evaluated_at_call_time(self):
+        # Regression test for the mutable-default-argument bug: the
+        # default value for ``thedate`` must resolve at call time, not
+        # once at import time. We patch ``datetime`` in the module under
+        # test and assert both calls see the patched "now".
+        fake_now = datetime(2030, 1, 2, 3, 4, 5, tzinfo=pytz.utc)
+        with patch('oasislmf.utils.data.datetime') as mock_datetime:
+            mock_datetime.now.return_value = fake_now
+            result = get_utctimestamp(fmt=self._RUN_DIR_FMT)
+        self.assertEqual(result, '20300102030405')
+
+    def test_naive_input_is_treated_as_utc(self):
+        # The function's name says ``utctimestamp`` — a naive datetime
+        # must be interpreted as a UTC wall-clock, NOT as local time.
+        # CPython's ``naive.astimezone()`` treats naive datetimes as
+        # local, and that's precisely what makes the default-argument
+        # path of the current implementation wrong on any non-UTC box
+        # (issue #1936). This test pins the desired contract so a
+        # well-meaning future edit can't silently reintroduce the
+        # off-by-local-offset bug.
+        original_tz = os.environ.get('TZ')
+        try:
+            for tz_name in ('UTC', 'Europe/Zurich', 'Pacific/Auckland'):
+                os.environ['TZ'] = tz_name
+                if hasattr(time, 'tzset'):
+                    time.tzset()
+                naive = datetime(2026, 3, 5, 0, 30, 0)
+                result = get_utctimestamp(naive, fmt=self._RUN_DIR_FMT)
+                self.assertEqual(
+                    result, '20260305003000',
+                    f'naive input drifted under TZ={tz_name!r}')
+        finally:
+            if original_tz is None:
+                os.environ.pop('TZ', None)
+            else:
+                os.environ['TZ'] = original_tz
+            if hasattr(time, 'tzset'):
+                time.tzset()
+
+    def test_output_is_stable_across_process_timezone(self):
+        # The whole point of issue #1936: the run-directory timestamp
+        # must not depend on the TZ env var of the process. We flip TZ
+        # to two wildly different zones and check the output matches.
+        original_tz = os.environ.get('TZ')
+        try:
+            for tz_name in ('UTC', 'Europe/Zurich', 'Pacific/Auckland'):
+                os.environ['TZ'] = tz_name
+                if hasattr(time, 'tzset'):
+                    time.tzset()
+                result = get_utctimestamp(
+                    self._SAMPLE_UTC, fmt=self._RUN_DIR_FMT)
+                self.assertEqual(
+                    result, '20260305003000',
+                    f'timestamp drifted under TZ={tz_name!r}')
+        finally:
+            if original_tz is None:
+                os.environ.pop('TZ', None)
+            else:
+                os.environ['TZ'] = original_tz
+            if hasattr(time, 'tzset'):
+                time.tzset()
 
 
 class TestValidateVulnerabilityReplacements(TestCase):

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -6,7 +6,7 @@ import string
 import time
 from collections import OrderedDict
 from datetime import datetime
-from unittest import TestCase
+from unittest import TestCase, skipUnless
 from unittest.mock import patch, MagicMock
 
 import numpy as np
@@ -1371,32 +1371,47 @@ class TestGetUtctimestamp(TestCase):
         result = get_utctimestamp(self._SAMPLE_ZURICH, fmt=self._RUN_DIR_FMT)
         self.assertEqual(result, '20260305003000')
 
-    def test_default_argument_is_evaluated_at_call_time(self):
-        # Regression test for the mutable-default-argument bug: the
-        # default value for ``thedate`` must resolve at call time, not
-        # once at import time. We patch ``datetime`` in the module under
-        # test and assert both calls see the patched "now".
+    def test_default_fmt_produces_human_readable_utc(self):
+        # The function's default ``fmt`` is ``'%Y-%b-%d %H:%M:%S'``. This
+        # test pins the full default-fmt output so a change to either the
+        # fmt default or the rendering path is caught. Also covers the
+        # default-fmt path that the previous hypothesis test used to
+        # exercise with random datetimes.
+        result = get_utctimestamp(self._SAMPLE_UTC)
+        self.assertEqual(result, '2026-Mar-05 00:30:00')
+
+    def test_default_now_is_resolved_at_call_time(self):
+        # When called with no ``thedate`` argument, the current UTC time
+        # must be evaluated on each call rather than once at import time.
+        # The previous signature used a mutable default
+        # (``thedate=datetime.utcnow()``) which only ran at import — this
+        # test guards against that regression. We patch the module's
+        # ``datetime`` and assert the call-time ``now()`` is used.
         fake_now = datetime(2030, 1, 2, 3, 4, 5, tzinfo=pytz.utc)
         with patch('oasislmf.utils.data.datetime') as mock_datetime:
             mock_datetime.now.return_value = fake_now
             result = get_utctimestamp(fmt=self._RUN_DIR_FMT)
         self.assertEqual(result, '20300102030405')
 
+    @skipUnless(
+        hasattr(time, 'tzset'),
+        'Flipping TZ mid-process requires POSIX time.tzset()')
     def test_naive_input_is_treated_as_utc(self):
         # The function's name says ``utctimestamp`` — a naive datetime
         # must be interpreted as a UTC wall-clock, NOT as local time.
         # CPython's ``naive.astimezone()`` treats naive datetimes as
-        # local, and that's precisely what makes the default-argument
-        # path of the current implementation wrong on any non-UTC box
+        # local, and that's precisely what made the default-argument
+        # path of the previous implementation wrong on any non-UTC box
         # (issue #1936). This test pins the desired contract so a
         # well-meaning future edit can't silently reintroduce the
-        # off-by-local-offset bug.
+        # off-by-local-offset bug. Skipped on non-POSIX platforms
+        # because flipping ``os.environ['TZ']`` without ``tzset()`` has
+        # no effect on the process's local-time view.
         original_tz = os.environ.get('TZ')
         try:
             for tz_name in ('UTC', 'Europe/Zurich', 'Pacific/Auckland'):
                 os.environ['TZ'] = tz_name
-                if hasattr(time, 'tzset'):
-                    time.tzset()
+                time.tzset()
                 naive = datetime(2026, 3, 5, 0, 30, 0)
                 result = get_utctimestamp(naive, fmt=self._RUN_DIR_FMT)
                 self.assertEqual(
@@ -1407,19 +1422,23 @@ class TestGetUtctimestamp(TestCase):
                 os.environ.pop('TZ', None)
             else:
                 os.environ['TZ'] = original_tz
-            if hasattr(time, 'tzset'):
-                time.tzset()
+            time.tzset()
 
+    @skipUnless(
+        hasattr(time, 'tzset'),
+        'Flipping TZ mid-process requires POSIX time.tzset()')
     def test_output_is_stable_across_process_timezone(self):
-        # The whole point of issue #1936: the run-directory timestamp
-        # must not depend on the TZ env var of the process. We flip TZ
-        # to two wildly different zones and check the output matches.
+        # Regression guard: the run-directory timestamp must not depend
+        # on the TZ env var of the process, even for tz-aware inputs.
+        # This is a forward guard — if a future edit reintroduces a
+        # local-time conversion step, this test catches it under any
+        # non-UTC TZ. Skipped on non-POSIX platforms for the same reason
+        # as ``test_naive_input_is_treated_as_utc``.
         original_tz = os.environ.get('TZ')
         try:
             for tz_name in ('UTC', 'Europe/Zurich', 'Pacific/Auckland'):
                 os.environ['TZ'] = tz_name
-                if hasattr(time, 'tzset'):
-                    time.tzset()
+                time.tzset()
                 result = get_utctimestamp(
                     self._SAMPLE_UTC, fmt=self._RUN_DIR_FMT)
                 self.assertEqual(
@@ -1430,8 +1449,7 @@ class TestGetUtctimestamp(TestCase):
                 os.environ.pop('TZ', None)
             else:
                 os.environ['TZ'] = original_tz
-            if hasattr(time, 'tzset'):
-                time.tzset()
+            time.tzset()
 
 
 class TestValidateVulnerabilityReplacements(TestCase):


### PR DESCRIPTION
Fixes #1936. See the thread on the issue for context on #1937.

The old `get_utctimestamp` used `datetime.utcnow()` as the default — which returns a naive datetime, and `naive.astimezone(tz)` interprets naive values as local time, so the call was effectively subtracting the local offset from every run-dir timestamp on non-UTC hosts. This switches to a tz-aware default (`datetime.now(pytz.utc)`), uses a `None` sentinel to also close a mutable-default-argument issue in the old signature, and treats any naive input as UTC.

The existing `test_get_utctimestamp` asserted the function body against itself, so it passed against the buggy code. Replaced with a few cases, two of which actually fail on `main`.

<!--start_release_notes-->
### Correct UTC timestamps in run directory names
`get_utctimestamp` now produces a correct UTC wall-clock string regardless of the host's local timezone, fixing the off-by-one-hour run directory names reported in #1936.
<!--end_release_notes-->