### PR TITLE
Fix resource monitor for V2 worker runs

### DIFF
--- a/.github/workflows/piwind-test-v1.yml
+++ b/.github/workflows/piwind-test-v1.yml
@@ -79,7 +79,7 @@ jobs:
       worker_tag: model_worker-${{ needs.check_images.outputs.platform_sha }}
       server_image: coreoasis/github-actions
       server_tag: api_server-${{ needs.check_images.outputs.platform_sha }}
-      debug_mode: '0'
+      debug_mode: '1'
       pytest_opts: "--docker-compose=./docker/plat2-v2.docker-compose.yml -k all_outputs"
       worker_api_ver: 'v1'
       storage_suffix: '_platform1'

--- a/.github/workflows/piwind-test-v1.yml
+++ b/.github/workflows/piwind-test-v1.yml
@@ -80,6 +80,6 @@ jobs:
       server_image: coreoasis/github-actions
       server_tag: api_server-${{ needs.check_images.outputs.platform_sha }}
       debug_mode: '0'
-      pytest_opts: "--docker-compose=./docker/plat2-v2.docker-compose.yml -k all_outputs control_set case_0 case_1 case_3 case_4 case_5 case_6 case_7 case_8"
+      pytest_opts: "--docker-compose=./docker/plat2-v2.docker-compose.yml -k all_outputs"
       worker_api_ver: 'v1'
       storage_suffix: '_platform1'

--- a/.github/workflows/piwind-test-v1.yml
+++ b/.github/workflows/piwind-test-v1.yml
@@ -63,12 +63,50 @@ jobs:
       cve_severity: 'SKIP'
       docker_push: 'true'
       checkout_ref: ${{ github.event_name != 'workflow_dispatch' && 'main' || inputs.platform_branch }}
-      oasislmf_branch: ${{ github.ref }}
-      ods_branch: ${{ inputs.ods_branch }}
+
+  patch_worker_image:
+    if: ${{ !failure() && !cancelled() }}
+    needs: [check_images, build_platform]
+    runs-on: ubuntu-latest
+    outputs:
+      worker_tag: ${{ steps.patch.outputs.worker_tag }}
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build worker image with oasislmf branch
+        id: patch
+        env:
+          PLATFORM_SHA: ${{ needs.check_images.outputs.platform_sha }}
+        run: |
+          WORKER_TAG="model_worker-${PLATFORM_SHA}-oasislmf-${GITHUB_SHA}"
+          cat > Dockerfile.patch << 'DOCKERFILE'
+          ARG BASE_IMAGE
+          FROM ${BASE_IMAGE}
+          ARG OASISLMF_BRANCH
+          RUN pip uninstall oasislmf -y && \
+              pip install --user --no-warn-script-location "git+https://github.com/OasisLMF/OasisLMF.git@${OASISLMF_BRANCH}#egg=oasislmf[extra]"
+          ARG ODS_BRANCH
+          RUN if [ ! -z "$ODS_BRANCH" ]; then \
+              pip uninstall ods-tools -y && \
+              pip install --user --no-warn-script-location "git+https://github.com/OasisLMF/ODS_Tools.git@${ODS_BRANCH}#egg=ods-tools"; \
+            fi
+          DOCKERFILE
+          docker build \
+            --build-arg BASE_IMAGE="coreoasis/github-actions:model_worker-${PLATFORM_SHA}" \
+            --build-arg OASISLMF_BRANCH="${{ github.ref }}" \
+            --build-arg ODS_BRANCH="${{ inputs.ods_branch }}" \
+            -t "coreoasis/github-actions:${WORKER_TAG}" \
+            -f Dockerfile.patch .
+          docker push "coreoasis/github-actions:${WORKER_TAG}"
+          echo "worker_tag=${WORKER_TAG}" >> $GITHUB_OUTPUT
 
   platform1:
     if: ${{ !failure() && !cancelled() }}
-    needs: [check_images, build_platform]
+    needs: [check_images, build_platform, patch_worker_image]
     uses: OasisLMF/OasisPiWind/.github/workflows/integration.yml@main
     secrets: inherit
     with:
@@ -76,7 +114,7 @@ jobs:
       oasislmf_branch: ${{ github.ref }}
       ods_branch: ${{ github.event_name != 'workflow_dispatch' && 'main' || inputs.ods_branch }}
       worker_image: coreoasis/github-actions
-      worker_tag: model_worker-${{ needs.check_images.outputs.platform_sha }}
+      worker_tag: ${{ needs.patch_worker_image.outputs.worker_tag }}
       server_image: coreoasis/github-actions
       server_tag: api_server-${{ needs.check_images.outputs.platform_sha }}
       debug_mode: '1'

--- a/.github/workflows/piwind-test-v1.yml
+++ b/.github/workflows/piwind-test-v1.yml
@@ -79,7 +79,7 @@ jobs:
       worker_tag: model_worker-${{ needs.check_images.outputs.platform_sha }}
       server_image: coreoasis/github-actions
       server_tag: api_server-${{ needs.check_images.outputs.platform_sha }}
-      debug_mode: '1'
-      pytest_opts: "--docker-compose=./docker/plat2-v2.docker-compose.yml"
+      debug_mode: '0'
+      pytest_opts: "--docker-compose=./docker/plat2-v2.docker-compose.yml -k all_outputs control_set case_0 case_1 case_3 case_4 case_5 case_6 case_7 case_8"
       worker_api_ver: 'v1'
       storage_suffix: '_platform1'

--- a/.github/workflows/piwind-test-v2.yml
+++ b/.github/workflows/piwind-test-v2.yml
@@ -80,6 +80,6 @@ jobs:
       server_image: coreoasis/github-actions
       server_tag: api_server-${{ needs.check_images.outputs.platform_sha }}
       debug_mode: '0'
-      pytest_opts: "--docker-compose=./docker/plat2-v2.docker-compose.yml -k all_outputs case_7 case_6"
+      pytest_opts: "--docker-compose=./docker/plat2-v2.docker-compose.yml -k all_outputs"
       worker_api_ver: 'v2'
       storage_suffix: '_platform2'

--- a/.github/workflows/piwind-test-v2.yml
+++ b/.github/workflows/piwind-test-v2.yml
@@ -79,7 +79,7 @@ jobs:
       worker_tag: model_worker-${{ needs.check_images.outputs.platform_sha }}
       server_image: coreoasis/github-actions
       server_tag: api_server-${{ needs.check_images.outputs.platform_sha }}
-      debug_mode: '1'
-      pytest_opts: "--docker-compose=./docker/plat2-v2.docker-compose.yml"
+      debug_mode: '0'
+      pytest_opts: "--docker-compose=./docker/plat2-v2.docker-compose.yml -k all_outputs case_7 case_6"
       worker_api_ver: 'v2'
       storage_suffix: '_platform2'

--- a/.github/workflows/piwind-test-v2.yml
+++ b/.github/workflows/piwind-test-v2.yml
@@ -79,7 +79,7 @@ jobs:
       worker_tag: model_worker-${{ needs.check_images.outputs.platform_sha }}
       server_image: coreoasis/github-actions
       server_tag: api_server-${{ needs.check_images.outputs.platform_sha }}
-      debug_mode: '0'
+      debug_mode: '1'
       pytest_opts: "--docker-compose=./docker/plat2-v2.docker-compose.yml -k all_outputs"
       worker_api_ver: 'v2'
       storage_suffix: '_platform2'

--- a/.github/workflows/piwind-test-v2.yml
+++ b/.github/workflows/piwind-test-v2.yml
@@ -63,12 +63,50 @@ jobs:
       cve_severity: 'SKIP'
       docker_push: 'true'
       checkout_ref: ${{ github.event_name != 'workflow_dispatch' && 'main' || inputs.platform_branch }}
-      oasislmf_branch: ${{ github.ref }}
-      ods_branch: ${{ inputs.ods_branch }}
+
+  patch_worker_image:
+    if: ${{ !failure() && !cancelled() }}
+    needs: [check_images, build_platform]
+    runs-on: ubuntu-latest
+    outputs:
+      worker_tag: ${{ steps.patch.outputs.worker_tag }}
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build worker image with oasislmf branch
+        id: patch
+        env:
+          PLATFORM_SHA: ${{ needs.check_images.outputs.platform_sha }}
+        run: |
+          WORKER_TAG="model_worker-${PLATFORM_SHA}-oasislmf-${GITHUB_SHA}"
+          cat > Dockerfile.patch << 'DOCKERFILE'
+          ARG BASE_IMAGE
+          FROM ${BASE_IMAGE}
+          ARG OASISLMF_BRANCH
+          RUN pip uninstall oasislmf -y && \
+              pip install --user --no-warn-script-location "git+https://github.com/OasisLMF/OasisLMF.git@${OASISLMF_BRANCH}#egg=oasislmf[extra]"
+          ARG ODS_BRANCH
+          RUN if [ ! -z "$ODS_BRANCH" ]; then \
+              pip uninstall ods-tools -y && \
+              pip install --user --no-warn-script-location "git+https://github.com/OasisLMF/ODS_Tools.git@${ODS_BRANCH}#egg=ods-tools"; \
+            fi
+          DOCKERFILE
+          docker build \
+            --build-arg BASE_IMAGE="coreoasis/github-actions:model_worker-${PLATFORM_SHA}" \
+            --build-arg OASISLMF_BRANCH="${{ github.ref }}" \
+            --build-arg ODS_BRANCH="${{ inputs.ods_branch }}" \
+            -t "coreoasis/github-actions:${WORKER_TAG}" \
+            -f Dockerfile.patch .
+          docker push "coreoasis/github-actions:${WORKER_TAG}"
+          echo "worker_tag=${WORKER_TAG}" >> $GITHUB_OUTPUT
 
   platform2:
     if: ${{ !failure() && !cancelled() }}
-    needs: [check_images, build_platform]
+    needs: [check_images, build_platform, patch_worker_image]
     uses: OasisLMF/OasisPiWind/.github/workflows/integration.yml@main
     secrets: inherit
     with:
@@ -76,7 +114,7 @@ jobs:
       oasislmf_branch: ${{ github.ref }}
       ods_branch: ${{ github.event_name != 'workflow_dispatch' && 'main' || inputs.ods_branch }}
       worker_image: coreoasis/github-actions
-      worker_tag: model_worker-${{ needs.check_images.outputs.platform_sha }}
+      worker_tag: ${{ needs.patch_worker_image.outputs.worker_tag }}
       server_image: coreoasis/github-actions
       server_tag: api_server-${{ needs.check_images.outputs.platform_sha }}
       debug_mode: '1'

--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -412,6 +412,8 @@ class GenerateLossesPartial(GenerateLossesDir):
         {'name': 'process_number', 'default': None, 'type': int, 'help': 'Partition number to run, if not set then run all in a single script'},
         {'name': 'max_process_id', 'default': -1, 'type': int, 'help': 'Max number of loss chunks, defaults to `kernel_num_processes` if not set'},
         {'name': 'kernel_fifo_queue_dir', 'default': None, 'is_path': True, 'help': 'Override the path used for fifo processing'},
+        {'name': 'resource_monitor_interval', 'default': 1.0, 'type': float,
+         'help': 'Polling interval in seconds for the resource monitor that tracks pytools CPU and memory usage (default: 1.0)'},
     ]
 
     def run(self):
@@ -469,6 +471,7 @@ class GenerateLossesPartial(GenerateLossesDir):
         else:
             self.logger.info("Set `OASIS_WEBSOCKET_URL` and `OASIS_WEBSOCKET_URL` environment variables for run progress updates")
         bash_params['analysis_pk'] = self.kwargs.get('analysis_pk', None)
+        bash_params['resource_monitor_interval'] = self.resource_monitor_interval
 
         with setcwd(model_run_fp):
             try:
@@ -508,6 +511,8 @@ class GenerateLossesOutput(GenerateLossesDir):
         {'name': 'script_fp', 'default': None},
         {'name': 'remove_working_file', 'default': False, 'help': 'Delete files in the "work/" dir onces outputs have completed'},
         {'name': 'max_process_id', 'default': -1, 'type': int, 'help': 'Max number of loss chunks, defaults to `kernel_num_processes` if not set'},
+        {'name': 'resource_monitor_interval', 'default': 1.0, 'type': float,
+         'help': 'Polling interval in seconds for the resource monitor that tracks pytools CPU and memory usage (default: 1.0)'},
     ]
 
     def run(self):
@@ -535,6 +540,7 @@ class GenerateLossesOutput(GenerateLossesDir):
             remove_working_file=self.remove_working_file,
             max_process_id=self.max_process_id,
         )
+        bash_params['resource_monitor_interval'] = self.resource_monitor_interval
         with setcwd(model_run_fp):
             try:
                 self.logger.info('Generating Loss outputs in {}'.format(model_run_fp))

--- a/oasislmf/execution/bash.py
+++ b/oasislmf/execution/bash.py
@@ -2198,7 +2198,7 @@ def bash_wrapper(
     print_command(filename, 'shopt -s inherit_errexit 2>/dev/null || echo "WARNING: Unable to set inherit_errexit. Possibly unsupported by this shell, Subprocess failures may not be detected."')
 
     print_command(filename, '')
-    if process_number:
+    if log_sub_dir:
         print_command(filename, f'LOG_DIR=log/{log_sub_dir}')
     else:
         print_command(filename, 'LOG_DIR=log')

--- a/oasislmf/execution/resource_monitor.py
+++ b/oasislmf/execution/resource_monitor.py
@@ -68,9 +68,10 @@ class ResourceMonitor:
         poll_interval (float): Seconds between polls (default 1.0).
     """
 
-    def __init__(self, output_dir, poll_interval=1.0):
+    def __init__(self, output_dir, poll_interval=1.0, generate_report=True):
         self.output_dir = output_dir
         self.poll_interval = max(0.1, float(poll_interval))
+        self.generate_report = generate_report
         self._stop_event = threading.Event()
         self._thread = None
         self._csv_path = os.path.join(output_dir, 'resource_monitor.csv')
@@ -99,7 +100,8 @@ class ResourceMonitor:
         self._thread = None
         logger.info("Resource monitor stopped, csv=%s", self._csv_path)
 
-        self._generate_report()
+        if self.generate_report:
+            self._generate_report()
 
     # -- internal --------------------------------------------------------
 
@@ -119,9 +121,11 @@ class ResourceMonitor:
                     if rows:
                         if csvfile is None:
                             os.makedirs(self.output_dir, exist_ok=True)
-                            csvfile = open(self._csv_path, 'w', newline='')
+                            write_header = not os.path.isfile(self._csv_path)
+                            csvfile = open(self._csv_path, 'a', newline='')
                             writer = csv.writer(csvfile)
-                            writer.writerow(CSV_HEADER)
+                            if write_header:
+                                writer.writerow(CSV_HEADER)
                         writer.writerows(rows)
                         csvfile.flush()
                 except Exception:

--- a/oasislmf/execution/resource_monitor.py
+++ b/oasislmf/execution/resource_monitor.py
@@ -68,10 +68,11 @@ class ResourceMonitor:
         poll_interval (float): Seconds between polls (default 1.0).
     """
 
-    def __init__(self, output_dir, poll_interval=1.0, generate_report=True):
+    def __init__(self, output_dir, poll_interval=1.0, generate_report=True, log_root=None):
         self.output_dir = output_dir
         self.poll_interval = max(0.1, float(poll_interval))
         self.generate_report = generate_report
+        self.log_root = log_root
         self._stop_event = threading.Event()
         self._thread = None
         self._csv_path = os.path.join(output_dir, 'resource_monitor.csv')
@@ -175,25 +176,55 @@ class ResourceMonitor:
 
     # -- report generation -----------------------------------------------
 
-    def _generate_report(self):
-        """Read the CSV and generate a markdown report with optional plots."""
-        if not os.path.isfile(self._csv_path):
-            logger.info("No resource monitor CSV found, skipping report")
-            return
+    def _find_all_csvs(self):
+        """Return all resource_monitor.csv paths found in immediate subdirs of log_root."""
+        csv_paths = []
+        if not self.log_root or not os.path.isdir(self.log_root):
+            return csv_paths
+        for entry in sorted(os.scandir(self.log_root), key=lambda e: e.name):
+            if entry.is_dir():
+                csv_path = os.path.join(entry.path, 'resource_monitor.csv')
+                if os.path.isfile(csv_path):
+                    csv_paths.append(csv_path)
+        return csv_paths
 
-        rows = _load_csv(self._csv_path)
+    def _generate_report(self):
+        """Read the CSV(s) and generate a markdown report with optional plots.
+
+        When ``log_root`` is set all ``resource_monitor.csv`` files found in
+        immediate sub-directories of ``log_root`` are combined before the
+        report is generated, and the report is written to
+        ``log_root/resource_report/``.
+        """
+        if self.log_root:
+            csv_paths = self._find_all_csvs()
+            if not csv_paths:
+                logger.info("No resource monitor CSVs found under %s, skipping report", self.log_root)
+                return
+            rows = []
+            for path in csv_paths:
+                rows.extend(_load_csv(path))
+            report_dir = os.path.join(self.log_root, 'resource_report')
+            source_csv = os.path.join(self.log_root, 'resource_monitor.csv')
+        else:
+            if not os.path.isfile(self._csv_path):
+                logger.info("No resource monitor CSV found, skipping report")
+                return
+            rows = _load_csv(self._csv_path)
+            report_dir = os.path.join(self.output_dir, 'resource_report')
+            source_csv = self._csv_path
+
         if not rows:
             logger.info("Resource monitor CSV is empty, skipping report")
             return
 
-        report_dir = os.path.join(self.output_dir, 'resource_report')
         os.makedirs(report_dir, exist_ok=True)
 
         stats = _compute_stats(rows)
         system_memory_mb = psutil.virtual_memory().total / (1024 * 1024)
         peak_total_uss_mb = _compute_peak_total_uss(rows)
         plots = _generate_plots(rows, report_dir, system_memory_mb)
-        md_path = _write_markdown(self._csv_path, report_dir, stats, plots,
+        md_path = _write_markdown(source_csv, report_dir, stats, plots,
                                   len(rows), system_memory_mb, peak_total_uss_mb)
         logger.info("Resource monitor report: %s (%d samples, %d plots)",
                     md_path, len(rows), len(plots))

--- a/oasislmf/execution/resource_monitor.py
+++ b/oasislmf/execution/resource_monitor.py
@@ -179,13 +179,24 @@ class ResourceMonitor:
     def _find_all_csvs(self):
         """Return all resource_monitor.csv paths found in immediate subdirs of log_root."""
         csv_paths = []
-        if not self.log_root or not os.path.isdir(self.log_root):
+        if not self.log_root:
+            logger.info("Resource monitor: log_root not set, skipping CSV discovery")
             return csv_paths
-        for entry in sorted(os.scandir(self.log_root), key=lambda e: e.name):
-            if entry.is_dir():
+        if not os.path.isdir(self.log_root):
+            logger.info("Resource monitor: log_root '%s' does not exist or is not a directory", self.log_root)
+            return csv_paths
+        logger.info("Resource monitor: scanning '%s' for resource_monitor.csv files", self.log_root)
+        with os.scandir(self.log_root) as it:
+            for entry in sorted(it, key=lambda e: e.name):
+                if not entry.is_dir():
+                    continue
                 csv_path = os.path.join(entry.path, 'resource_monitor.csv')
                 if os.path.isfile(csv_path):
+                    logger.info("Resource monitor: found %s", csv_path)
                     csv_paths.append(csv_path)
+                else:
+                    logger.debug("Resource monitor: no CSV in %s", entry.path)
+        logger.info("Resource monitor: %d CSV(s) found to combine", len(csv_paths))
         return csv_paths
 
     def _generate_report(self):
@@ -197,6 +208,7 @@ class ResourceMonitor:
         ``log_root/resource_report/``.
         """
         if self.log_root:
+            logger.info("Resource monitor: generating combined report from log_root='%s'", self.log_root)
             csv_paths = self._find_all_csvs()
             if not csv_paths:
                 logger.info("No resource monitor CSVs found under %s, skipping report", self.log_root)

--- a/oasislmf/execution/runner.py
+++ b/oasislmf/execution/runner.py
@@ -165,6 +165,8 @@ def rerun():
 
 @oasis_log()
 def run_analysis(**params):
+    resource_monitor_interval = params.pop('resource_monitor_interval', 1.0)
+
     with bash_wrapper(params['filename'],
                       params['bash_trace'],
                       params['stderr_guard'],
@@ -172,15 +174,34 @@ def run_analysis(**params):
                       process_number=params.get("process_number", None)):
         create_bash_analysis(**params)
 
-    bash_trace = subprocess.check_output(['bash', params['filename']]).decode('utf-8')
+    process_number = params.get('process_number')
+    monitor_dir = os.path.join('log', str(process_number)) if process_number else 'log'
+    monitor = ResourceMonitor(output_dir=monitor_dir, poll_interval=resource_monitor_interval, generate_report=False)
+    proc = subprocess.Popen(['bash', params['filename']], stdout=subprocess.PIPE)
+    monitor.start(proc.pid)
+    stdout, _ = proc.communicate()
+    monitor.stop()
+    if proc.returncode != 0:
+        raise subprocess.CalledProcessError(proc.returncode, ['bash', params['filename']], output=stdout)
+    bash_trace = stdout.decode('utf-8')
     logging.info(bash_trace)
     return params['fifo_queue_dir'], bash_trace
 
 
 @oasis_log()
 def run_outputs(**params):
+    resource_monitor_interval = params.pop('resource_monitor_interval', 1.0)
+
     with bash_wrapper(params['filename'], params['bash_trace'], params['stderr_guard'], log_sub_dir='out'):
         create_bash_outputs(**params)
-    bash_trace = subprocess.check_output(['bash', params['filename']]).decode('utf-8')
+
+    monitor = ResourceMonitor(output_dir=os.path.join('log', 'out'), poll_interval=resource_monitor_interval)
+    proc = subprocess.Popen(['bash', params['filename']], stdout=subprocess.PIPE)
+    monitor.start(proc.pid)
+    stdout, _ = proc.communicate()
+    monitor.stop()
+    if proc.returncode != 0:
+        raise subprocess.CalledProcessError(proc.returncode, ['bash', params['filename']], output=stdout)
+    bash_trace = stdout.decode('utf-8')
     logging.info(bash_trace)
     return bash_trace

--- a/oasislmf/execution/runner.py
+++ b/oasislmf/execution/runner.py
@@ -195,7 +195,7 @@ def run_outputs(**params):
     with bash_wrapper(params['filename'], params['bash_trace'], params['stderr_guard'], log_sub_dir='out'):
         create_bash_outputs(**params)
 
-    monitor = ResourceMonitor(output_dir=os.path.join('log', 'out'), poll_interval=resource_monitor_interval)
+    monitor = ResourceMonitor(output_dir=os.path.join('log', 'out'), poll_interval=resource_monitor_interval, log_root='log')
     proc = subprocess.Popen(['bash', params['filename']], stdout=subprocess.PIPE)
     monitor.start(proc.pid)
     stdout, _ = proc.communicate()

--- a/oasislmf/execution/runner.py
+++ b/oasislmf/execution/runner.py
@@ -175,7 +175,9 @@ def run_analysis(**params):
         create_bash_analysis(**params)
 
     process_number = params.get('process_number')
-    monitor_dir = os.path.join('log', str(process_number)) if process_number else 'log'
+    run_dir = os.path.dirname(params['filename'])
+    log_root = os.path.join(run_dir, 'log')
+    monitor_dir = os.path.join(log_root, str(process_number)) if process_number else log_root
     monitor = ResourceMonitor(output_dir=monitor_dir, poll_interval=resource_monitor_interval, generate_report=False)
     proc = subprocess.Popen(['bash', params['filename']], stdout=subprocess.PIPE)
     monitor.start(proc.pid)
@@ -195,7 +197,9 @@ def run_outputs(**params):
     with bash_wrapper(params['filename'], params['bash_trace'], params['stderr_guard'], log_sub_dir='out'):
         create_bash_outputs(**params)
 
-    monitor = ResourceMonitor(output_dir=os.path.join('log', 'out'), poll_interval=resource_monitor_interval, log_root='log')
+    run_dir = os.path.dirname(params['filename'])
+    log_root = os.path.join(run_dir, 'log')
+    monitor = ResourceMonitor(output_dir=os.path.join(log_root, 'out'), poll_interval=resource_monitor_interval, log_root=log_root)
     proc = subprocess.Popen(['bash', params['filename']], stdout=subprocess.PIPE)
     monitor.start(proc.pid)
     stdout, _ = proc.communicate()


### PR DESCRIPTION
<!--start_release_notes-->
### Fix resource monitor for V2 worker runs
* Fixed CI worker testing, and limited to single piwind run
* Fix for running the resource monitor in V2 runs 
* https://github.com/OasisLMF/OasisPlatform/pull/1383 ~ platform fix to make sure all the logs are staged before generating the monitor report  
* https://github.com/OasisLMF/OasisPiWind/pull/215 ~ Piwind CI workflow stores the log tar for each run
<!--end_release_notes-->
