### PR TITLE
API client, added option for disabled auth

### DIFF
--- a/oasislmf/platform_api/session.py
+++ b/oasislmf/platform_api/session.py
@@ -55,6 +55,11 @@ class APISession(Session):
         # Check connectivity & authentication
         self.health_check()
         self.retry_max = retries
+
+        if self._fetch_server_auth_type() == 'disabled':
+            self.auth_type = 'disabled'
+            return
+
         self.auth_type = auth_type
         if auth_type == "simple" and username and password:
             self.auth_credentials = {"username": username, "password": password}
@@ -140,11 +145,21 @@ class APISession(Session):
                 error = "HTTP {}".format(http_err_code)
                 return True
             elif http_err_code in [401, 403]:
-                if self.tkn_refresh is not None:
+                if self.auth_type != 'disabled' and self.tkn_refresh is not None:
                     self.logger.debug("requesting refresh token")
                     self._refresh_token()
                     return True
         return False
+
+    def _fetch_server_auth_type(self):
+        try:
+            url = urljoin(self.url_base, 'server_info/')
+            r = super(APISession, self).get(url, timeout=self.timeout)
+            if r.status_code == 200:
+                return r.json().get('config', {}).get('API_AUTH_TYPE')
+        except Exception:
+            pass
+        return None
 
     # @oasis_log
     def health_check(self):

--- a/oasislmf/platform_api/session.py
+++ b/oasislmf/platform_api/session.py
@@ -58,6 +58,7 @@ class APISession(Session):
 
         if self._fetch_server_auth_type() == 'disabled':
             self.auth_type = 'disabled'
+            self.auth_credentials = {}
             return
 
         self.auth_type = auth_type

--- a/tests/computation/test_platform.py
+++ b/tests/computation/test_platform.py
@@ -34,7 +34,10 @@ class TestPlatformList(ComputationChecker):
         responce_queue.get(
             url=f'{self.api_url}/healthcheck/',
             json={"status": "OK"})
-
+        responce_queue.get(
+            url=f'{self.api_url}/server_info/',
+            json={'error': 'unauthorized'},
+            status=401)
         responce_queue.post(
             url=f'{self.api_url}/access_token/',
             json={"access_token": "acc_tkn", "refresh_token": "ref_tkn"},
@@ -163,7 +166,10 @@ class TestPlatformRunInputs(ComputationChecker):
         responce_queue.get(
             url=f'{self.api_url}/healthcheck/',
             json={"status": "OK"})
-
+        responce_queue.get(
+            url=f'{self.api_url}/server_info/',
+            json={'error': 'unauthorized'},
+            status=401)
         responce_queue.post(
             url=f'{self.api_url}/access_token/',
             json={"access_token": "acc_tkn", "refresh_token": "ref_tkn"},
@@ -719,7 +725,10 @@ class TestPlatformDelete(ComputationChecker):
         responce_queue.get(
             url=f'{self.api_url}/healthcheck/',
             json={"status": "OK"})
-
+        responce_queue.get(
+            url=f'{self.api_url}/server_info/',
+            json={'error': 'unauthorized'},
+            status=401)
         responce_queue.post(
             url=f'{self.api_url}/access_token/',
             json={"access_token": "acc_tkn", "refresh_token": "ref_tkn"},
@@ -791,7 +800,10 @@ class TestPlatformGet(ComputationChecker):
         responce_queue.get(
             url=f'{self.api_url}/healthcheck/',
             json={"status": "OK"})
-
+        responce_queue.get(
+            url=f'{self.api_url}/server_info/',
+            json={'error': 'unauthorized'},
+            status=401)
         responce_queue.post(
             url=f'{self.api_url}/access_token/',
             json={"access_token": "acc_tkn", "refresh_token": "ref_tkn"},

--- a/tests/computation/test_platform.py
+++ b/tests/computation/test_platform.py
@@ -256,6 +256,10 @@ class TestPlatformRunInputs(ComputationChecker):
         responses.get(
             url=f'{self.api_url}/healthcheck/',
             json={"status": "OK"})
+        responses.get(
+            url=f'{self.api_url}/server_info/',
+            json={'error': 'unauthorized'},
+            status=401)
         responses.post(
             url=f'{self.api_url}/access_token/',
             json={'error': 'unauthorized'},
@@ -273,18 +277,18 @@ class TestPlatformRunInputs(ComputationChecker):
         with self.assertRaises(OasisException) as context:
             self.manager.platform_run_inputs()
 
-        unauthorized_req = responses.calls[1].request
-        unauthorized_rsp = responses.calls[1].response
+        unauthorized_req = responses.calls[2].request
+        unauthorized_rsp = responses.calls[2].response
         self.assertEqual(unauthorized_req.body, b'{"username": "admin", "password": "password"}')
         self.assertEqual(unauthorized_rsp.status_code, 401)
 
-        unauthorized_req = responses.calls[3].request
-        unauthorized_rsp = responses.calls[3].response
+        unauthorized_req = responses.calls[5].request
+        unauthorized_rsp = responses.calls[5].response
         self.assertEqual(unauthorized_req.body, b'{"client_id": "oasis-service", "client_secret": "serviceNotSoSecret"}')
         self.assertEqual(unauthorized_rsp.status_code, 401)
 
-        authorized_req = responses.calls[5].request
-        authorized_rsp = responses.calls[5].response
+        authorized_req = responses.calls[8].request
+        authorized_rsp = responses.calls[8].response
         self.assertEqual(authorized_req.body, b'{"username": "AzureDiamond", "password": "hunter2"}')
         self.assertEqual(authorized_rsp.status_code, 200)
 
@@ -292,6 +296,10 @@ class TestPlatformRunInputs(ComputationChecker):
         responses.get(
             url=f'{self.api_url}/healthcheck/',
             json={"status": "OK"})
+        responses.get(
+            url=f'{self.api_url}/server_info/',
+            json={'error': 'unauthorized'},
+            status=401)
         responses.post(
             url=f'{self.api_url}/access_token/',
             json={"access_token": "acc_tkn", "refresh_token": "ref_tkn"},
@@ -305,8 +313,8 @@ class TestPlatformRunInputs(ComputationChecker):
         with self.assertRaises(OasisException) as context:
             self.manager.platform_run_inputs(server_login_json=json_credentials_file.name)
 
-        authorized_req = responses.calls[1].request
-        authorized_rsp = responses.calls[1].response
+        authorized_req = responses.calls[2].request
+        authorized_rsp = responses.calls[2].response
         self.assertEqual(authorized_req.body, b'{"username": "AzureDiamond", "password": "hunter2"}')
         self.assertEqual(authorized_rsp.status_code, 200)
 
@@ -314,6 +322,10 @@ class TestPlatformRunInputs(ComputationChecker):
         responses.get(
             url=f'{self.api_url}/healthcheck/',
             json={"status": "OK"})
+        responses.get(
+            url=f'{self.api_url}/server_info/',
+            json={'error': 'unauthorized'},
+            status=401)
         responses.post(
             url=f'{self.api_url}/access_token/',
             json={"access_token": "acc_tkn", "refresh_token": "ref_tkn"},
@@ -327,8 +339,8 @@ class TestPlatformRunInputs(ComputationChecker):
         with self.assertRaises(OasisException) as context:
             self.manager.platform_run_inputs(server_login_json=json_credentials_file.name)
 
-        authorized_req = responses.calls[1].request
-        authorized_rsp = responses.calls[1].response
+        authorized_req = responses.calls[2].request
+        authorized_rsp = responses.calls[2].response
         self.assertEqual(authorized_req.body, b'{"client_id": "serviceId", "client_secret": "serviceSecret"}')
         self.assertEqual(authorized_rsp.status_code, 200)
 


### PR DESCRIPTION
<!--start_release_notes-->
### API client, added option for disabled auth
See: https://github.com/OasisLMF/OasisPlatform/pull/1387/  Client checks if `server_info/`  returns 200 (normally needs to be authenticated) and runs without authorization if disabled
<!--end_release_notes-->
