### PR TITLE
Update API client for OIDC M2M

### DIFF
--- a/oasislmf/computation/run/platform.py
+++ b/oasislmf/computation/run/platform.py
@@ -33,49 +33,54 @@ class PlatformBase(ComputationStep):
             'pre_exist': False, 'help': 'Server login credentials json string'},
         {'name': 'server_url', 'default': 'http://localhost:8000', 'help': 'URL to Oasis Platform server, default is localhost'},
         {'name': 'server_version', 'default': 'v2', 'help': "Version prefix for OasisPlatform server, 'v1' = single server run, 'v2' = distributed on cluster"},
+        {'name': 'auth_type', 'required': False, 'default': None,
+            'choices': ['simple', 'oidc', 'm2m'],
+            'help': 'Authentication type: simple (username/password JWT), oidc (client credentials via platform), m2m (client credentials direct to IdP)'},
         {'name': 'oidc_token_url', 'required': False, 'default': None,
-            'help': 'OIDC token endpoint URL for M2M client_credentials grant (e.g. https://idp.example.com/oauth2/token)'},
+            'help': 'Token endpoint URL for m2m client_credentials grant (e.g. https://idp.example.com/oauth2/token)'},
         {'name': 'oidc_scope', 'required': False, 'default': None,
-            'help': 'OAuth2 scope to request when fetching an M2M token (e.g. oasis/m2m)'},
+            'help': 'OAuth2 scope to request when fetching an m2m token (e.g. oasis/m2m)'},
     ]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.server = self.open_connection()
 
-    def load_credentials(self, login_arg):
+    def load_credentials(self, login_arg, auth_type=None):
         """
-        Load credentials from JSON file or Prompt for username / password
+        Load credentials from JSON file or prompt interactively.
 
         Options:
             1.'--server-login ./APIcredentials.json'
             2. Load credentials from default config file '-C oasislmf.json'
+            3. Interactive prompt (menu skipped when auth_type is already known)
         """
         if isinstance(login_arg, str):
             with io.open(login_arg, encoding='utf-8') as f:
                 return json.load(f)
 
-        while True:
-            user_response = input("Auth type — simple JWT [1], OIDC client_credentials via platform [2], OIDC M2M direct [3]: ").strip()
-            if user_response == "1":
-                auth_mode = "simple"
-                break
-            elif user_response == "2":
-                auth_mode = "oidc"
-                break
-            elif user_response == "3":
-                auth_mode = "oidc_m2m"
-                break
+        if auth_type is None:
+            while True:
+                user_response = input("Auth type — simple JWT [1], OIDC via platform [2], M2M direct to IdP [3]: ").strip()
+                if user_response == "1":
+                    auth_type = "simple"
+                    break
+                elif user_response == "2":
+                    auth_type = "oidc"
+                    break
+                elif user_response == "3":
+                    auth_type = "m2m"
+                    break
 
         self.logger.info('API Login:')
         api_login = {}
-        if auth_mode == "simple":
+        if auth_type == "simple":
             api_login['username'] = input('Username: ')
             api_login['password'] = getpass.getpass('Password: ')
-        elif auth_mode == "oidc":
+        elif auth_type == "oidc":
             api_login['client_id'] = input('Client ID: ')
             api_login['client_secret'] = getpass.getpass('Client Secret: ')
-        else:
+        elif auth_type == "m2m":
             api_login['client_id'] = input('Client ID: ')
             api_login['client_secret'] = getpass.getpass('Client Secret: ')
             api_login['token_url'] = input('Token URL: ')
@@ -121,35 +126,40 @@ class PlatformBase(ComputationStep):
     def open_connection(self):
         """
         Attempts connection in this order:
-        1. API_EXAMPLE_AUTH username/password
-        2. API_EXAMPLE_AUTH client_id/client_secret (+ oidc_token_url/oidc_scope if set)
+        1. API_EXAMPLE_AUTH username/password  (skipped when auth_type is oidc or m2m)
+        2. API_EXAMPLE_AUTH client_id/client_secret  (skipped when auth_type is simple)
         3. Prompt or load credentials
         """
+        auth_type = getattr(self, 'auth_type', None)
+
         if not isinstance(self.server_login_json, str):
             # 1. Try example username/password
-            if 'username' in API_EXAMPLE_AUTH and 'password' in API_EXAMPLE_AUTH:
-                conn = self.try_connection(
-                    auth_type="simple",
-                    username=API_EXAMPLE_AUTH['username'],
-                    password=API_EXAMPLE_AUTH['password']
-                )
-                if conn:
-                    return conn
+            if auth_type in (None, "simple"):
+                if 'username' in API_EXAMPLE_AUTH and 'password' in API_EXAMPLE_AUTH:
+                    conn = self.try_connection(
+                        auth_type="simple",
+                        username=API_EXAMPLE_AUTH['username'],
+                        password=API_EXAMPLE_AUTH['password']
+                    )
+                    if conn:
+                        return conn
 
             # 2. Try example client_id/client_secret
-            if 'client_id' in API_EXAMPLE_AUTH and 'client_secret' in API_EXAMPLE_AUTH:
-                conn = self.try_connection(
-                    auth_type="oidc",
-                    client_id=API_EXAMPLE_AUTH['client_id'],
-                    client_secret=API_EXAMPLE_AUTH['client_secret'],
-                    **self._oidc_m2m_kwargs()
-                )
-                if conn:
-                    return conn
+            if auth_type in (None, "oidc", "m2m"):
+                if 'client_id' in API_EXAMPLE_AUTH and 'client_secret' in API_EXAMPLE_AUTH:
+                    example_auth_type = auth_type if auth_type in ("oidc", "m2m") else "oidc"
+                    conn = self.try_connection(
+                        auth_type=example_auth_type,
+                        client_id=API_EXAMPLE_AUTH['client_id'],
+                        client_secret=API_EXAMPLE_AUTH['client_secret'],
+                        **self._oidc_m2m_kwargs()
+                    )
+                    if conn:
+                        return conn
 
         # 3. Load credentials (file or prompt)
         self.logger.info("-- Authentication Required --")
-        credentials = self.load_credentials(self.server_login_json)
+        credentials = self.load_credentials(self.server_login_json, auth_type=auth_type)
         self.logger.info(f'Connecting to - {self.server_url}')
 
         if 'username' in credentials and 'password' in credentials:
@@ -161,14 +171,14 @@ class PlatformBase(ComputationStep):
             )
 
         if 'client_id' in credentials and 'client_secret' in credentials:
-            # token_url in credentials → M2M direct; step params override/supplement
-            m2m_kwargs = {
-                k: credentials[k] for k in ('token_url', 'scope') if k in credentials
-            }
+            m2m_kwargs = {k: credentials[k] for k in ('token_url', 'scope') if k in credentials}
             m2m_kwargs.update(self._oidc_m2m_kwargs())
+            resolved_type = auth_type if auth_type in ("oidc", "m2m") else (
+                "m2m" if m2m_kwargs.get('token_url') else "oidc"
+            )
             return self.try_connection(
                 fail_safe=False,
-                auth_type="oidc",
+                auth_type=resolved_type,
                 client_id=credentials['client_id'],
                 client_secret=credentials['client_secret'],
                 **m2m_kwargs

--- a/oasislmf/computation/run/platform.py
+++ b/oasislmf/computation/run/platform.py
@@ -33,6 +33,10 @@ class PlatformBase(ComputationStep):
             'pre_exist': False, 'help': 'Server login credentials json string'},
         {'name': 'server_url', 'default': 'http://localhost:8000', 'help': 'URL to Oasis Platform server, default is localhost'},
         {'name': 'server_version', 'default': 'v2', 'help': "Version prefix for OasisPlatform server, 'v1' = single server run, 'v2' = distributed on cluster"},
+        {'name': 'oidc_token_url', 'required': False, 'default': None,
+            'help': 'OIDC token endpoint URL for M2M client_credentials grant (e.g. https://idp.example.com/oauth2/token)'},
+        {'name': 'oidc_scope', 'required': False, 'default': None,
+            'help': 'OAuth2 scope to request when fetching an M2M token (e.g. oasis/m2m)'},
     ]
 
     def __init__(self, **kwargs):
@@ -52,22 +56,32 @@ class PlatformBase(ComputationStep):
                 return json.load(f)
 
         while True:
-            user_response = input("Use simple JWT [Y/n]: ").lower().strip()
-            if user_response in ["y", "yes"]:
-                use_simple = True
+            user_response = input("Auth type — simple JWT [1], OIDC client_credentials via platform [2], OIDC M2M direct [3]: ").strip()
+            if user_response == "1":
+                auth_mode = "simple"
                 break
-            elif user_response in ["n", "no"]:
-                use_simple = False
+            elif user_response == "2":
+                auth_mode = "oidc"
+                break
+            elif user_response == "3":
+                auth_mode = "oidc_m2m"
                 break
 
         self.logger.info('API Login:')
         api_login = {}
-        if use_simple:
+        if auth_mode == "simple":
             api_login['username'] = input('Username: ')
             api_login['password'] = getpass.getpass('Password: ')
+        elif auth_mode == "oidc":
+            api_login['client_id'] = input('Client ID: ')
+            api_login['client_secret'] = getpass.getpass('Client Secret: ')
         else:
             api_login['client_id'] = input('Client ID: ')
             api_login['client_secret'] = getpass.getpass('Client Secret: ')
+            api_login['token_url'] = input('Token URL: ')
+            scope = input('Scope (leave blank to omit): ').strip()
+            if scope:
+                api_login['scope'] = scope
 
         return api_login
 
@@ -93,13 +107,22 @@ class PlatformBase(ComputationStep):
                 )
                 return None
             else:
-                raise e  # Some other error – propagate
+                raise e  # propagate unexpected errors
+
+    def _oidc_m2m_kwargs(self):
+        """Return token_url/scope kwargs when the step params are set."""
+        kwargs = {}
+        if getattr(self, 'oidc_token_url', None):
+            kwargs['token_url'] = self.oidc_token_url
+        if getattr(self, 'oidc_scope', None):
+            kwargs['scope'] = self.oidc_scope
+        return kwargs
 
     def open_connection(self):
         """
         Attempts connection in this order:
         1. API_EXAMPLE_AUTH username/password
-        2. API_EXAMPLE_AUTH client_id/client_secret
+        2. API_EXAMPLE_AUTH client_id/client_secret (+ oidc_token_url/oidc_scope if set)
         3. Prompt or load credentials
         """
         if not isinstance(self.server_login_json, str):
@@ -118,7 +141,8 @@ class PlatformBase(ComputationStep):
                 conn = self.try_connection(
                     auth_type="oidc",
                     client_id=API_EXAMPLE_AUTH['client_id'],
-                    client_secret=API_EXAMPLE_AUTH['client_secret']
+                    client_secret=API_EXAMPLE_AUTH['client_secret'],
+                    **self._oidc_m2m_kwargs()
                 )
                 if conn:
                     return conn
@@ -127,6 +151,7 @@ class PlatformBase(ComputationStep):
         self.logger.info("-- Authentication Required --")
         credentials = self.load_credentials(self.server_login_json)
         self.logger.info(f'Connecting to - {self.server_url}')
+
         if 'username' in credentials and 'password' in credentials:
             return self.try_connection(
                 fail_safe=False,
@@ -134,15 +159,24 @@ class PlatformBase(ComputationStep):
                 username=credentials['username'],
                 password=credentials['password']
             )
+
         if 'client_id' in credentials and 'client_secret' in credentials:
+            # token_url in credentials → M2M direct; step params override/supplement
+            m2m_kwargs = {
+                k: credentials[k] for k in ('token_url', 'scope') if k in credentials
+            }
+            m2m_kwargs.update(self._oidc_m2m_kwargs())
             return self.try_connection(
                 fail_safe=False,
                 auth_type="oidc",
                 client_id=credentials['client_id'],
-                client_secret=credentials['client_secret']
+                client_secret=credentials['client_secret'],
+                **m2m_kwargs
             )
+
         raise OasisException(
-            f"Error: No valid credentials provided for platform, current credential keys [{credentials.keys()}], must be one of username/password or client_id/client_secret"
+            f"Error: No valid credentials provided for platform, current credential keys [{list(credentials.keys())}], "
+            "must be one of username/password or client_id/client_secret"
         )
 
     def tabulate_json(self, json_data, items):

--- a/oasislmf/computation/run/platform.py
+++ b/oasislmf/computation/run/platform.py
@@ -112,7 +112,7 @@ class PlatformBase(ComputationStep):
                 )
                 return None
             else:
-                raise e  # propagate unexpected errors
+                raise e  # Some other error – propagate  
 
     def _oidc_m2m_kwargs(self):
         """Return token_url/scope kwargs when the step params are set."""

--- a/oasislmf/computation/run/platform.py
+++ b/oasislmf/computation/run/platform.py
@@ -112,7 +112,7 @@ class PlatformBase(ComputationStep):
                 )
                 return None
             else:
-                raise e  # Some other error – propagate  
+                raise e  # Some other error – propagate
 
     def _oidc_m2m_kwargs(self):
         """Return token_url/scope kwargs when the step params are set."""

--- a/oasislmf/platform_api/client.py
+++ b/oasislmf/platform_api/client.py
@@ -419,7 +419,7 @@ class APIClient(object):
         self,
         api_url='http://localhost:8000',
         api_ver='V2',
-        auth_type="simple",
+        auth_type=None,
         username="admin",
         password="password",
         client_id="oasis-service",

--- a/oasislmf/platform_api/client.py
+++ b/oasislmf/platform_api/client.py
@@ -426,6 +426,8 @@ class APIClient(object):
         client_secret="serviceNotSoSecret",
         access_token=None,
         refresh_token=None,
+        token_url=None,
+        scope=None,
         timeout=25,
         logger=None,
         **kwargs
@@ -441,6 +443,8 @@ class APIClient(object):
             client_secret=client_secret,
             access_token=access_token,
             refresh_token=refresh_token,
+            token_url=token_url,
+            scope=scope,
             timeout=timeout,
             **kwargs
         )

--- a/oasislmf/platform_api/session.py
+++ b/oasislmf/platform_api/session.py
@@ -63,21 +63,28 @@ class APISession(Session):
         self.health_check()
         self.retry_max = retries
 
-        if self._fetch_server_auth_type() == 'disabled':
+        server_auth = self._fetch_server_auth_type()
+        resolved_type = auth_type if auth_type is not None else server_auth
+
+        if resolved_type == 'disabled':
             self.auth_type = 'disabled'
             self.auth_credentials = {}
             return
 
-        self.auth_type = auth_type
-        if auth_type == "simple" and username and password:
+        self.auth_type = resolved_type
+        if resolved_type == "simple" and username and password:
             self.auth_credentials = {"username": username, "password": password}
-        elif auth_type == "oidc" and client_id and client_secret:
+        elif resolved_type in ("oidc", "m2m") and client_id and client_secret:
+            if resolved_type == "m2m" and not token_url:
+                raise OasisException("auth_type 'm2m' requires token_url")
             self.auth_credentials = {"client_id": client_id, "client_secret": client_secret}
-        elif auth_type == "token" and access_token and refresh_token:
+        elif resolved_type == "token" and access_token and refresh_token:
             self.auth_credentials = {"access_token": access_token, "refresh_token": refresh_token}
         else:
             raise OasisException(
-                f"Missing credentials for auth_type {auth_type}: must provide either username/password or client_id/client_secret or access_token/refresh_token.")
+                f"Missing credentials for auth_type '{resolved_type}': simple requires username/password, "
+                "oidc/m2m requires client_id/client_secret (m2m also requires token_url), "
+                "token requires access_token/refresh_token.")
         self.__get_access_token()
 
     def __get_access_token(self):
@@ -87,8 +94,8 @@ class APISession(Session):
             self.headers['authorization'] = 'Bearer {}'.format(self.tkn_access)
             return
 
-        if self.auth_type == "oidc" and self.token_url:
-            # Standard M2M client_credentials grant: Basic Auth + form-encoded body
+        if self.auth_type == "m2m":
+            # client_credentials grant direct to IdP token endpoint
             try:
                 data = {'grant_type': 'client_credentials'}
                 if self.scope:
@@ -110,26 +117,27 @@ class APISession(Session):
                 return
             except (TypeError, AttributeError, BytesWarning, HTTPError, ConnectionError, ReadTimeout) as e:
                 if isinstance(e, HTTPError) and e.response is not None:
-                    self.logger.error('OIDC token request failed (%s): %s', e.response.status_code, e.response.text)
+                    self.logger.error('M2M token request failed (%s): %s', e.response.status_code, e.response.text)
                 raise OasisException('Authentication Error', e)
 
-        try:
-            url = urljoin(self.url_base, 'access_token/')
-            r = self.post(url, json=self.auth_credentials)
-            r.raise_for_status()
-            self.tkn_access = r.json()['access_token']
-            if self.auth_type == "simple":
-                self.tkn_refresh = r.json()['refresh_token']
-            else:
-                self.tkn_refresh = self.tkn_access
-            self.headers['authorization'] = 'Bearer {}'.format(self.tkn_access)
-            return
-        except (TypeError, AttributeError, BytesWarning, HTTPError, ConnectionError, ReadTimeout) as e:
-            err_msg = 'Authentication Error'
-            raise OasisException(err_msg, e)
+        if self.auth_type in ("simple", "oidc"):
+            # simple: username/password JWT via platform /access_token/
+            # oidc: client_credentials relayed through platform /access_token/
+            try:
+                url = urljoin(self.url_base, 'access_token/')
+                r = self.post(url, json=self.auth_credentials)
+                r.raise_for_status()
+                self.tkn_access = r.json()['access_token']
+                self.tkn_refresh = r.json().get('refresh_token', self.tkn_access)
+                self.headers['authorization'] = 'Bearer {}'.format(self.tkn_access)
+                return
+            except (TypeError, AttributeError, BytesWarning, HTTPError, ConnectionError, ReadTimeout) as e:
+                raise OasisException('Authentication Error', e)
+
+        raise OasisException(f"Unknown auth_type: '{self.auth_type}'")
 
     def _refresh_token(self):
-        if self.auth_type == "oidc":
+        if self.auth_type == "m2m":
             self.__get_access_token()
             return
         try:

--- a/oasislmf/platform_api/session.py
+++ b/oasislmf/platform_api/session.py
@@ -85,7 +85,7 @@ class APISession(Session):
             self.headers['authorization'] = 'Bearer {}'.format(self.tkn_access)
             return
 
-        if self.token_url:
+        if self.auth_type == "oidc" and self.token_url:
             # Standard M2M client_credentials grant: Basic Auth + form-encoded body
             try:
                 data = {'grant_type': 'client_credentials'}
@@ -125,7 +125,7 @@ class APISession(Session):
             raise OasisException(err_msg, e)
 
     def _refresh_token(self):
-        if self.token_url or self.auth_type == "oidc":
+        if self.auth_type == "oidc":
             self.__get_access_token()
             return
         try:

--- a/oasislmf/platform_api/session.py
+++ b/oasislmf/platform_api/session.py
@@ -56,6 +56,8 @@ class APISession(Session):
         }
         self.adapters.clear()
         self.mount(self.url_base, HTTPAdapter(max_retries=self.retry_max))
+        if token_url:
+            self.mount(token_url, HTTPAdapter(max_retries=self.retry_max))
 
         # Check connectivity & authentication
         self.health_check()
@@ -107,6 +109,8 @@ class APISession(Session):
                 self.headers['authorization'] = 'Bearer {}'.format(self.tkn_access)
                 return
             except (TypeError, AttributeError, BytesWarning, HTTPError, ConnectionError, ReadTimeout) as e:
+                if isinstance(e, HTTPError) and e.response is not None:
+                    self.logger.error('OIDC token request failed (%s): %s', e.response.status_code, e.response.text)
                 raise OasisException('Authentication Error', e)
 
         try:

--- a/oasislmf/platform_api/session.py
+++ b/oasislmf/platform_api/session.py
@@ -1,5 +1,6 @@
 from requests import Session
 from requests.adapters import HTTPAdapter
+from requests.auth import HTTPBasicAuth
 from requests_toolbelt import MultipartEncoder
 from requests.exceptions import (
     ConnectionError,
@@ -26,6 +27,8 @@ class APISession(Session):
         client_secret=None,
         access_token=None,
         refresh_token=None,
+        token_url=None,
+        scope=None,
         timeout=25,
         retries=5,
         retry_delay=1,
@@ -40,6 +43,8 @@ class APISession(Session):
         self.tkn_access = None
         self.tkn_refresh = None
         self.url_base = urljoin(api_url, '')
+        self.token_url = token_url
+        self.scope = scope
         self.timeout = timeout
         self.retry_max = 0
         self.retry_delay = retry_delay
@@ -79,6 +84,31 @@ class APISession(Session):
             self.tkn_refresh = self.auth_credentials["refresh_token"]
             self.headers['authorization'] = 'Bearer {}'.format(self.tkn_access)
             return
+
+        if self.auth_type == "oidc" and self.token_url:
+            # Standard M2M client_credentials grant: Basic Auth + form-encoded body
+            try:
+                data = {'grant_type': 'client_credentials'}
+                if self.scope:
+                    data['scope'] = self.scope
+                r = super(APISession, self).post(
+                    self.token_url,
+                    data=data,
+                    auth=HTTPBasicAuth(
+                        self.auth_credentials['client_id'],
+                        self.auth_credentials['client_secret'],
+                    ),
+                    headers={'Content-Type': 'application/x-www-form-urlencoded'},
+                    timeout=self.timeout,
+                )
+                r.raise_for_status()
+                self.tkn_access = r.json()['access_token']
+                self.tkn_refresh = self.tkn_access
+                self.headers['authorization'] = 'Bearer {}'.format(self.tkn_access)
+                return
+            except (TypeError, AttributeError, BytesWarning, HTTPError, ConnectionError, ReadTimeout) as e:
+                raise OasisException('Authentication Error', e)
+
         try:
             url = urljoin(self.url_base, 'access_token/')
             r = self.post(url, json=self.auth_credentials)

--- a/oasislmf/platform_api/session.py
+++ b/oasislmf/platform_api/session.py
@@ -85,7 +85,7 @@ class APISession(Session):
             self.headers['authorization'] = 'Bearer {}'.format(self.tkn_access)
             return
 
-        if self.auth_type == "oidc" and self.token_url:
+        if self.token_url:
             # Standard M2M client_credentials grant: Basic Auth + form-encoded body
             try:
                 data = {'grant_type': 'client_credentials'}
@@ -125,7 +125,7 @@ class APISession(Session):
             raise OasisException(err_msg, e)
 
     def _refresh_token(self):
-        if self.auth_type == "oidc":
+        if self.token_url or self.auth_type == "oidc":
             self.__get_access_token()
             return
         try:

--- a/oasislmf/platform_api/session.py
+++ b/oasislmf/platform_api/session.py
@@ -121,7 +121,7 @@ class APISession(Session):
             # Authorization Code Flow — redirect user to IdP, receive an auth code
             elif self.auth_type == "oidc":
                 url = urljoin(self.url_base, 'access_token/')
-                r = self.post(url, json=self.auth_credentials)
+                r = super(APISession, self).post(url, json=self.auth_credentials, timeout=self.timeout)
                 r.raise_for_status()
                 self.tkn_access = r.json()['access_token']
                 self.tkn_refresh = None  # oidc has no refresh token
@@ -198,7 +198,7 @@ class APISession(Session):
                 error = "HTTP {}".format(http_err_code)
                 return True
             elif http_err_code in [401, 403]:
-                if self.auth_type != 'disabled' and self.tkn_refresh is not None:
+                if self.auth_type != 'disabled' and (self.tkn_refresh is not None or self.auth_type in ('m2m', 'oidc')):
                     self.logger.debug("requesting refresh token")
                     self._refresh_token()
                     return True

--- a/oasislmf/platform_api/session.py
+++ b/oasislmf/platform_api/session.py
@@ -114,7 +114,7 @@ class APISession(Session):
                 )
                 r.raise_for_status()
                 self.tkn_access = r.json()['access_token']
-                self.tkn_refresh = self.tkn_access
+                self.tkn_refresh = None
                 self.headers['authorization'] = 'Bearer {}'.format(self.tkn_access)
                 return
 

--- a/oasislmf/platform_api/session.py
+++ b/oasislmf/platform_api/session.py
@@ -88,15 +88,17 @@ class APISession(Session):
         self.__get_access_token()
 
     def __get_access_token(self):
+        # Token given directly     
         if self.auth_type == "token":
             self.tkn_access = self.auth_credentials["access_token"]
             self.tkn_refresh = self.auth_credentials["refresh_token"]
             self.headers['authorization'] = 'Bearer {}'.format(self.tkn_access)
             return
 
-        if self.auth_type == "m2m":
-            # client_credentials grant direct to IdP token endpoint
-            try:
+        # Attempt to fetch token 
+        try:
+            # client_credentials grant - direct request to IdP token endpoint
+            if self.auth_type == "m2m":
                 data = {'grant_type': 'client_credentials'}
                 if self.scope:
                     data['scope'] = self.scope
@@ -114,30 +116,39 @@ class APISession(Session):
                 self.tkn_access = r.json()['access_token']
                 self.tkn_refresh = self.tkn_access
                 self.headers['authorization'] = 'Bearer {}'.format(self.tkn_access)
-                return
-            except (TypeError, AttributeError, BytesWarning, HTTPError, ConnectionError, ReadTimeout) as e:
-                if isinstance(e, HTTPError) and e.response is not None:
-                    self.logger.error('M2M token request failed (%s): %s', e.response.status_code, e.response.text)
-                raise OasisException('Authentication Error', e)
+                return     
 
-        if self.auth_type in ("simple", "oidc"):
-            # simple: username/password JWT via platform /access_token/
-            # oidc: client_credentials relayed through platform /access_token/
-            try:
+            # Authorization Code Flow — redirect user to IdP, receive an auth code
+            elif self.auth_type == "oidc":
                 url = urljoin(self.url_base, 'access_token/')
                 r = self.post(url, json=self.auth_credentials)
                 r.raise_for_status()
                 self.tkn_access = r.json()['access_token']
-                self.tkn_refresh = r.json().get('refresh_token', self.tkn_access)
+                self.tkn_refresh = None  # oidc has no refresh token
                 self.headers['authorization'] = 'Bearer {}'.format(self.tkn_access)
-                return
-            except (TypeError, AttributeError, BytesWarning, HTTPError, ConnectionError, ReadTimeout) as e:
-                raise OasisException('Authentication Error', e)
+                return     
 
-        raise OasisException(f"Unknown auth_type: '{self.auth_type}'")
+            # usermame / password ~ token fetch direct to Django with refresh
+            elif self.auth_type == "simple":
+                url = urljoin(self.url_base, 'access_token/')
+                r = self.post(url, json=self.auth_credentials)
+                r.raise_for_status()
+                self.tkn_access = r.json()['access_token']
+                self.tkn_refresh = r.json()['refresh_token']
+                self.headers['authorization'] = 'Bearer {}'.format(self.tkn_access)
+                return     
+            
+            # Unsupported auth type
+            raise OasisException(f"Unknown auth_type: '{self.auth_type}'")
+
+        except (TypeError, AttributeError, BytesWarning, HTTPError, ConnectionError, ReadTimeout) as e:
+            if isinstance(e, HTTPError) and e.response is not None:
+                self.logger.error('Access token request failed (%s): %s', e.response.status_code, e.response.text)
+            raise OasisException('Authentication Error', e)
+
 
     def _refresh_token(self):
-        if self.auth_type == "m2m":
+        if self.auth_type in  ("m2m", "oidc"):
             self.__get_access_token()
             return
         try:

--- a/oasislmf/platform_api/session.py
+++ b/oasislmf/platform_api/session.py
@@ -88,14 +88,14 @@ class APISession(Session):
         self.__get_access_token()
 
     def __get_access_token(self):
-        # Token given directly     
+        # Token given directly
         if self.auth_type == "token":
             self.tkn_access = self.auth_credentials["access_token"]
             self.tkn_refresh = self.auth_credentials["refresh_token"]
             self.headers['authorization'] = 'Bearer {}'.format(self.tkn_access)
             return
 
-        # Attempt to fetch token 
+        # Attempt to fetch token
         try:
             # client_credentials grant - direct request to IdP token endpoint
             if self.auth_type == "m2m":
@@ -116,7 +116,7 @@ class APISession(Session):
                 self.tkn_access = r.json()['access_token']
                 self.tkn_refresh = self.tkn_access
                 self.headers['authorization'] = 'Bearer {}'.format(self.tkn_access)
-                return     
+                return
 
             # Authorization Code Flow — redirect user to IdP, receive an auth code
             elif self.auth_type == "oidc":
@@ -126,7 +126,7 @@ class APISession(Session):
                 self.tkn_access = r.json()['access_token']
                 self.tkn_refresh = None  # oidc has no refresh token
                 self.headers['authorization'] = 'Bearer {}'.format(self.tkn_access)
-                return     
+                return
 
             # usermame / password ~ token fetch direct to Django with refresh
             elif self.auth_type == "simple":
@@ -136,8 +136,8 @@ class APISession(Session):
                 self.tkn_access = r.json()['access_token']
                 self.tkn_refresh = r.json()['refresh_token']
                 self.headers['authorization'] = 'Bearer {}'.format(self.tkn_access)
-                return     
-            
+                return
+
             # Unsupported auth type
             raise OasisException(f"Unknown auth_type: '{self.auth_type}'")
 
@@ -146,9 +146,8 @@ class APISession(Session):
                 self.logger.error('Access token request failed (%s): %s', e.response.status_code, e.response.text)
             raise OasisException('Authentication Error', e)
 
-
     def _refresh_token(self):
-        if self.auth_type in  ("m2m", "oidc"):
+        if self.auth_type in ("m2m", "oidc"):
             self.__get_access_token()
             return
         try:

--- a/tests/computation/test_platform.py
+++ b/tests/computation/test_platform.py
@@ -210,7 +210,7 @@ class TestPlatformRunInputs(ComputationChecker):
         self.assertEqual(str(context.exception),
                          'Error: At least one of the following inputs is required [portfolio_id, oed_location_csv, oed_accounts_csv]')
 
-    @patch('builtins.input', side_effect=['y', 'AzureDiamond'])
+    @patch('builtins.input', side_effect=['1', 'AzureDiamond'])
     @patch('getpass.getpass', return_value='hunter2')
     def test_run_inputs__enter_password__unauthorized(self, mock_password, mock_input):
         responses.get(
@@ -229,7 +229,7 @@ class TestPlatformRunInputs(ComputationChecker):
             self.manager.platform_run_inputs()
         self.assertIn('HTTPError: 401 Client Error: Unauthorized for url:', str(context.exception))
         mock_input.assert_has_calls([
-            call('Use simple JWT [Y/n]: '),
+            call('Auth type — simple JWT [1], OIDC via platform [2], M2M direct to IdP [3]: '),
             call('Username: ')
         ])
         self.assertEqual(mock_input.call_count, 2)
@@ -250,7 +250,7 @@ class TestPlatformRunInputs(ComputationChecker):
         self.assertEqual(str(context.exception),
                          f'Authentication Error, HTTPError: 500 Server Error: Internal Server Error for url: {self.api_url}/access_token/')
 
-    @patch('builtins.input', side_effect=['y', 'AzureDiamond'])
+    @patch('builtins.input', side_effect=['1', 'AzureDiamond'])
     @patch('getpass.getpass', return_value='hunter2')
     def test_run_inputs__enter_password__authorized(self, mock_password, mock_input):
         responses.get(
@@ -690,7 +690,8 @@ class TestPlatformRun(ComputationChecker):
                                     reporting_currency):
 
         # Extract funcution kwargs into dict, and replace booleans with temp file paths
-        call_args = {k: v for k, v in locals().items() if k in self.default_args}
+        call_args = dict(self.default_args)
+        call_args.update({k: v for k, v in locals().items() if k in self.default_args})
         call_args['server_url'] = self.api_url
         call_args['lookup_chunks'] = None
         call_args['analysis_chunks'] = None

--- a/tests/platform_api/test_session.py
+++ b/tests/platform_api/test_session.py
@@ -923,3 +923,188 @@ class TestGetAccessTokenDirectToken(unittest.TestCase):
         self.assertEqual(session.tkn_access, 'direct_access')
         self.assertEqual(session.tkn_refresh, 'direct_refresh')
         self.assertEqual(session.headers['authorization'], 'Bearer direct_access')
+
+
+# ---------------------------------------------------------------------------
+# Token-expiry / 401 behaviour tests
+# ---------------------------------------------------------------------------
+
+class TestTokenExpiry(unittest.TestCase):
+    """
+    Verify how each auth mode reacts when the server returns 401/403
+    (expired or invalid access token).
+    """
+
+    def _expired_response(self, status=401):
+        r = Mock()
+        r.raise_for_status.side_effect = HTTPError(response=Mock(status_code=status))
+        return r
+
+    def _success_response(self):
+        r = Mock()
+        r.raise_for_status.return_value = None
+        return r
+
+    # --- oidc: tkn_refresh is None → 401 is not retried ---
+
+    def test_oidc__401_raises_immediately_without_refresh(self):
+        session, _, _ = _make_session(
+            auth_type='oidc',
+            client_id='cid',
+            client_secret='secret',
+        )
+        self.assertIsNone(session.tkn_refresh)
+
+        refresh_mock = Mock()
+        with patch.object(Session, 'get', return_value=self._expired_response()), \
+             patch.object(session, '_refresh_token', refresh_mock):
+            with self.assertRaises(HTTPError):
+                session.get('http://example.com/api/resource/')
+
+        refresh_mock.assert_not_called()
+
+    def test_oidc__401_does_not_retry(self):
+        session, _, _ = _make_session(
+            auth_type='oidc',
+            client_id='cid',
+            client_secret='secret',
+        )
+        get_mock = Mock(return_value=self._expired_response())
+
+        with patch.object(Session, 'get', get_mock):
+            with self.assertRaises(HTTPError):
+                session.get('http://example.com/api/resource/')
+
+        self.assertEqual(get_mock.call_count, 1)
+
+    def test_oidc__403_also_raises_immediately(self):
+        session, _, _ = _make_session(
+            auth_type='oidc',
+            client_id='cid',
+            client_secret='secret',
+        )
+        with patch.object(Session, 'get', return_value=self._expired_response(403)):
+            with self.assertRaises(HTTPError):
+                session.get('http://example.com/api/resource/')
+
+    # --- disabled: auth_type == 'disabled' → 401 is not retried ---
+
+    def test_disabled__401_raises_immediately_without_refresh(self):
+        session, _, _ = _make_session(auth_type='disabled')
+        refresh_mock = Mock()
+
+        with patch.object(Session, 'get', return_value=self._expired_response()), \
+             patch.object(session, '_refresh_token', refresh_mock):
+            with self.assertRaises(HTTPError):
+                session.get('http://example.com/api/resource/')
+
+        refresh_mock.assert_not_called()
+
+    # --- simple / token: tkn_refresh is set → 401 triggers _refresh_token then retries ---
+
+    def test_simple__401_triggers_refresh_and_succeeds(self):
+        session, _, _ = _make_session(
+            auth_type='simple',
+            username='user',
+            password='pass',
+        )
+        get_mock = Mock(side_effect=[
+            self._expired_response(401),
+            self._success_response(),
+        ])
+        refresh_mock = Mock()
+
+        with patch.object(Session, 'get', get_mock), \
+             patch.object(session, '_refresh_token', refresh_mock):
+            session.get('http://example.com/api/resource/')
+
+        refresh_mock.assert_called_once()
+        self.assertEqual(get_mock.call_count, 2)
+
+    def test_token__401_triggers_refresh_and_succeeds(self):
+        session, _, _ = _make_session(
+            auth_type='token',
+            access_token='access',
+            refresh_token='refresh',
+        )
+        get_mock = Mock(side_effect=[
+            self._expired_response(401),
+            self._success_response(),
+        ])
+        refresh_mock = Mock()
+
+        with patch.object(Session, 'get', get_mock), \
+             patch.object(session, '_refresh_token', refresh_mock):
+            session.get('http://example.com/api/resource/')
+
+        refresh_mock.assert_called_once()
+        self.assertEqual(get_mock.call_count, 2)
+
+    # --- m2m: tkn_refresh mirrors access token (not None) → 401 triggers re-fetch from IdP ---
+
+    def test_m2m__401_triggers_refresh_and_succeeds(self):
+        session, _, _ = _make_session(
+            auth_type='m2m',
+            client_id='cid',
+            client_secret='secret',
+            token_url='http://idp.example.com/token',
+        )
+        self.assertIsNotNone(session.tkn_refresh)
+
+        get_mock = Mock(side_effect=[
+            self._expired_response(401),
+            self._success_response(),
+        ])
+        refresh_mock = Mock()
+
+        with patch.object(Session, 'get', get_mock), \
+             patch.object(session, '_refresh_token', refresh_mock):
+            session.get('http://example.com/api/resource/')
+
+        refresh_mock.assert_called_once()
+        self.assertEqual(get_mock.call_count, 2)
+
+    def test_m2m__persistent_401_exhausts_retries_and_raises(self):
+        session, _, _ = _make_session(
+            auth_type='m2m',
+            client_id='cid',
+            client_secret='secret',
+            token_url='http://idp.example.com/token',
+        )
+        retries = session.retry_max
+        get_mock = Mock(return_value=self._expired_response(401))
+        refresh_mock = Mock()
+
+        with patch.object(Session, 'get', get_mock), \
+             patch.object(session, '_refresh_token', refresh_mock):
+            with self.assertRaises(OasisException):
+                session.get('http://example.com/api/resource/')
+
+        self.assertEqual(get_mock.call_count, retries)
+        self.assertEqual(refresh_mock.call_count, retries - 1)
+
+    def test_m2m__401_new_token_set_on_retry(self):
+        """After expiry, a refreshed token should be used for subsequent requests."""
+        session, _, _ = _make_session(
+            auth_type='m2m',
+            client_id='cid',
+            client_secret='secret',
+            token_url='http://idp.example.com/token',
+        )
+
+        def fake_refresh():
+            session.tkn_access = 'refreshed_access'
+            session.tkn_refresh = 'refreshed_access'
+            session.headers['authorization'] = 'Bearer refreshed_access'
+
+        get_mock = Mock(side_effect=[
+            self._expired_response(401),
+            self._success_response(),
+        ])
+
+        with patch.object(Session, 'get', get_mock), \
+             patch.object(session, '_refresh_token', side_effect=fake_refresh):
+            session.get('http://example.com/api/resource/')
+
+        self.assertEqual(session.tkn_access, 'refreshed_access')
+        self.assertEqual(session.headers['authorization'], 'Bearer refreshed_access')

--- a/tests/platform_api/test_session.py
+++ b/tests/platform_api/test_session.py
@@ -945,47 +945,79 @@ class TestTokenExpiry(unittest.TestCase):
         r.raise_for_status.return_value = None
         return r
 
-    # --- oidc: tkn_refresh is None → 401 is not retried ---
+    # --- oidc: tkn_refresh is None but auth_type is oidc → 401 should re-authenticate ---
 
-    def test_oidc__401_raises_immediately_without_refresh(self):
+    def test_oidc__401_triggers_refresh_and_succeeds(self):
         session, _, _ = _make_session(
             auth_type='oidc',
             client_id='cid',
             client_secret='secret',
         )
-        self.assertIsNone(session.tkn_refresh)
-
+        get_mock = Mock(side_effect=[
+            self._expired_response(401),
+            self._success_response(),
+        ])
         refresh_mock = Mock()
-        with patch.object(Session, 'get', return_value=self._expired_response()), \
+
+        with patch.object(Session, 'get', get_mock), \
                 patch.object(session, '_refresh_token', refresh_mock):
-            with self.assertRaises(HTTPError):
-                session.get('http://example.com/api/resource/')
+            session.get('http://example.com/api/resource/')
 
-        refresh_mock.assert_not_called()
+        refresh_mock.assert_called_once()
+        self.assertEqual(get_mock.call_count, 2)
 
-    def test_oidc__401_does_not_retry(self):
+    def test_oidc__401_retries_after_refresh(self):
         session, _, _ = _make_session(
             auth_type='oidc',
             client_id='cid',
             client_secret='secret',
         )
-        get_mock = Mock(return_value=self._expired_response())
+        get_mock = Mock(side_effect=[
+            self._expired_response(401),
+            self._success_response(),
+        ])
 
-        with patch.object(Session, 'get', get_mock):
-            with self.assertRaises(HTTPError):
-                session.get('http://example.com/api/resource/')
+        with patch.object(Session, 'get', get_mock), \
+                patch.object(session, '_refresh_token'):
+            session.get('http://example.com/api/resource/')
 
-        self.assertEqual(get_mock.call_count, 1)
+        self.assertEqual(get_mock.call_count, 2)
 
-    def test_oidc__403_also_raises_immediately(self):
+    def test_oidc__403_triggers_refresh(self):
         session, _, _ = _make_session(
             auth_type='oidc',
             client_id='cid',
             client_secret='secret',
         )
-        with patch.object(Session, 'get', return_value=self._expired_response(403)):
-            with self.assertRaises(HTTPError):
+        get_mock = Mock(side_effect=[
+            self._expired_response(403),
+            self._success_response(),
+        ])
+        refresh_mock = Mock()
+
+        with patch.object(Session, 'get', get_mock), \
+                patch.object(session, '_refresh_token', refresh_mock):
+            session.get('http://example.com/api/resource/')
+
+        refresh_mock.assert_called_once()
+
+    def test_oidc__persistent_401_exhausts_retries_and_raises(self):
+        session, _, _ = _make_session(
+            auth_type='oidc',
+            client_id='cid',
+            client_secret='secret',
+        )
+        retries = session.retry_max
+        get_mock = Mock(return_value=self._expired_response(401))
+        refresh_mock = Mock()
+
+        with patch.object(Session, 'get', get_mock), \
+                patch.object(session, '_refresh_token', refresh_mock):
+            with self.assertRaises(OasisException):
                 session.get('http://example.com/api/resource/')
+
+        self.assertEqual(get_mock.call_count, retries)
+        self.assertEqual(refresh_mock.call_count, retries - 1)
 
     # --- disabled: auth_type == 'disabled' → 401 is not retried ---
 

--- a/tests/platform_api/test_session.py
+++ b/tests/platform_api/test_session.py
@@ -509,8 +509,8 @@ def _make_session(auth_type=None, post_response=None, server_auth_type=None, **i
     get_mock = Mock(return_value=server_info)
 
     with patch.object(APISession, 'health_check'), \
-         patch.object(Session, 'post', post_mock), \
-         patch.object(Session, 'get', get_mock):
+            patch.object(Session, 'post', post_mock), \
+            patch.object(Session, 'get', get_mock):
         session = APISession(
             'http://example.com/api/',
             auth_type=auth_type,
@@ -654,7 +654,7 @@ class TestAPISessionInitCredentialErrors(unittest.TestCase):
 
     def _assert_raises_on_init(self, **init_kwargs):
         with patch.object(APISession, 'health_check'), \
-             patch.object(Session, 'get'):
+                patch.object(Session, 'get'):
             with self.assertRaises(OasisException):
                 APISession('http://example.com/api/', timeout=0.1, **init_kwargs)
 
@@ -751,8 +751,8 @@ class TestAPISessionServerAuthTypeFallback(unittest.TestCase):
         server_info.json.return_value = {'config': {'API_AUTH_TYPE': 'simple'}}
 
         with patch.object(APISession, 'health_check'), \
-             patch.object(Session, 'post', return_value=post_response), \
-             patch.object(Session, 'get', return_value=server_info):
+                patch.object(Session, 'post', return_value=post_response), \
+                patch.object(Session, 'get', return_value=server_info):
             session = APISession(
                 'http://example.com/api/',
                 # auth_type intentionally omitted
@@ -810,7 +810,7 @@ class TestRefreshTokenOIDCAndM2M(unittest.TestCase):
         get_access_mock = Mock()
 
         with patch.object(session, '_APISession__get_access_token', get_access_mock), \
-             patch.object(Session, 'post') as post_mock:
+                patch.object(Session, 'post') as post_mock:
             session._refresh_token()
 
         post_mock.assert_not_called()
@@ -820,7 +820,7 @@ class TestRefreshTokenOIDCAndM2M(unittest.TestCase):
         get_access_mock = Mock()
 
         with patch.object(session, '_APISession__get_access_token', get_access_mock), \
-             patch.object(Session, 'post') as post_mock:
+                patch.object(Session, 'post') as post_mock:
             session._refresh_token()
 
         post_mock.assert_not_called()
@@ -957,7 +957,7 @@ class TestTokenExpiry(unittest.TestCase):
 
         refresh_mock = Mock()
         with patch.object(Session, 'get', return_value=self._expired_response()), \
-             patch.object(session, '_refresh_token', refresh_mock):
+                patch.object(session, '_refresh_token', refresh_mock):
             with self.assertRaises(HTTPError):
                 session.get('http://example.com/api/resource/')
 
@@ -994,7 +994,7 @@ class TestTokenExpiry(unittest.TestCase):
         refresh_mock = Mock()
 
         with patch.object(Session, 'get', return_value=self._expired_response()), \
-             patch.object(session, '_refresh_token', refresh_mock):
+                patch.object(session, '_refresh_token', refresh_mock):
             with self.assertRaises(HTTPError):
                 session.get('http://example.com/api/resource/')
 
@@ -1015,7 +1015,7 @@ class TestTokenExpiry(unittest.TestCase):
         refresh_mock = Mock()
 
         with patch.object(Session, 'get', get_mock), \
-             patch.object(session, '_refresh_token', refresh_mock):
+                patch.object(session, '_refresh_token', refresh_mock):
             session.get('http://example.com/api/resource/')
 
         refresh_mock.assert_called_once()
@@ -1034,7 +1034,7 @@ class TestTokenExpiry(unittest.TestCase):
         refresh_mock = Mock()
 
         with patch.object(Session, 'get', get_mock), \
-             patch.object(session, '_refresh_token', refresh_mock):
+                patch.object(session, '_refresh_token', refresh_mock):
             session.get('http://example.com/api/resource/')
 
         refresh_mock.assert_called_once()
@@ -1058,7 +1058,7 @@ class TestTokenExpiry(unittest.TestCase):
         refresh_mock = Mock()
 
         with patch.object(Session, 'get', get_mock), \
-             patch.object(session, '_refresh_token', refresh_mock):
+                patch.object(session, '_refresh_token', refresh_mock):
             session.get('http://example.com/api/resource/')
 
         refresh_mock.assert_called_once()
@@ -1076,7 +1076,7 @@ class TestTokenExpiry(unittest.TestCase):
         refresh_mock = Mock()
 
         with patch.object(Session, 'get', get_mock), \
-             patch.object(session, '_refresh_token', refresh_mock):
+                patch.object(session, '_refresh_token', refresh_mock):
             with self.assertRaises(OasisException):
                 session.get('http://example.com/api/resource/')
 
@@ -1103,7 +1103,7 @@ class TestTokenExpiry(unittest.TestCase):
         ])
 
         with patch.object(Session, 'get', get_mock), \
-             patch.object(session, '_refresh_token', side_effect=fake_refresh):
+                patch.object(session, '_refresh_token', side_effect=fake_refresh):
             session.get('http://example.com/api/resource/')
 
         self.assertEqual(session.tkn_access, 'refreshed_access')

--- a/tests/platform_api/test_session.py
+++ b/tests/platform_api/test_session.py
@@ -623,8 +623,8 @@ class TestAPISessionInitM2M(unittest.TestCase):
     def test_m2m_auth__access_token_set(self):
         self.assertEqual(self.session.tkn_access, 'test_access')
 
-    def test_m2m_auth__refresh_token_equals_access_token(self):
-        self.assertEqual(self.session.tkn_refresh, self.session.tkn_access)
+    def test_m2m_auth__no_refresh_token(self):
+        self.assertIsNone(self.session.tkn_refresh)
 
     def test_m2m_auth__authorization_header_set(self):
         self.assertEqual(self.session.headers['authorization'], 'Bearer test_access')
@@ -891,14 +891,14 @@ class TestGetAccessTokenM2M(unittest.TestCase):
         self.assertEqual(auth_used.username, 'm2m_cid')
         self.assertEqual(auth_used.password, 'm2m_secret')
 
-    def test_get_access_token__refresh_token_mirrors_access_token(self):
+    def test_get_access_token__no_refresh_token(self):
         new_response = _ok_response('fresh_access', 'ignored')
 
         with patch.object(Session, 'post', return_value=new_response):
             self.session._APISession__get_access_token()
 
         self.assertEqual(self.session.tkn_access, 'fresh_access')
-        self.assertEqual(self.session.tkn_refresh, 'fresh_access')
+        self.assertIsNone(self.session.tkn_refresh)
 
     def test_get_access_token__http_error_raises_oasis_exception(self):
         error_response = Mock()
@@ -1081,7 +1081,7 @@ class TestTokenExpiry(unittest.TestCase):
             client_secret='secret',
             token_url='http://idp.example.com/token',
         )
-        self.assertIsNotNone(session.tkn_refresh)
+        self.assertIsNone(session.tkn_refresh)  # m2m has no refresh token; re-auth uses auth_type check
 
         get_mock = Mock(side_effect=[
             self._expired_response(401),

--- a/tests/platform_api/test_session.py
+++ b/tests/platform_api/test_session.py
@@ -1,6 +1,7 @@
 import unittest
-from unittest.mock import Mock, patch, ANY
+from unittest.mock import Mock, patch, ANY, call
 from requests.exceptions import HTTPError, ConnectionError, ReadTimeout
+from requests.auth import HTTPBasicAuth
 from requests_toolbelt import MultipartEncoder
 from requests import Session
 from pathlib import Path
@@ -479,3 +480,446 @@ class APISessionTests(unittest.TestCase):
             timeout=self.timeout
         )
         self.assertEqual(put_mock.call_count, 1)
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by the auth-mode tests below
+# ---------------------------------------------------------------------------
+
+def _ok_response(access='test_access', refresh='test_refresh'):
+    r = Mock()
+    r.raise_for_status.return_value = None
+    r.json.return_value = {'access_token': access, 'refresh_token': refresh}
+    return r
+
+
+def _make_session(auth_type=None, post_response=None, server_auth_type=None, **init_kwargs):
+    """
+    Construct an APISession with all network calls mocked.
+    Returns (session, post_mock, get_mock).
+    """
+    if post_response is None:
+        post_response = _ok_response()
+
+    server_info = Mock()
+    server_info.status_code = 200
+    server_info.json.return_value = {'config': {'API_AUTH_TYPE': server_auth_type}}
+
+    post_mock = Mock(return_value=post_response)
+    get_mock = Mock(return_value=server_info)
+
+    with patch.object(APISession, 'health_check'), \
+         patch.object(Session, 'post', post_mock), \
+         patch.object(Session, 'get', get_mock):
+        session = APISession(
+            'http://example.com/api/',
+            auth_type=auth_type,
+            timeout=0.1,
+            retries=3,
+            retry_delay=0.1,
+            **init_kwargs,
+        )
+    return session, post_mock, get_mock
+
+
+# ---------------------------------------------------------------------------
+# Init / auth-mode tests
+# ---------------------------------------------------------------------------
+
+class TestAPISessionInitDisabled(unittest.TestCase):
+
+    def test_disabled_auth__no_credentials_required(self):
+        session, post_mock, _ = _make_session(auth_type='disabled')
+        self.assertEqual(session.auth_type, 'disabled')
+        self.assertEqual(session.auth_credentials, {})
+        self.assertIsNone(session.tkn_access)
+        self.assertIsNone(session.tkn_refresh)
+        post_mock.assert_not_called()
+
+    def test_disabled_auth__header_unchanged(self):
+        session, _, _ = _make_session(auth_type='disabled')
+        self.assertEqual(session.headers['authorization'], '')
+
+
+class TestAPISessionInitToken(unittest.TestCase):
+
+    def setUp(self):
+        self.access = 'direct_access_token'
+        self.refresh = 'direct_refresh_token'
+        self.session, self.post_mock, _ = _make_session(
+            auth_type='token',
+            access_token=self.access,
+            refresh_token=self.refresh,
+        )
+
+    def test_token_auth__tokens_set_directly(self):
+        self.assertEqual(self.session.tkn_access, self.access)
+        self.assertEqual(self.session.tkn_refresh, self.refresh)
+
+    def test_token_auth__authorization_header_set(self):
+        self.assertEqual(self.session.headers['authorization'], f'Bearer {self.access}')
+
+    def test_token_auth__no_http_call_for_token(self):
+        # Session.post must not be called during __get_access_token for token auth
+        self.post_mock.assert_not_called()
+
+
+class TestAPISessionInitOIDC(unittest.TestCase):
+
+    def setUp(self):
+        self.client_id = 'my_client'
+        self.client_secret = 'my_secret'
+        self.session, self.post_mock, _ = _make_session(
+            auth_type='oidc',
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+        )
+
+    def test_oidc_auth__posts_to_access_token_endpoint(self):
+        self.post_mock.assert_called_once_with(
+            'http://example.com/api/access_token/',
+            json={'client_id': self.client_id, 'client_secret': self.client_secret},
+            timeout=0.1,
+        )
+
+    def test_oidc_auth__access_token_set(self):
+        self.assertEqual(self.session.tkn_access, 'test_access')
+
+    def test_oidc_auth__no_refresh_token(self):
+        self.assertIsNone(self.session.tkn_refresh)
+
+    def test_oidc_auth__authorization_header_set(self):
+        self.assertEqual(self.session.headers['authorization'], 'Bearer test_access')
+
+
+class TestAPISessionInitM2M(unittest.TestCase):
+
+    def setUp(self):
+        self.client_id = 'm2m_client'
+        self.client_secret = 'm2m_secret'
+        self.token_url = 'http://idp.example.com/token'
+        self.session, self.post_mock, _ = _make_session(
+            auth_type='m2m',
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            token_url=self.token_url,
+        )
+
+    def test_m2m_auth__posts_to_token_url(self):
+        self.post_mock.assert_called_once_with(
+            self.token_url,
+            data={'grant_type': 'client_credentials'},
+            auth=ANY,
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            timeout=0.1,
+        )
+
+    def test_m2m_auth__uses_basic_auth(self):
+        auth_used = self.post_mock.call_args.kwargs['auth']
+        self.assertIsInstance(auth_used, HTTPBasicAuth)
+        self.assertEqual(auth_used.username, self.client_id)
+        self.assertEqual(auth_used.password, self.client_secret)
+
+    def test_m2m_auth__access_token_set(self):
+        self.assertEqual(self.session.tkn_access, 'test_access')
+
+    def test_m2m_auth__refresh_token_equals_access_token(self):
+        self.assertEqual(self.session.tkn_refresh, self.session.tkn_access)
+
+    def test_m2m_auth__authorization_header_set(self):
+        self.assertEqual(self.session.headers['authorization'], 'Bearer test_access')
+
+    def test_m2m_auth__with_scope(self):
+        _, post_mock, _ = _make_session(
+            auth_type='m2m',
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            token_url=self.token_url,
+            scope='openid profile',
+        )
+        post_mock.assert_called_once_with(
+            self.token_url,
+            data={'grant_type': 'client_credentials', 'scope': 'openid profile'},
+            auth=ANY,
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            timeout=0.1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Credential validation error tests
+# ---------------------------------------------------------------------------
+
+class TestAPISessionInitCredentialErrors(unittest.TestCase):
+
+    def _assert_raises_on_init(self, **init_kwargs):
+        with patch.object(APISession, 'health_check'), \
+             patch.object(Session, 'get'):
+            with self.assertRaises(OasisException):
+                APISession('http://example.com/api/', timeout=0.1, **init_kwargs)
+
+    def test_simple_missing_password(self):
+        self._assert_raises_on_init(auth_type='simple', username='user')
+
+    def test_simple_missing_username(self):
+        self._assert_raises_on_init(auth_type='simple', password='pass')
+
+    def test_simple_no_credentials(self):
+        self._assert_raises_on_init(auth_type='simple')
+
+    def test_oidc_missing_client_secret(self):
+        self._assert_raises_on_init(auth_type='oidc', client_id='cid')
+
+    def test_oidc_missing_client_id(self):
+        self._assert_raises_on_init(auth_type='oidc', client_secret='secret')
+
+    def test_oidc_no_credentials(self):
+        self._assert_raises_on_init(auth_type='oidc')
+
+    def test_m2m_missing_token_url(self):
+        self._assert_raises_on_init(auth_type='m2m', client_id='cid', client_secret='secret')
+
+    def test_m2m_missing_client_secret(self):
+        self._assert_raises_on_init(auth_type='m2m', client_id='cid', token_url='http://idp/token')
+
+    def test_token_missing_refresh_token(self):
+        self._assert_raises_on_init(auth_type='token', access_token='tok')
+
+    def test_token_missing_access_token(self):
+        self._assert_raises_on_init(auth_type='token', refresh_token='refresh')
+
+    def test_unknown_auth_type(self):
+        self._assert_raises_on_init(auth_type='ldap')
+
+
+# ---------------------------------------------------------------------------
+# _fetch_server_auth_type tests
+# ---------------------------------------------------------------------------
+
+class TestFetchServerAuthType(unittest.TestCase):
+
+    def setUp(self):
+        # Use a simple-auth session as the test subject
+        self.session, _, _ = _make_session(
+            auth_type='simple',
+            username='user',
+            password='pass',
+        )
+
+    def test_returns_auth_type_from_server_info(self):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {'config': {'API_AUTH_TYPE': 'oidc'}}
+
+        with patch.object(Session, 'get', return_value=response):
+            result = self.session._fetch_server_auth_type()
+
+        self.assertEqual(result, 'oidc')
+
+    def test_returns_none_when_server_returns_non_200(self):
+        response = Mock()
+        response.status_code = 500
+
+        with patch.object(Session, 'get', return_value=response):
+            result = self.session._fetch_server_auth_type()
+
+        self.assertIsNone(result)
+
+    def test_returns_none_on_connection_error(self):
+        with patch.object(Session, 'get', side_effect=ConnectionError()):
+            result = self.session._fetch_server_auth_type()
+
+        self.assertIsNone(result)
+
+    def test_returns_none_when_config_key_absent(self):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {}
+
+        with patch.object(Session, 'get', return_value=response):
+            result = self.session._fetch_server_auth_type()
+
+        self.assertIsNone(result)
+
+
+class TestAPISessionServerAuthTypeFallback(unittest.TestCase):
+
+    def test_server_auth_type_used_when_auth_type_not_given(self):
+        post_response = _ok_response()
+        server_info = Mock()
+        server_info.status_code = 200
+        server_info.json.return_value = {'config': {'API_AUTH_TYPE': 'simple'}}
+
+        with patch.object(APISession, 'health_check'), \
+             patch.object(Session, 'post', return_value=post_response), \
+             patch.object(Session, 'get', return_value=server_info):
+            session = APISession(
+                'http://example.com/api/',
+                # auth_type intentionally omitted
+                username='user',
+                password='pass',
+                timeout=0.1,
+            )
+
+        self.assertEqual(session.auth_type, 'simple')
+
+
+# ---------------------------------------------------------------------------
+# _refresh_token tests for oidc / m2m
+# ---------------------------------------------------------------------------
+
+class TestRefreshTokenOIDCAndM2M(unittest.TestCase):
+
+    def _make_oidc_session(self):
+        session, _, _ = _make_session(
+            auth_type='oidc',
+            client_id='cid',
+            client_secret='secret',
+        )
+        return session
+
+    def _make_m2m_session(self):
+        session, _, _ = _make_session(
+            auth_type='m2m',
+            client_id='cid',
+            client_secret='secret',
+            token_url='http://idp.example.com/token',
+        )
+        return session
+
+    def test_refresh_token__oidc_calls_get_access_token(self):
+        session = self._make_oidc_session()
+        get_access_mock = Mock()
+
+        with patch.object(session, '_APISession__get_access_token', get_access_mock):
+            session._refresh_token()
+
+        get_access_mock.assert_called_once()
+
+    def test_refresh_token__m2m_calls_get_access_token(self):
+        session = self._make_m2m_session()
+        get_access_mock = Mock()
+
+        with patch.object(session, '_APISession__get_access_token', get_access_mock):
+            session._refresh_token()
+
+        get_access_mock.assert_called_once()
+
+    def test_refresh_token__oidc_does_not_call_refresh_endpoint(self):
+        session = self._make_oidc_session()
+        get_access_mock = Mock()
+
+        with patch.object(session, '_APISession__get_access_token', get_access_mock), \
+             patch.object(Session, 'post') as post_mock:
+            session._refresh_token()
+
+        post_mock.assert_not_called()
+
+    def test_refresh_token__m2m_does_not_call_refresh_endpoint(self):
+        session = self._make_m2m_session()
+        get_access_mock = Mock()
+
+        with patch.object(session, '_APISession__get_access_token', get_access_mock), \
+             patch.object(Session, 'post') as post_mock:
+            session._refresh_token()
+
+        post_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# __get_access_token tests for oidc / m2m / token
+# ---------------------------------------------------------------------------
+
+class TestGetAccessTokenOIDC(unittest.TestCase):
+
+    def setUp(self):
+        self.session, _, _ = _make_session(
+            auth_type='oidc',
+            client_id='cid',
+            client_secret='secret',
+        )
+
+    def test_get_access_token__posts_client_credentials_to_api(self):
+        new_response = _ok_response('new_access', 'ignored_refresh')
+
+        with patch.object(Session, 'post', return_value=new_response) as post_mock:
+            self.session._APISession__get_access_token()
+
+        post_mock.assert_called_once_with(
+            'http://example.com/api/access_token/',
+            json={'client_id': 'cid', 'client_secret': 'secret'},
+            timeout=0.1,
+        )
+        self.assertEqual(self.session.tkn_access, 'new_access')
+        self.assertIsNone(self.session.tkn_refresh)
+
+    def test_get_access_token__http_error_raises_oasis_exception(self):
+        error_response = Mock()
+        error_response.raise_for_status.side_effect = HTTPError(response=Mock(status_code=401))
+
+        with patch.object(Session, 'post', return_value=error_response):
+            with self.assertRaises(OasisException):
+                self.session._APISession__get_access_token()
+
+
+class TestGetAccessTokenM2M(unittest.TestCase):
+
+    def setUp(self):
+        self.token_url = 'http://idp.example.com/token'
+        self.session, _, _ = _make_session(
+            auth_type='m2m',
+            client_id='m2m_cid',
+            client_secret='m2m_secret',
+            token_url=self.token_url,
+        )
+
+    def test_get_access_token__posts_to_token_url_with_basic_auth(self):
+        new_response = _ok_response('new_m2m_access', 'ignored')
+
+        with patch.object(Session, 'post', return_value=new_response) as post_mock:
+            self.session._APISession__get_access_token()
+
+        post_mock.assert_called_once_with(
+            self.token_url,
+            data={'grant_type': 'client_credentials'},
+            auth=ANY,
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            timeout=0.1,
+        )
+        auth_used = post_mock.call_args.kwargs['auth']
+        self.assertIsInstance(auth_used, HTTPBasicAuth)
+        self.assertEqual(auth_used.username, 'm2m_cid')
+        self.assertEqual(auth_used.password, 'm2m_secret')
+
+    def test_get_access_token__refresh_token_mirrors_access_token(self):
+        new_response = _ok_response('fresh_access', 'ignored')
+
+        with patch.object(Session, 'post', return_value=new_response):
+            self.session._APISession__get_access_token()
+
+        self.assertEqual(self.session.tkn_access, 'fresh_access')
+        self.assertEqual(self.session.tkn_refresh, 'fresh_access')
+
+    def test_get_access_token__http_error_raises_oasis_exception(self):
+        error_response = Mock()
+        error_response.raise_for_status.side_effect = HTTPError(response=Mock(status_code=401))
+
+        with patch.object(Session, 'post', return_value=error_response):
+            with self.assertRaises(OasisException):
+                self.session._APISession__get_access_token()
+
+
+class TestGetAccessTokenDirectToken(unittest.TestCase):
+
+    def test_token_auth__tokens_assigned_without_http_call(self):
+        session, post_mock, _ = _make_session(
+            auth_type='token',
+            access_token='direct_access',
+            refresh_token='direct_refresh',
+        )
+        # post_mock was used during __init__ (healthcheck area) only;
+        # the token path must not have added any calls to Session.post
+        post_mock.assert_not_called()
+        self.assertEqual(session.tkn_access, 'direct_access')
+        self.assertEqual(session.tkn_refresh, 'direct_refresh')
+        self.assertEqual(session.headers['authorization'], 'Bearer direct_access')


### PR DESCRIPTION
<!--start_release_notes-->
### Update API client for OIDC M2M
Added new auth_mode `m2m` which uses client_credentials grant direct to IdP.  Added three new flags to the API client CLI to support this. 

```
  --auth-type {simple,oidc,m2m}
                        Authentication type: simple (username/password JWT), oidc (client credentials via platform),
                        m2m (client credentials direct to IdP)
  --oidc-token-url OIDC_TOKEN_URL
                        Token endpoint URL for m2m client_credentials grant (e.g.
                        https://idp.example.com/oauth2/token)
  --oidc-scope OIDC_SCOPE
                        OAuth2 scope to request when fetching an m2m token (e.g. oasis/m2m)

```

<!--end_release_notes-->


## Example 

`oasislmf.json`
```
{
  "server_url": "<Oasis-API-URL>",
  "oidc_token_url": "<Idp-auth-url>/oauth2/token/",
  "oidc_scope": "oasis/m2m",
  "server_login_json": "server-auth-creds.json"
}
```

`server-auth-creds.json`
```
{
  "client_id": "<client for IdP>",
  "client_secret": "<secret for IdP>"
}
```