### PR TITLE
Fix for stalled runs on V2 workers 

### DIFF
--- a/oasislmf/execution/bash.py
+++ b/oasislmf/execution/bash.py
@@ -2334,7 +2334,7 @@ def create_bash_analysis(
             print_command(filename, 'rm -R -f {}*'.format(fifo_queue_dir))
         else:
             print_command(
-                filename, f"find {fifo_queue_dir} \\( -name '*P{process_number}[^0-9]*' -o -name '*P{process_number}' \\)" + " -exec rm -R -f {} +")
+                filename, f"find {fifo_queue_dir} -regextype posix-extended -regex '.*/[^/]*_P{process_number}([^0-9].*)?$' -exec rm -f {{}} +")
 
         if full_correlation:
             print_command(filename, 'mkdir -p {}'.format(fifo_full_correlation_dir))

--- a/tests/model_execution/reference_bash_base/all_outputs_1_csv_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_csv_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_csv_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_csv_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_csv_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_csv_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_csv_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_csv_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_csv_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_csv_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_csv_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_csv_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_csv_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_csv_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_csv_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_csv_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_csv_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_csv_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_fc_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_fc_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_fc_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_fc_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_fc_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_fc_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_fc_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_fc_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_fc_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_fc_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_fc_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_fc_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_fc_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_fc_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_fc_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_fc_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_fc_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_fc_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_parquet_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_parquet_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_parquet_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_parquet_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_parquet_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_parquet_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_parquet_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_parquet_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_parquet_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_parquet_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_parquet_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_parquet_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_parquet_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_parquet_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_parquet_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_parquet_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/all_outputs_1_parquet_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_base/all_outputs_1_parquet_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/custom_gul_sample_1_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/custom_gul_sample_1_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/custom_gul_sample_1_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/custom_gul_sample_1_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/custom_gul_sample_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_base/custom_gul_sample_1_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/custom_gul_sample_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_base/custom_gul_sample_1_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/custom_gul_sample_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_base/custom_gul_sample_1_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/custom_gul_sample_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_base/custom_gul_sample_1_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/custom_gul_sample_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_base/custom_gul_sample_1_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/custom_gul_sample_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_base/custom_gul_sample_1_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/custom_gul_sample_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_base/custom_gul_sample_1_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/custom_gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/custom_gul_summarycalc_1_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/custom_gul_summarycalc_1_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/custom_gul_summarycalc_1_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/custom_gul_summarycalc_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_base/custom_gul_summarycalc_1_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/custom_gul_summarycalc_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_base/custom_gul_summarycalc_1_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/custom_gul_summarycalc_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_base/custom_gul_summarycalc_1_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/custom_gul_summarycalc_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_base/custom_gul_summarycalc_1_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/custom_gul_summarycalc_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_base/custom_gul_summarycalc_1_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/custom_gul_summarycalc_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_base/custom_gul_summarycalc_1_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/custom_gul_summarycalc_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_base/custom_gul_summarycalc_1_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_ept_psept_2_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_ept_psept_2_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_ept_psept_2_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_ept_psept_2_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_ept_psept_2_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_ept_psept_2_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_ept_psept_2_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_ept_psept_2_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_ept_psept_2_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_ept_psept_2_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_ept_psept_2_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_ept_psept_2_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_ept_psept_2_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_ept_psept_2_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_ept_psept_2_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_ept_psept_2_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_ept_psept_2_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_ept_psept_2_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_palt_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_palt_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_palt_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_palt_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_palt_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_palt_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_palt_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_palt_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_palt_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_palt_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_palt_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_palt_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_palt_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_palt_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_palt_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_palt_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_palt_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_palt_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_psept_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_psept_lec_1_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_psept_lec_1_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_psept_lec_1_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_psept_lec_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_psept_lec_1_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_psept_lec_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_psept_lec_1_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_psept_lec_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_psept_lec_1_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_psept_lec_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_psept_lec_1_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_psept_lec_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_psept_lec_1_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_psept_lec_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_psept_lec_1_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ord_psept_lec_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ord_psept_lec_1_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ri__pla_csv_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ri__pla_csv_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ri__pla_csv_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ri__pla_csv_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ri__pla_csv_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ri__pla_csv_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ri__pla_csv_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ri__pla_csv_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ri__pla_csv_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ri__pla_csv_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ri__pla_csv_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ri__pla_csv_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ri__pla_csv_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ri__pla_csv_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ri__pla_csv_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ri__pla_csv_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_il_ri__pla_csv_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_base/gul_il_ri__pla_csv_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_ept_1_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_ept_1_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_ept_1_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_ept_1_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_ept_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_ept_1_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_ept_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_ept_1_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_ept_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_ept_1_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_ept_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_ept_1_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_ept_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_ept_1_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_ept_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_ept_1_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_ept_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_ept_1_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_ept_2_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_ept_2_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_ept_2_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_ept_2_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_ept_2_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_ept_2_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_ept_2_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_ept_2_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_ept_2_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_ept_2_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_ept_2_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_ept_2_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_ept_2_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_ept_2_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_ept_2_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_ept_2_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_ept_2_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_ept_2_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_palt_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_palt_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_palt_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_palt_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_palt_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_palt_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_palt_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_palt_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_palt_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_palt_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_palt_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_palt_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_palt_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_palt_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_palt_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_palt_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_palt_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_palt_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_psept_2_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_psept_2_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_psept_2_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_psept_2_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_psept_2_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_psept_2_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_psept_2_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_psept_2_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_psept_2_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_psept_2_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_psept_2_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_psept_2_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_psept_2_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_psept_2_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_psept_2_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_psept_2_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_ord_psept_2_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_base/gul_ord_psept_2_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/gul_summarycalc_1_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_summarycalc_1_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/gul_summarycalc_1_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_summarycalc_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_base/gul_summarycalc_1_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_summarycalc_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_base/gul_summarycalc_1_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_summarycalc_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_base/gul_summarycalc_1_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_summarycalc_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_base/gul_summarycalc_1_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_summarycalc_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_base/gul_summarycalc_1_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_summarycalc_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_base/gul_summarycalc_1_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/gul_summarycalc_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_base/gul_summarycalc_1_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/il_only_no_ord_leccalc_output_3_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/il_only_no_ord_leccalc_output_3_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/il_only_no_ord_leccalc_output_3_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/il_only_no_ord_leccalc_output_3_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/il_only_no_ord_leccalc_output_3_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_base/il_only_no_ord_leccalc_output_3_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/il_only_no_ord_leccalc_output_3_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_base/il_only_no_ord_leccalc_output_3_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/il_only_no_ord_leccalc_output_3_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_base/il_only_no_ord_leccalc_output_3_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/il_only_no_ord_leccalc_output_3_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_base/il_only_no_ord_leccalc_output_3_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/il_only_no_ord_leccalc_output_3_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_base/il_only_no_ord_leccalc_output_3_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/il_only_no_ord_leccalc_output_3_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_base/il_only_no_ord_leccalc_output_3_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/il_only_no_ord_leccalc_output_3_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_base/il_only_no_ord_leccalc_output_3_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/il_only_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/il_only_summarycalc_1_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/il_only_summarycalc_1_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/il_only_summarycalc_1_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/il_only_summarycalc_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_base/il_only_summarycalc_1_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/il_only_summarycalc_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_base/il_only_summarycalc_1_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/il_only_summarycalc_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_base/il_only_summarycalc_1_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/il_only_summarycalc_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_base/il_only_summarycalc_1_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/il_only_summarycalc_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_base/il_only_summarycalc_1_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/il_only_summarycalc_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_base/il_only_summarycalc_1_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/il_only_summarycalc_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_base/il_only_summarycalc_1_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/ri_only_no_ord_leccalc_3_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/ri_only_no_ord_leccalc_3_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/ri_only_no_ord_leccalc_3_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_base/ri_only_no_ord_leccalc_3_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/ri_only_no_ord_leccalc_3_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_base/ri_only_no_ord_leccalc_3_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/ri_only_no_ord_leccalc_3_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_base/ri_only_no_ord_leccalc_3_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/ri_only_no_ord_leccalc_3_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_base/ri_only_no_ord_leccalc_3_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/ri_only_no_ord_leccalc_3_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_base/ri_only_no_ord_leccalc_3_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/ri_only_no_ord_leccalc_3_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_base/ri_only_no_ord_leccalc_3_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/ri_only_no_ord_leccalc_3_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_base/ri_only_no_ord_leccalc_3_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_base/ri_only_no_ord_leccalc_3_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_base/ri_only_no_ord_leccalc_3_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_csm/custom_gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_csm/custom_gul_summarycalc_1_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.1.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.2.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.3.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.4.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.5.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.6.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.7.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.1.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.2.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.3.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.4.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.5.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.6.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.7.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.1.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.2.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.3.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.4.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.5.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.6.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.7.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.1.sh
@@ -76,7 +76,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.2.sh
@@ -76,7 +76,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.3.sh
@@ -76,7 +76,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.4.sh
@@ -76,7 +76,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.5.sh
@@ -76,7 +76,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.6.sh
@@ -76,7 +76,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.7.sh
@@ -76,7 +76,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.1.sh
@@ -76,7 +76,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.2.sh
@@ -76,7 +76,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.3.sh
@@ -76,7 +76,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.4.sh
@@ -76,7 +76,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.5.sh
@@ -76,7 +76,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.6.sh
@@ -76,7 +76,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.7.sh
@@ -76,7 +76,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.1.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.2.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.3.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.4.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.5.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.6.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.7.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.1.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.2.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.3.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.4.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.5.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.6.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.7.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.1.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.2.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.3.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.4.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.5.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.6.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.7.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.1.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.2.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.3.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.4.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.5.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.6.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.7.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.1.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.2.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.3.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.4.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.5.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.6.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.7.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.1.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.2.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.3.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.4.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.5.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.6.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.7.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.1.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.2.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.3.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.4.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.5.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.6.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.7.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.1.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.2.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.3.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.4.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.5.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.6.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.7.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.1.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.2.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.3.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.4.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.5.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.6.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.7.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.1.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.2.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.3.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.4.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.5.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.6.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.7.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.1.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.2.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.3.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.4.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.5.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.6.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.7.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.1.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.2.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.3.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.4.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.5.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.6.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.7.sh
@@ -67,7 +67,7 @@ check_complete(){
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find /tmp/%FIFO_DIR%/fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find /tmp/%FIFO_DIR%/fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_err/update-tmp-tests.sh
+++ b/tests/model_execution/reference_bash_err/update-tmp-tests.sh
@@ -2,5 +2,8 @@ readarray -t files < <(find . -maxdepth 1 -type f -name "*partition*.sh")
 
 for f in "${files[@]}"; do
     echo $f
-    sed -i 's|/tmp/[a-zA-Z0-9]*/|/tmp/%FIFO_DIR%/|g' $f
+    sed -i \
+        -e 's|/tmp/[^ ]*/fifo/|/tmp/%FIFO_DIR%/fifo/|g' \
+        -e '/rm -R -f/ s|/tmp/[^ ]*/|/tmp/%FIFO_DIR%/|g' \
+        $f
 done

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_csv_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_csv_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_csv_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_csv_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_csv_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_csv_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_csv_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_csv_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_csv_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_csv_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_csv_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_csv_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_csv_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_csv_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_csv_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_csv_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_csv_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_csv_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_fc_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_fc_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_fc_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_fc_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_fc_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_fc_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_fc_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_fc_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_fc_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_fc_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_fc_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_fc_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_fc_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_fc_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_fc_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_fc_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_fc_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_fc_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_parquet_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_parquet_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_parquet_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_parquet_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_parquet_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_parquet_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_parquet_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_parquet_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_parquet_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_parquet_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_parquet_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_parquet_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_parquet_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_parquet_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_parquet_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_parquet_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/all_outputs_1_parquet_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_lb/all_outputs_1_parquet_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/custom_gul_sample_1_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/custom_gul_sample_1_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/custom_gul_sample_1_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/custom_gul_sample_1_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/custom_gul_sample_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_lb/custom_gul_sample_1_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/custom_gul_sample_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_lb/custom_gul_sample_1_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/custom_gul_sample_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_lb/custom_gul_sample_1_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/custom_gul_sample_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_lb/custom_gul_sample_1_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/custom_gul_sample_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_lb/custom_gul_sample_1_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/custom_gul_sample_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_lb/custom_gul_sample_1_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/custom_gul_sample_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_lb/custom_gul_sample_1_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/custom_gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/custom_gul_summarycalc_1_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/custom_gul_summarycalc_1_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/custom_gul_summarycalc_1_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/custom_gul_summarycalc_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_lb/custom_gul_summarycalc_1_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/custom_gul_summarycalc_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_lb/custom_gul_summarycalc_1_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/custom_gul_summarycalc_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_lb/custom_gul_summarycalc_1_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/custom_gul_summarycalc_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_lb/custom_gul_summarycalc_1_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/custom_gul_summarycalc_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_lb/custom_gul_summarycalc_1_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/custom_gul_summarycalc_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_lb/custom_gul_summarycalc_1_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/custom_gul_summarycalc_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_lb/custom_gul_summarycalc_1_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_ept_psept_2_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_ept_psept_2_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_ept_psept_2_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_ept_psept_2_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_ept_psept_2_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_ept_psept_2_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_ept_psept_2_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_ept_psept_2_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_ept_psept_2_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_ept_psept_2_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_ept_psept_2_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_ept_psept_2_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_ept_psept_2_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_ept_psept_2_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_ept_psept_2_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_ept_psept_2_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_ept_psept_2_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_ept_psept_2_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_palt_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_palt_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_palt_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_palt_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_palt_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_palt_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_palt_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_palt_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_palt_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_palt_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_palt_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_palt_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_palt_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_palt_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_palt_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_palt_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_palt_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_palt_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_psept_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_psept_lec_1_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_psept_lec_1_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_psept_lec_1_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_psept_lec_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_psept_lec_1_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_psept_lec_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_psept_lec_1_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_psept_lec_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_psept_lec_1_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_psept_lec_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_psept_lec_1_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_psept_lec_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_psept_lec_1_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_psept_lec_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_psept_lec_1_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ord_psept_lec_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ord_psept_lec_1_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ri__pla_csv_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ri__pla_csv_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ri__pla_csv_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ri__pla_csv_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ri__pla_csv_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ri__pla_csv_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ri__pla_csv_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ri__pla_csv_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ri__pla_csv_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ri__pla_csv_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ri__pla_csv_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ri__pla_csv_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ri__pla_csv_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ri__pla_csv_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ri__pla_csv_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ri__pla_csv_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_il_ri__pla_csv_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_lb/gul_il_ri__pla_csv_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_ept_1_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_ept_1_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_ept_1_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_ept_1_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_ept_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_ept_1_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_ept_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_ept_1_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_ept_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_ept_1_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_ept_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_ept_1_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_ept_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_ept_1_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_ept_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_ept_1_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_ept_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_ept_1_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_ept_2_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_ept_2_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_ept_2_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_ept_2_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_ept_2_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_ept_2_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_ept_2_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_ept_2_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_ept_2_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_ept_2_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_ept_2_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_ept_2_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_ept_2_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_ept_2_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_ept_2_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_ept_2_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_ept_2_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_ept_2_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_palt_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_palt_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_palt_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_palt_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_palt_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_palt_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_palt_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_palt_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_palt_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_palt_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_palt_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_palt_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_palt_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_palt_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_palt_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_palt_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_palt_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_palt_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_psept_2_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_psept_2_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_psept_2_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_psept_2_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_psept_2_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_psept_2_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_psept_2_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_psept_2_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_psept_2_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_psept_2_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_psept_2_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_psept_2_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_psept_2_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_psept_2_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_psept_2_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_psept_2_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_ord_psept_2_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_lb/gul_ord_psept_2_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/gul_summarycalc_1_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_summarycalc_1_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/gul_summarycalc_1_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_summarycalc_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_lb/gul_summarycalc_1_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_summarycalc_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_lb/gul_summarycalc_1_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_summarycalc_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_lb/gul_summarycalc_1_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_summarycalc_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_lb/gul_summarycalc_1_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_summarycalc_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_lb/gul_summarycalc_1_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_summarycalc_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_lb/gul_summarycalc_1_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/gul_summarycalc_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_lb/gul_summarycalc_1_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/il_only_no_ord_leccalc_output_3_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/il_only_no_ord_leccalc_output_3_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/il_only_no_ord_leccalc_output_3_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/il_only_no_ord_leccalc_output_3_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/il_only_no_ord_leccalc_output_3_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_lb/il_only_no_ord_leccalc_output_3_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/il_only_no_ord_leccalc_output_3_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_lb/il_only_no_ord_leccalc_output_3_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/il_only_no_ord_leccalc_output_3_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_lb/il_only_no_ord_leccalc_output_3_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/il_only_no_ord_leccalc_output_3_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_lb/il_only_no_ord_leccalc_output_3_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/il_only_no_ord_leccalc_output_3_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_lb/il_only_no_ord_leccalc_output_3_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/il_only_no_ord_leccalc_output_3_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_lb/il_only_no_ord_leccalc_output_3_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/il_only_no_ord_leccalc_output_3_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_lb/il_only_no_ord_leccalc_output_3_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/il_only_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/il_only_summarycalc_1_output_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/il_only_summarycalc_1_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/il_only_summarycalc_1_output_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/il_only_summarycalc_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_lb/il_only_summarycalc_1_output_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/il_only_summarycalc_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_lb/il_only_summarycalc_1_output_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/il_only_summarycalc_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_lb/il_only_summarycalc_1_output_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/il_only_summarycalc_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_lb/il_only_summarycalc_1_output_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/il_only_summarycalc_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_lb/il_only_summarycalc_1_output_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/il_only_summarycalc_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_lb/il_only_summarycalc_1_output_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/il_only_summarycalc_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_lb/il_only_summarycalc_1_output_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/ri_only_no_ord_leccalc_3_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/ri_only_no_ord_leccalc_3_1_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/ri_only_no_ord_leccalc_3_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_lb/ri_only_no_ord_leccalc_3_8_partition.0.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P1([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/ri_only_no_ord_leccalc_3_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_lb/ri_only_no_ord_leccalc_3_8_partition.1.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P2[^0-9]*' -o -name '*P2' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P2([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/ri_only_no_ord_leccalc_3_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_lb/ri_only_no_ord_leccalc_3_8_partition.2.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P3[^0-9]*' -o -name '*P3' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P3([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/ri_only_no_ord_leccalc_3_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_lb/ri_only_no_ord_leccalc_3_8_partition.3.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P4[^0-9]*' -o -name '*P4' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P4([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/ri_only_no_ord_leccalc_3_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_lb/ri_only_no_ord_leccalc_3_8_partition.4.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P5[^0-9]*' -o -name '*P5' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P5([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/ri_only_no_ord_leccalc_3_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_lb/ri_only_no_ord_leccalc_3_8_partition.5.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P6[^0-9]*' -o -name '*P6' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P6([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/ri_only_no_ord_leccalc_3_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_lb/ri_only_no_ord_leccalc_3_8_partition.6.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P7[^0-9]*' -o -name '*P7' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P7([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/reference_bash_lb/ri_only_no_ord_leccalc_3_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_lb/ri_only_no_ord_leccalc_3_8_partition.7.sh
@@ -13,7 +13,7 @@ rm -R -f $LOG_DIR/*
 
 find output -type f -not -name '*summary-info*' -not -name '*.json' -exec rm -R -f {} +
 
-find fifo/ \( -name '*P8[^0-9]*' -o -name '*P8' \) -exec rm -R -f {} +
+find fifo/ -regextype posix-extended -regex '.*/[^/]*_P8([^0-9].*)?$' -exec rm -f {} +
 rm -R -f work/*
 mkdir -p work/kat/
 

--- a/tests/model_execution/test_bash.py
+++ b/tests/model_execution/test_bash.py
@@ -13,6 +13,7 @@ from oasislmf.model_execution.bash import (bash_params, bash_wrapper,
 from oasislmf.utils import diff
 
 TEST_DIRECTORY = os.path.dirname(__file__)
+UPDATE_BASH_TESTS = os.environ.get('UPDATE_BASH_TESTS', '').lower() in ('1', 'true', 'yes')
 
 
 class GenbashBase(TestCase):
@@ -39,7 +40,8 @@ class GenbashBase(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        shutil.rmtree(cls.KPARSE_OUTPUT_FOLDER, ignore_errors=True)
+        if not UPDATE_BASH_TESTS:
+            shutil.rmtree(cls.KPARSE_OUTPUT_FOLDER, ignore_errors=True)
 
     def setUp(self):
         self.temp_reference_file = None
@@ -266,7 +268,11 @@ class Genbash_base(GenbashBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.KPARSE_OUTPUT_FOLDER = tempfile.mkdtemp(prefix='output_bash_base_')
+        if UPDATE_BASH_TESTS:
+            cls.KPARSE_OUTPUT_FOLDER = os.path.join(TEST_DIRECTORY, "output_bash_base")
+            os.makedirs(cls.KPARSE_OUTPUT_FOLDER, exist_ok=True)
+        else:
+            cls.KPARSE_OUTPUT_FOLDER = tempfile.mkdtemp(prefix='output_bash_base_')
         cls.KPARSE_REFERENCE_FOLDER = os.path.join(TEST_DIRECTORY, "reference_bash_base")
 
 
@@ -277,7 +283,11 @@ class Genbash_ErrorGuard_and_TempDir(GenbashBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.KPARSE_OUTPUT_FOLDER = tempfile.mkdtemp(prefix='output_bash_err_')
+        if UPDATE_BASH_TESTS:
+            cls.KPARSE_OUTPUT_FOLDER = os.path.join(TEST_DIRECTORY, "output_bash_err")
+            os.makedirs(cls.KPARSE_OUTPUT_FOLDER, exist_ok=True)
+        else:
+            cls.KPARSE_OUTPUT_FOLDER = tempfile.mkdtemp(prefix='output_bash_err_')
         cls.KPARSE_REFERENCE_FOLDER = os.path.join(TEST_DIRECTORY, "reference_bash_err")
 
         cls.gul_alloc_rule = 1
@@ -294,7 +304,11 @@ class Genbash_LoadBalancer_and_gulpy(GenbashBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.KPARSE_OUTPUT_FOLDER = tempfile.mkdtemp(prefix='output_bash_lb_')
+        if UPDATE_BASH_TESTS:
+            cls.KPARSE_OUTPUT_FOLDER = os.path.join(TEST_DIRECTORY, "output_bash_lb")
+            os.makedirs(cls.KPARSE_OUTPUT_FOLDER, exist_ok=True)
+        else:
+            cls.KPARSE_OUTPUT_FOLDER = tempfile.mkdtemp(prefix='output_bash_lb_')
         cls.KPARSE_REFERENCE_FOLDER = os.path.join(TEST_DIRECTORY, "reference_bash_lb")
 
         cls.num_gul_per_lb = 2
@@ -308,7 +322,11 @@ class Genbash_CustomGulcalc(GenbashBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.KPARSE_OUTPUT_FOLDER = tempfile.mkdtemp(prefix='output_bash_csm_')
+        if UPDATE_BASH_TESTS:
+            cls.KPARSE_OUTPUT_FOLDER = os.path.join(TEST_DIRECTORY, "output_bash_csm")
+            os.makedirs(cls.KPARSE_OUTPUT_FOLDER, exist_ok=True)
+        else:
+            cls.KPARSE_OUTPUT_FOLDER = tempfile.mkdtemp(prefix='output_bash_csm_')
         cls.KPARSE_REFERENCE_FOLDER = os.path.join(TEST_DIRECTORY, "reference_bash_csm")
 
     @staticmethod

--- a/tests/model_execution/update.sh
+++ b/tests/model_execution/update.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-
+UPDATE_BASH_TESTS=1 python -m pytest test_bash.py
 cp output_bash_base/* reference_bash_base
 cp output_bash_lb/* reference_bash_lb 
 cp output_bash_err/* reference_bash_err 


### PR DESCRIPTION
<!--start_release_notes-->
### Fix for stalled runs on V2 workers 
Fixed issue where one run script matched an deleted another chunks FIFO queues, causing that chunk of events to stall 
<!--end_release_notes-->


#### Example
```
oasis-worker(2.5.3) edaa578eb5bc /tmp/run/analysis-5_losses-951e5c5a8d5d458baf44b26936c2289f/run-data/fifo $ ls
gul_P1              gul_S1_summary_P1      il_S1_plt_ord_P1      ri_P1              ri_S1_summary_P1      rl_IP1_S1_plt_ord_P1
gul_P2              gul_S1_summary_P1.idx  il_S1_plt_ord_P2      ri_P2              ri_S1_summary_P1.idx  rl_IP1_S1_plt_ord_P2
gul_P3              gul_S1_summary_P2      il_S1_plt_ord_P3      ri_P3              ri_S1_summary_P2      rl_IP1_S1_plt_ord_P3
gul_P4              gul_S1_summary_P2.idx  il_S1_plt_ord_P4      ri_P4              ri_S1_summary_P2.idx  rl_IP1_S1_plt_ord_P4
gul_S1_elt_ord_P1   gul_S1_summary_P3      il_S1_selt_ord_P1     ri_S1_elt_ord_P1   ri_S1_summary_P3      rl_IP1_S1_selt_ord_P1
gul_S1_elt_ord_P2   gul_S1_summary_P3.idx  il_S1_selt_ord_P2     ri_S1_elt_ord_P2   ri_S1_summary_P3.idx  rl_IP1_S1_selt_ord_P2
gul_S1_elt_ord_P3   gul_S1_summary_P4      il_S1_selt_ord_P3     ri_S1_elt_ord_P3   ri_S1_summary_P4      rl_IP1_S1_selt_ord_P3
gul_S1_elt_ord_P4   gul_S1_summary_P4.idx  il_S1_selt_ord_P4     ri_S1_elt_ord_P4   ri_S1_summary_P4.idx  rl_IP1_S1_selt_ord_P4
gul_S1_plt_ord_P1   il_P1                  il_S1_summary_P1      ri_S1_plt_ord_P1   rl_IP1_P1             rl_IP1_S1_summary_P1
gul_S1_plt_ord_P2   il_P2                  il_S1_summary_P1.idx  ri_S1_plt_ord_P2   rl_IP1_P2             rl_IP1_S1_summary_P1.idx
gul_S1_plt_ord_P3   il_P3                  il_S1_summary_P2      ri_S1_plt_ord_P3   rl_IP1_P3             rl_IP1_S1_summary_P2
gul_S1_plt_ord_P4   il_P4                  il_S1_summary_P2.idx  ri_S1_plt_ord_P4   rl_IP1_P4             rl_IP1_S1_summary_P2.idx
gul_S1_selt_ord_P1  il_S1_elt_ord_P1       il_S1_summary_P3      ri_S1_selt_ord_P1  rl_IP1_S1_elt_ord_P1  rl_IP1_S1_summary_P3
gul_S1_selt_ord_P2  il_S1_elt_ord_P2       il_S1_summary_P3.idx  ri_S1_selt_ord_P2  rl_IP1_S1_elt_ord_P2  rl_IP1_S1_summary_P3.idx
gul_S1_selt_ord_P3  il_S1_elt_ord_P3       il_S1_summary_P4      ri_S1_selt_ord_P3  rl_IP1_S1_elt_ord_P3  rl_IP1_S1_summary_P4
gul_S1_selt_ord_P4  il_S1_elt_ord_P4       il_S1_summary_P4.idx  ri_S1_selt_ord_P4  rl_IP1_S1_elt_ord_P4  rl_IP1_S1_summary_P4.idx

```
https://github.com/OasisLMF/OasisLMF/blob/a6696fba3e63aaf00c479f362181e8b8ca5b4157/oasislmf/execution/bash.py#L2337

creates a line like `find fifo/ \( -name '*P1[^0-9]*' -o -name '*P1' \) -exec rm -R -f {} +`   

which incorrectly match with files like `rl_IP1_S1_plt_ord_P4`


#### Effect 
if `1.run_analysis.sh`  happens to run after other chunks have already created FIFO, then they'll get deleted mid execution, causing a long stall (of hours) and eventual failure with:
```
[2026-05-07 11:27:25,561: INFO/ForkPoolWorker-4227] Task celery.chord_unlock[6d1a8886-802d-4e5a-9670-e271dc5a1dfe] retry: Retry in 1.0s
/tmp/run/analysis-4_losses-d4116b4caa954c7e8f5297c4b54294ad/run-data/4.run_analysis.sh: line 147: fifo/rl_IP1_S1_summary_P4.idx: No such file or directory
/tmp/run/analysis-4_losses-d4116b4caa954c7e8f5297c4b54294ad/run-data/3.run_analysis.sh: line 146: fifo/rl_IP1_S1_summary_P3: No such file or directory
/tmp/run/analysis-3_losses-c9321d759aac4b4b880b185e0922c53e/run-data/3.run_analysis.sh: line 146: fifo/rl_IP1_S1_summary_P3: No such file or directory
/tmp/run/analysis-3_losses-c9321d759aac4b4b880b185e0922c53e/run-data/2.run_analysis.sh: line 147: fifo/rl_IP1_S1_summary_P2.idx: No such file or directory
/tmp/run/analysis-3_losses-c9321d759aac4b4b880b185e0922c53e/run-data/2.run_analysis.sh: line 146: fifo/rl_IP1_S1_summary_P2: No such file or directory
/tmp/run/analysis-3_losses-c9321d759aac4b4b880b185e0922c53e/run-data/4.run_analysis.sh: line 146: fifo/rl_IP1_S1_summary_P4: No such file or directory
/tmp/run/analysis-3_losses-c9321d759aac4b4b880b185e0922c53e/run-data/3.run_analysis.sh: line 147: fifo/rl_IP1_S1_summary_P3.idx: No such file or directory
/tmp/run/analysis-3_losses-c9321d759aac4b4b880b185e0922c53e/run-data/4.run_analysis.sh: line 147: fifo/rl_IP1_S1_summary_P4.idx: No such file or directory
/tmp/run/analysis-4_losses-d4116b4caa954c7e8f5297c4b54294ad/run-data/4.run_analysis.sh: line 146: fifo/rl_IP1_S1_summary_P4: No such file or directory
/tmp/run/analysis-4_losses-d4116b4caa954c7e8f5297c4b54294ad/run-data/3.run_analysis.sh: line 147: fifo/rl_IP1_S1_summary_P3.idx: No such file or directory
/tmp/run/analysis-4_losses-d4116b4caa954c7e8f5297c4b54294ad/run-data/3.run_analysis.sh: line 53: 40793 Killed                  oasis_exec_monitor.sh $$ $LOG_DIR
/tmp/run/analysis-3_losses-c9321d759aac4b4b880b185e0922c53e/run-data/3.run_analysis.sh: line 53: 16647 Killed                  oasis_exec_monitor.sh $$ $LOG_DIR
/tmp/run/analysis-3_losses-c9321d759aac4b4b880b185e0922c53e/run-data/4.run_analysis.sh: line 53: 16809 Killed                  oasis_exec_monitor.sh $$ $LOG_DIR
/tmp/run/analysis-4_losses-d4116b4caa954c7e8f5297c4b54294ad/run-data/4.run_analysis.sh: line 53: 40792 Killed                  oasis_exec_monitor.sh $$ $LOG_DIR
/tmp/run/analysis-3_losses-c9321d759aac4b4b880b185e0922c53e/run-data/2.run_analysis.sh: line 53: 16671 Killed                  oasis_exec_monitor.sh $$ $LOG_DIR
grep: warning: * at start of expression
grep: warning: * at start of expression
grep: warning: * at start of expression
grep: warning: * at start of expression
grep: warning: * at start of expression
grep: warning: * at start of expression
grep: grep: warning: * at start of expression
warning: * at start of expression
[2026-05-07 12:51:37,533: INFO/ForkPoolWorker-2947] Resource monitor stopped, csv=/tmp/run/analysis-4_losses-d4116b4caa954c7e8f5297c4b54294ad/run-data/log/4/resource_monitor.csv

[2026-05-07 12:51:37,561: INFO/ForkPoolWorker-2947] 
KERNEL_STDERR:
/tmp/run/analysis-4_losses-d4116b4caa954c7e8f5297c4b54294ad/run-data/4.run_analysis.sh: line 144: fifo/rl_IP1_S1_elt_ord_P4: No such file or directory
/tmp/run/analysis-4_losses-d4116b4caa954c7e8f5297c4b54294ad/run-data/4.run_analysis.sh: line 143: fifo/rl_IP1_S1_plt_ord_P4: No such file or directory
/tmp/run/analysis-4_losses-d4116b4caa954c7e8f5297c4b54294ad/run-data/4.run_analysis.sh: line 145: fifo/rl_IP1_S1_selt_ord_P4: No such file or directory
[2026-05-07 12:51:37,561: INFO/ForkPoolWorker-2946] 
KERNEL_STDERR:
/tmp/run/analysis-4_losses-d4116b4caa954c7e8f5297c4b54294ad/run-data/3.run_analysis.sh: line 144: fifo/rl_IP1_S1_elt_ord_P3: No such file or directory
/tmp/run/analysis-4_losses-d4116b4caa954c7e8f5297c4b54294ad/run-data/3.run_analysis.sh: line 143: fifo/rl_IP1_S1_plt_ord_P3: No such file or directory
/tmp/run/analysis-4_losses-d4116b4caa954c7e8f5297c4b54294ad/run-data/3.run_analysis.sh: line 145: fifo/rl_IP1_S1_selt_ord_P3: No such file or directory
[2026-05-07 12:51:37,561: INFO/ForkPoolWorker-2946] 
```