### PR TITLE
Add portfolio complexity metrics to oasislmf exposure run

### DIFF
--- a/oasislmf/computation/run/exposure.py
+++ b/oasislmf/computation/run/exposure.py
@@ -72,7 +72,7 @@ class RunExposure(ComputationStep):
         {'name': 'oed_scope_csv', 'is_path': True, 'pre_exist': True, 'help': 'Override path for the reinsurance scope CSV'},
         # -s flag for scope in other files taken for src dir already
         {'name': 'portfolio_complexity', 'type': str2bool, 'const': True, 'nargs': '?', 'default': True,
-         'help': 'if True, compute and report portfolio complexity metrics after generating FM files'},
+         'help': 'if True, compute and report portfolio complexity metrics (GUL dimensions always; IL/RI FM structure when present)'},
     ]
 
     chained_commands = [GenerateKeysDeterministic]
@@ -141,8 +141,8 @@ class RunExposure(ComputationStep):
             intermediary_csv=self.intermediary_csv,
         ).run()
 
-        # 3. Portfolio complexity report (IL only – requires fm_programme etc.)
-        if self.portfolio_complexity and il:
+        # 3. Portfolio complexity report
+        if self.portfolio_complexity:
             try:
                 complexity = compute_portfolio_complexity(run_dir)
                 report_path = os.path.join(run_dir, 'portfolio_complexity.json')

--- a/oasislmf/computation/run/exposure.py
+++ b/oasislmf/computation/run/exposure.py
@@ -4,6 +4,7 @@ __all__ = [
 ]
 
 import csv
+import json
 import os
 import shutil
 import tempfile
@@ -17,6 +18,8 @@ from oasislmf.computation.generate.keys import GenerateKeysDeterministic
 from oasislmf.computation.generate.losses import GenerateLossesDeterministic
 from oasislmf.preparation.il_inputs import get_oed_hierarchy
 from oasislmf.preparation.summaries import calculated_summary_cols
+from oasislmf.pytools.fm.portfolio_complexity import (
+    compute_portfolio_complexity, format_complexity_report)
 from oasislmf.utils.data import (get_dataframe, get_exposure_data,
                                  print_dataframe)
 from oasislmf.utils.defaults import (KERNEL_ALLOC_FM_MAX,
@@ -68,6 +71,8 @@ class RunExposure(ComputationStep):
         {'name': 'oed_info_csv', 'flag': '-i', 'is_path': True, 'pre_exist': True, 'help': 'Override path for the reinsurance info CSV'},
         {'name': 'oed_scope_csv', 'is_path': True, 'pre_exist': True, 'help': 'Override path for the reinsurance scope CSV'},
         # -s flag for scope in other files taken for src dir already
+        {'name': 'portfolio_complexity', 'type': str2bool, 'const': True, 'nargs': '?', 'default': True,
+         'help': 'if True, compute and report portfolio complexity metrics after generating FM files'},
     ]
 
     chained_commands = [GenerateKeysDeterministic]
@@ -136,7 +141,19 @@ class RunExposure(ComputationStep):
             intermediary_csv=self.intermediary_csv,
         ).run()
 
-        # 3. Run Deterministic Losses
+        # 3. Portfolio complexity report (IL only – requires fm_programme etc.)
+        if self.portfolio_complexity and il:
+            try:
+                complexity = compute_portfolio_complexity(run_dir)
+                report_path = os.path.join(run_dir, 'portfolio_complexity.json')
+                with open(report_path, 'w') as fh:
+                    json.dump(complexity, fh, indent=2)
+                self.logger.info(format_complexity_report(complexity))
+                self.logger.debug(f'Portfolio complexity metrics written to {report_path}')
+            except Exception as exc:
+                self.logger.warning(f'Could not compute portfolio complexity metrics: {exc}')
+
+        # 4. Run Deterministic Losses
         losses = GenerateLossesDeterministic(
             exposure_data=exposure_data,
             oasis_files_dir=run_dir,

--- a/oasislmf/pytools/fm/portfolio_complexity.py
+++ b/oasislmf/pytools/fm/portfolio_complexity.py
@@ -3,89 +3,51 @@ __all__ = [
     'format_complexity_report',
 ]
 
+import json
 import logging
+import os
 from collections import Counter
 
 import numpy as np
 
-from .financial_structure import load_static
+from oasislmf.pytools.common.data import (
+    fm_policytc_dtype, fm_profile_dtype, fm_profile_step_dtype,
+    fm_programme_dtype, fm_xref_dtype, items_dtype, load_as_array,
+    load_as_ndarray, oasis_float,
+)
 
 logger = logging.getLogger(__name__)
 
 
-def compute_portfolio_complexity(static_path):
-    """Compute portfolio complexity metrics from FM static files.
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
 
-    Reads the raw FM files (fm_programme, fm_policytc, fm_profile, fm_xref,
-    items, coverages) from *static_path* and returns a dict of metrics that
-    can be used to estimate the compute requirements of a full model run.
+def _has_fm_files(path):
+    """Return True if *path* contains fm_programme .bin or .csv."""
+    return (
+        os.path.isfile(os.path.join(path, 'fm_programme.bin')) or
+        os.path.isfile(os.path.join(path, 'fm_programme.csv'))
+    )
 
-    The key cost drivers captured are:
 
-    * **GUL work units** – proportional to the number of items; this is the
-      per-event cost of ground-up loss calculation.
-    * **FM work units** – proportional to ``total_fm_nodes × num_fm_layers``
-      (the per-event cost of financial-module calculation).
-
-    Multiplying either figure by the number of model events gives a rough
-    total-run cost for that dimension.  Other factors (model footprint size,
-    output file requests, RI structure) will add further cost on top.
-
-    Parameters
-    ----------
-    static_path : str
-        Directory containing the FM static files (.bin or .csv).
-
-    Returns
-    -------
-    dict
-        Flat-ish dict suitable for JSON serialisation.  Keys:
-
-        portfolio_dimensions
-            num_items, num_coverages
-
-        fm_structure
-            num_fm_levels, num_fm_layers, nodes_per_level,
-            total_fm_nodes, avg_children_per_node,
-            avg_children_per_level
-
-        profile_complexity
-            num_unique_profiles, has_stepped_profiles,
-            calcrule_distribution
-
-        outputs
-            num_output_ids
-
-        complexity_scores
-            gul_work_units, fm_work_units
-    """
-    programme, policytc, profile, stepped, xref, items, coverages = load_static(static_path)
-
-    metrics = {}
-
-    # ------------------------------------------------------------------
-    # Portfolio dimensions
-    # ------------------------------------------------------------------
-    if len(items) > 0:
-        num_items = int(np.unique(items['item_id']).size)
+def _load_fm_arrays(path):
+    """Load raw FM arrays from *path*.  items/coverages are not required."""
+    programme = load_as_ndarray(path, 'fm_programme', fm_programme_dtype)
+    policytc = load_as_ndarray(path, 'fm_policytc', fm_policytc_dtype)
+    profile = load_as_ndarray(path, 'fm_profile_step', fm_profile_step_dtype, must_exist=False)
+    if len(profile) == 0:
+        profile = load_as_ndarray(path, 'fm_profile', fm_profile_dtype)
+        stepped = False
     else:
-        # Fall back: items at the bottom of the programme (level 1 from_agg_ids)
-        if len(programme) > 0:
-            min_level = int(programme['level_id'].min())
-            num_items = int(np.unique(programme[programme['level_id'] == min_level]['from_agg_id']).size)
-        else:
-            num_items = 0
+        stepped = True
+    xref = load_as_ndarray(path, 'fm_xref', fm_xref_dtype)
+    return programme, policytc, profile, stepped, xref
 
-    num_coverages = int(len(coverages)) if len(coverages) > 0 else None
 
-    metrics['portfolio_dimensions'] = {
-        'num_items': num_items,
-        'num_coverages': num_coverages,
-    }
-
-    # ------------------------------------------------------------------
+def _fm_section(programme, policytc, profile, stepped, xref):
+    """Compute the fm_structure and profile_complexity dicts from raw arrays."""
     # FM structure
-    # ------------------------------------------------------------------
     if len(programme) > 0:
         levels = np.unique(programme['level_id'])
         num_fm_levels = int(levels.max())
@@ -99,32 +61,31 @@ def compute_portfolio_complexity(static_path):
             n_parent_nodes = int(np.unique(rows['to_agg_id']).size)
             n_edges = int(mask.sum())
             nodes_per_level[lvl] = n_parent_nodes
-            avg_children_per_level[lvl] = round(n_edges / n_parent_nodes, 2) if n_parent_nodes > 0 else 1.0
+            avg_children_per_level[lvl] = (
+                round(n_edges / n_parent_nodes, 2) if n_parent_nodes > 0 else 1.0
+            )
 
         total_fm_nodes = sum(nodes_per_level.values())
-        all_children_counts = [avg_children_per_level[k] for k in avg_children_per_level]
-        overall_avg_children = round(float(np.mean(all_children_counts)), 2) if all_children_counts else 1.0
+        overall_avg = round(float(np.mean(list(avg_children_per_level.values()))), 2)
     else:
         num_fm_levels = 0
         nodes_per_level = {}
         avg_children_per_level = {}
         total_fm_nodes = 0
-        overall_avg_children = 1.0
+        overall_avg = 1.0
 
     num_fm_layers = int(policytc['layer_id'].max()) if len(policytc) > 0 else 1
 
-    metrics['fm_structure'] = {
+    fm_structure = {
         'num_fm_levels': num_fm_levels,
         'num_fm_layers': num_fm_layers,
         'nodes_per_level': nodes_per_level,
         'total_fm_nodes': total_fm_nodes,
-        'avg_children_per_node': overall_avg_children,
+        'avg_children_per_node': overall_avg,
         'avg_children_per_level': avg_children_per_level,
     }
 
-    # ------------------------------------------------------------------
     # Profile complexity
-    # ------------------------------------------------------------------
     if len(profile) > 0:
         num_unique_profiles = int(np.unique(profile['profile_id']).size)
         calcrule_counts = Counter(int(x) for x in profile['calcrule_id'])
@@ -133,31 +94,136 @@ def compute_portfolio_complexity(static_path):
         num_unique_profiles = 0
         calcrule_distribution = {}
 
-    metrics['profile_complexity'] = {
+    profile_complexity = {
         'num_unique_profiles': num_unique_profiles,
         'has_stepped_profiles': bool(stepped),
         'calcrule_distribution': calcrule_distribution,
     }
 
-    # ------------------------------------------------------------------
-    # Outputs
-    # ------------------------------------------------------------------
-    metrics['outputs'] = {
-        'num_output_ids': int(len(xref)),
-    }
+    outputs = {'num_output_ids': int(len(xref))}
 
-    # ------------------------------------------------------------------
-    # Complexity heuristics
-    # ------------------------------------------------------------------
-    # GUL work is proportional to number of items per event.
-    # FM work is proportional to (total nodes) × (layers) per event.
-    # Multiply by number of model events to get a full-run cost proxy.
-    gul_work_units = num_items
     fm_work_units = total_fm_nodes * num_fm_layers
 
+    return fm_structure, profile_complexity, outputs, fm_work_units
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def compute_portfolio_complexity(static_path):
+    """Compute portfolio complexity metrics from Oasis static files.
+
+    Works for GUL-only, IL, and IL+RI portfolios.
+
+    **GUL-only** (no account file):  only ``portfolio_dimensions`` and the
+    ``gul_work_units`` complexity score are populated.
+
+    **IL** (account file present):  additionally populates ``il`` with the FM
+    structure, profile complexity, and output count for the insured-loss layer.
+
+    **RI** (reinsurance files present):  additionally populates ``ri`` with
+    per-layer FM metrics and a total RI FM work-unit count.
+
+    The two key per-event cost proxies in ``complexity_scores`` are:
+
+    * ``gul_work_units = num_items``
+    * ``fm_work_units = il_fm_work_units + ri_fm_work_units``
+      where ``il_fm_work_units = total_il_nodes × il_layers`` and
+      ``ri_fm_work_units = Σ(total_ri_nodes_layer_k × ri_layers_k)``
+
+    Multiplying by the number of model events gives a per-dimension
+    full-run cost proxy.
+
+    Parameters
+    ----------
+    static_path : str
+        Directory containing the Oasis static files.  For IL this is the
+        directory with ``fm_programme.bin`` etc.  RI layer subdirectories
+        are discovered automatically via ``ri_layers.json``.
+
+    Returns
+    -------
+    dict
+    """
+    metrics = {}
+
+    # ------------------------------------------------------------------
+    # Portfolio dimensions (GUL — always available)
+    # ------------------------------------------------------------------
+    items = load_as_ndarray(static_path, 'items', items_dtype, must_exist=False)
+    coverages = load_as_array(static_path, 'coverages', oasis_float, must_exist=False)
+
+    if len(items) > 0:
+        num_items = int(np.unique(items['item_id']).size)
+    else:
+        num_items = 0
+
+    num_coverages = int(len(coverages)) if len(coverages) > 0 else None
+
+    metrics['portfolio_dimensions'] = {
+        'num_items': num_items,
+        'num_coverages': num_coverages,
+    }
+
+    il_fm_work_units = 0
+    ri_fm_work_units = 0
+
+    # ------------------------------------------------------------------
+    # IL FM structure (present only when an account file was supplied)
+    # ------------------------------------------------------------------
+    if _has_fm_files(static_path):
+        programme, policytc, profile, stepped, xref = _load_fm_arrays(static_path)
+        fm_structure, profile_complexity, outputs, il_fm_work_units = _fm_section(
+            programme, policytc, profile, stepped, xref
+        )
+        metrics['il'] = {
+            'fm_structure': fm_structure,
+            'profile_complexity': profile_complexity,
+            'outputs': outputs,
+        }
+
+    # ------------------------------------------------------------------
+    # RI FM structure (one entry per reinsurance layer)
+    # ------------------------------------------------------------------
+    ri_layers_json = os.path.join(static_path, 'ri_layers.json')
+    if os.path.exists(ri_layers_json):
+        with open(ri_layers_json) as fh:
+            ri_layers = json.load(fh)
+
+        layer_metrics = []
+        for layer_key in sorted(ri_layers.keys(), key=lambda k: int(k)):
+            layer_dir = ri_layers[layer_key]['directory']
+            if not _has_fm_files(layer_dir):
+                continue
+            prog, ptc, prof, stepped, xref = _load_fm_arrays(layer_dir)
+            fm_structure, profile_complexity, outputs, layer_wu = _fm_section(
+                prog, ptc, prof, stepped, xref
+            )
+            ri_fm_work_units += layer_wu
+            layer_metrics.append({
+                'layer': int(layer_key),
+                'fm_structure': fm_structure,
+                'profile_complexity': profile_complexity,
+                'outputs': outputs,
+                'fm_work_units': layer_wu,
+            })
+
+        if layer_metrics:
+            metrics['ri'] = {
+                'num_ri_layers': len(layer_metrics),
+                'layers': layer_metrics,
+                'total_ri_fm_work_units': ri_fm_work_units,
+            }
+
+    # ------------------------------------------------------------------
+    # Complexity scores
+    # ------------------------------------------------------------------
     metrics['complexity_scores'] = {
-        'gul_work_units': gul_work_units,
-        'fm_work_units': fm_work_units,
+        'gul_work_units': num_items,
+        'il_fm_work_units': il_fm_work_units,
+        'ri_fm_work_units': ri_fm_work_units,
+        'total_fm_work_units': il_fm_work_units + ri_fm_work_units,
     }
 
     return metrics
@@ -176,28 +242,13 @@ def format_complexity_report(metrics):
     str
     """
     pd_ = metrics.get('portfolio_dimensions', {})
-    fm_ = metrics.get('fm_structure', {})
-    pr_ = metrics.get('profile_complexity', {})
-    op_ = metrics.get('outputs', {})
+    il_ = metrics.get('il')
+    ri_ = metrics.get('ri')
     sc_ = metrics.get('complexity_scores', {})
 
     num_items = pd_.get('num_items', 0)
     num_covs = pd_.get('num_coverages')
-    num_levels = fm_.get('num_fm_levels', 0)
-    num_layers = fm_.get('num_fm_layers', 1)
-    nodes_per_level = fm_.get('nodes_per_level', {})
-    total_nodes = fm_.get('total_fm_nodes', 0)
-    avg_children = fm_.get('avg_children_per_node', 1.0)
-    num_profiles = pr_.get('num_unique_profiles', 0)
-    stepped = pr_.get('has_stepped_profiles', False)
-    calcrules = pr_.get('calcrule_distribution', {})
-    num_outputs = op_.get('num_output_ids', 0)
-    gul_wu = sc_.get('gul_work_units', 0)
-    fm_wu = sc_.get('fm_work_units', 0)
-
     cov_str = f'{num_covs:,}' if num_covs is not None else 'n/a'
-    nodes_str = ', '.join(f'L{k}: {v:,}' for k, v in sorted(nodes_per_level.items()))
-    calcrule_str = ', '.join(f'rule {k}: {v}' for k, v in calcrules.items())
 
     lines = [
         '',
@@ -208,28 +259,67 @@ def format_complexity_report(metrics):
         'Portfolio dimensions:',
         f'  Items (GUL):          {num_items:>10,}',
         f'  Coverages:            {cov_str:>10}',
-        '',
-        'Financial module (IL) structure:',
-        f'  FM levels:            {num_levels:>10,}',
-        f'  FM layers:            {num_layers:>10,}',
-        f'  Nodes per level:      {nodes_str}',
-        f'  Total FM nodes:       {total_nodes:>10,}',
-        f'  Avg children/node:    {avg_children:>10.2f}',
-        '',
-        'Profile complexity:',
-        f'  Unique profiles:      {num_profiles:>10,}',
-        f'  Stepped profiles:     {"Yes" if stepped else "No":>10}',
-        f'  Calc rules:           {calcrule_str}',
-        '',
-        'Outputs:',
-        f'  Output IDs:           {num_outputs:>10,}',
+    ]
+
+    def _fm_lines(fm_, prefix=''):
+        out = []
+        fm_structure = fm_.get('fm_structure', {})
+        pr_ = fm_.get('profile_complexity', {})
+        op_ = fm_.get('outputs', {})
+
+        num_levels = fm_structure.get('num_fm_levels', 0)
+        num_layers = fm_structure.get('num_fm_layers', 1)
+        nodes_per_level = fm_structure.get('nodes_per_level', {})
+        total_nodes = fm_structure.get('total_fm_nodes', 0)
+        avg_children = fm_structure.get('avg_children_per_node', 1.0)
+        num_profiles = pr_.get('num_unique_profiles', 0)
+        stepped = pr_.get('has_stepped_profiles', False)
+        calcrules = pr_.get('calcrule_distribution', {})
+        num_outputs = op_.get('num_output_ids', 0)
+
+        nodes_str = ', '.join(f'L{k}: {v:,}' for k, v in sorted(nodes_per_level.items()))
+        calcrule_str = ', '.join(f'rule {k}: {v}' for k, v in calcrules.items())
+
+        out += [
+            f'{prefix}  FM levels:            {num_levels:>10,}',
+            f'{prefix}  FM layers:            {num_layers:>10,}',
+            f'{prefix}  Nodes per level:      {nodes_str}',
+            f'{prefix}  Total FM nodes:       {total_nodes:>10,}',
+            f'{prefix}  Avg children/node:    {avg_children:>10.2f}',
+            f'{prefix}  Unique profiles:      {num_profiles:>10,}',
+            f'{prefix}  Stepped profiles:     {"Yes" if stepped else "No":>10}',
+            f'{prefix}  Calc rules:           {calcrule_str}',
+            f'{prefix}  Output IDs:           {num_outputs:>10,}',
+        ]
+        return out
+
+    if il_:
+        lines += ['', 'IL financial module structure:']
+        lines += _fm_lines(il_)
+
+    if ri_:
+        num_ri = ri_.get('num_ri_layers', 0)
+        lines += ['', f'RI financial module structure ({num_ri} layer{"s" if num_ri != 1 else ""}):']
+        for layer_info in ri_.get('layers', []):
+            lines.append(f'  Layer {layer_info["layer"]}:')
+            lines += _fm_lines(layer_info, prefix='  ')
+
+    lines += [
         '',
         'Complexity heuristics (per model event):',
-        f'  GUL work units:       {gul_wu:>10,}',
-        f'  FM  work units:       {fm_wu:>10,}  (nodes × layers)',
+        f'  GUL work units:       {sc_.get("gul_work_units", 0):>10,}',
+    ]
+    if il_:
+        lines.append(f'  IL  work units:       {sc_.get("il_fm_work_units", 0):>10,}  (IL nodes × layers)')
+    if ri_:
+        lines.append(f'  RI  work units:       {sc_.get("ri_fm_work_units", 0):>10,}  (Σ RI nodes × layers)')
+    if il_ or ri_:
+        lines.append(f'  Total FM work units:  {sc_.get("total_fm_work_units", 0):>10,}')
+    lines += [
         '  (multiply by event count for full-run cost proxy)',
         '',
         '=' * 54,
         '',
     ]
+
     return '\n'.join(lines)

--- a/oasislmf/pytools/fm/portfolio_complexity.py
+++ b/oasislmf/pytools/fm/portfolio_complexity.py
@@ -1,0 +1,235 @@
+__all__ = [
+    'compute_portfolio_complexity',
+    'format_complexity_report',
+]
+
+import logging
+from collections import Counter
+
+import numpy as np
+
+from .financial_structure import load_static
+
+logger = logging.getLogger(__name__)
+
+
+def compute_portfolio_complexity(static_path):
+    """Compute portfolio complexity metrics from FM static files.
+
+    Reads the raw FM files (fm_programme, fm_policytc, fm_profile, fm_xref,
+    items, coverages) from *static_path* and returns a dict of metrics that
+    can be used to estimate the compute requirements of a full model run.
+
+    The key cost drivers captured are:
+
+    * **GUL work units** – proportional to the number of items; this is the
+      per-event cost of ground-up loss calculation.
+    * **FM work units** – proportional to ``total_fm_nodes × num_fm_layers``
+      (the per-event cost of financial-module calculation).
+
+    Multiplying either figure by the number of model events gives a rough
+    total-run cost for that dimension.  Other factors (model footprint size,
+    output file requests, RI structure) will add further cost on top.
+
+    Parameters
+    ----------
+    static_path : str
+        Directory containing the FM static files (.bin or .csv).
+
+    Returns
+    -------
+    dict
+        Flat-ish dict suitable for JSON serialisation.  Keys:
+
+        portfolio_dimensions
+            num_items, num_coverages
+
+        fm_structure
+            num_fm_levels, num_fm_layers, nodes_per_level,
+            total_fm_nodes, avg_children_per_node,
+            avg_children_per_level
+
+        profile_complexity
+            num_unique_profiles, has_stepped_profiles,
+            calcrule_distribution
+
+        outputs
+            num_output_ids
+
+        complexity_scores
+            gul_work_units, fm_work_units
+    """
+    programme, policytc, profile, stepped, xref, items, coverages = load_static(static_path)
+
+    metrics = {}
+
+    # ------------------------------------------------------------------
+    # Portfolio dimensions
+    # ------------------------------------------------------------------
+    if len(items) > 0:
+        num_items = int(np.unique(items['item_id']).size)
+    else:
+        # Fall back: items at the bottom of the programme (level 1 from_agg_ids)
+        if len(programme) > 0:
+            min_level = int(programme['level_id'].min())
+            num_items = int(np.unique(programme[programme['level_id'] == min_level]['from_agg_id']).size)
+        else:
+            num_items = 0
+
+    num_coverages = int(len(coverages)) if len(coverages) > 0 else None
+
+    metrics['portfolio_dimensions'] = {
+        'num_items': num_items,
+        'num_coverages': num_coverages,
+    }
+
+    # ------------------------------------------------------------------
+    # FM structure
+    # ------------------------------------------------------------------
+    if len(programme) > 0:
+        levels = np.unique(programme['level_id'])
+        num_fm_levels = int(levels.max())
+
+        nodes_per_level = {}
+        avg_children_per_level = {}
+        for lvl in levels:
+            lvl = int(lvl)
+            mask = programme['level_id'] == lvl
+            rows = programme[mask]
+            n_parent_nodes = int(np.unique(rows['to_agg_id']).size)
+            n_edges = int(mask.sum())
+            nodes_per_level[lvl] = n_parent_nodes
+            avg_children_per_level[lvl] = round(n_edges / n_parent_nodes, 2) if n_parent_nodes > 0 else 1.0
+
+        total_fm_nodes = sum(nodes_per_level.values())
+        all_children_counts = [avg_children_per_level[k] for k in avg_children_per_level]
+        overall_avg_children = round(float(np.mean(all_children_counts)), 2) if all_children_counts else 1.0
+    else:
+        num_fm_levels = 0
+        nodes_per_level = {}
+        avg_children_per_level = {}
+        total_fm_nodes = 0
+        overall_avg_children = 1.0
+
+    num_fm_layers = int(policytc['layer_id'].max()) if len(policytc) > 0 else 1
+
+    metrics['fm_structure'] = {
+        'num_fm_levels': num_fm_levels,
+        'num_fm_layers': num_fm_layers,
+        'nodes_per_level': nodes_per_level,
+        'total_fm_nodes': total_fm_nodes,
+        'avg_children_per_node': overall_avg_children,
+        'avg_children_per_level': avg_children_per_level,
+    }
+
+    # ------------------------------------------------------------------
+    # Profile complexity
+    # ------------------------------------------------------------------
+    if len(profile) > 0:
+        num_unique_profiles = int(np.unique(profile['profile_id']).size)
+        calcrule_counts = Counter(int(x) for x in profile['calcrule_id'])
+        calcrule_distribution = {str(k): v for k, v in sorted(calcrule_counts.items())}
+    else:
+        num_unique_profiles = 0
+        calcrule_distribution = {}
+
+    metrics['profile_complexity'] = {
+        'num_unique_profiles': num_unique_profiles,
+        'has_stepped_profiles': bool(stepped),
+        'calcrule_distribution': calcrule_distribution,
+    }
+
+    # ------------------------------------------------------------------
+    # Outputs
+    # ------------------------------------------------------------------
+    metrics['outputs'] = {
+        'num_output_ids': int(len(xref)),
+    }
+
+    # ------------------------------------------------------------------
+    # Complexity heuristics
+    # ------------------------------------------------------------------
+    # GUL work is proportional to number of items per event.
+    # FM work is proportional to (total nodes) × (layers) per event.
+    # Multiply by number of model events to get a full-run cost proxy.
+    gul_work_units = num_items
+    fm_work_units = total_fm_nodes * num_fm_layers
+
+    metrics['complexity_scores'] = {
+        'gul_work_units': gul_work_units,
+        'fm_work_units': fm_work_units,
+    }
+
+    return metrics
+
+
+def format_complexity_report(metrics):
+    """Return a human-readable text summary of portfolio complexity metrics.
+
+    Parameters
+    ----------
+    metrics : dict
+        As returned by :func:`compute_portfolio_complexity`.
+
+    Returns
+    -------
+    str
+    """
+    pd_ = metrics.get('portfolio_dimensions', {})
+    fm_ = metrics.get('fm_structure', {})
+    pr_ = metrics.get('profile_complexity', {})
+    op_ = metrics.get('outputs', {})
+    sc_ = metrics.get('complexity_scores', {})
+
+    num_items = pd_.get('num_items', 0)
+    num_covs = pd_.get('num_coverages')
+    num_levels = fm_.get('num_fm_levels', 0)
+    num_layers = fm_.get('num_fm_layers', 1)
+    nodes_per_level = fm_.get('nodes_per_level', {})
+    total_nodes = fm_.get('total_fm_nodes', 0)
+    avg_children = fm_.get('avg_children_per_node', 1.0)
+    num_profiles = pr_.get('num_unique_profiles', 0)
+    stepped = pr_.get('has_stepped_profiles', False)
+    calcrules = pr_.get('calcrule_distribution', {})
+    num_outputs = op_.get('num_output_ids', 0)
+    gul_wu = sc_.get('gul_work_units', 0)
+    fm_wu = sc_.get('fm_work_units', 0)
+
+    cov_str = f'{num_covs:,}' if num_covs is not None else 'n/a'
+    nodes_str = ', '.join(f'L{k}: {v:,}' for k, v in sorted(nodes_per_level.items()))
+    calcrule_str = ', '.join(f'rule {k}: {v}' for k, v in calcrules.items())
+
+    lines = [
+        '',
+        '=' * 54,
+        'Portfolio Complexity Report',
+        '=' * 54,
+        '',
+        'Portfolio dimensions:',
+        f'  Items (GUL):          {num_items:>10,}',
+        f'  Coverages:            {cov_str:>10}',
+        '',
+        'Financial module (IL) structure:',
+        f'  FM levels:            {num_levels:>10,}',
+        f'  FM layers:            {num_layers:>10,}',
+        f'  Nodes per level:      {nodes_str}',
+        f'  Total FM nodes:       {total_nodes:>10,}',
+        f'  Avg children/node:    {avg_children:>10.2f}',
+        '',
+        'Profile complexity:',
+        f'  Unique profiles:      {num_profiles:>10,}',
+        f'  Stepped profiles:     {"Yes" if stepped else "No":>10}',
+        f'  Calc rules:           {calcrule_str}',
+        '',
+        'Outputs:',
+        f'  Output IDs:           {num_outputs:>10,}',
+        '',
+        'Complexity heuristics (per model event):',
+        f'  GUL work units:       {gul_wu:>10,}',
+        f'  FM  work units:       {fm_wu:>10,}  (nodes × layers)',
+        '  (multiply by event count for full-run cost proxy)',
+        '',
+        '=' * 54,
+        '',
+    ]
+    return '\n'.join(lines)


### PR DESCRIPTION
Closes #1972

## Summary

- Adds \`oasislmf/pytools/fm/portfolio_complexity.py\` with \`compute_portfolio_complexity()\` and \`format_complexity_report()\`
- Hooks into \`RunExposure.run()\` after FM file generation, controlled by \`--portfolio-complexity\` flag (default \`True\`)
- Works for **GUL-only**, **IL**, and **IL+RI** portfolios
- Writes \`portfolio_complexity.json\` to the run directory and logs a formatted summary at INFO level

## How it works

\`compute_portfolio_complexity(static_path)\` reads the raw FM static files using \`load_as_ndarray\` and returns a structured dict. The three cases are handled automatically:

| Run type | What is reported |
|---|---|
| GUL-only | Portfolio dimensions (items, coverages) + GUL work units |
| IL | + IL FM structure (levels, layers, nodes, branching, profiles, calc rules) |
| IL + RI | + per-RI-layer FM structure (discovered via \`ri_layers.json\`) |

### Complexity scores

All scores are **per-event** cost proxies — multiply by the number of model events for a full-run estimate:

| Score | Formula | Measures |
|---|---|---|
| \`gul_work_units\` | \`num_items\` | GUL calculation cost per event |
| \`il_fm_work_units\` | \`total_il_nodes x il_layers\` | IL FM traversal cost per event |
| \`ri_fm_work_units\` | sum(\`total_ri_nodes_k x ri_layers_k\`) | RI FM traversal cost per event |
| \`total_fm_work_units\` | \`il + ri\` | Combined FM cost per event |

### Disabling

\`\`\`bash
oasislmf exposure run --portfolio-complexity False ...
\`\`\`

## Test plan

- [ ] Run against a **GUL-only** portfolio (no account file) — verify \`portfolio_complexity.json\` is written with dimensions only and no \`il\`/\`ri\` keys
- [ ] Run against an **IL** portfolio — verify \`il\` section is populated
- [ ] Run against an **IL+RI** portfolio — verify \`ri\` section contains one entry per RI layer with correct \`fm_work_units\`
- [ ] Run with \`--portfolio-complexity False\` — verify no JSON file and no report logged
- [ ] Verify existing FM test cases (\`oasislmf exposure run-fm-tests\`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)