### PR TITLE
port receiving data from non oasis source wont crash

### DIFF
--- a/oasislmf/utils/socket_server.py
+++ b/oasislmf/utils/socket_server.py
@@ -53,7 +53,11 @@ class GulProgressServer:
 
     def _handle_client(self, client_socket):
         data = self._read_all(client_socket)
-        payload = json.loads(data)
+        try:
+            payload = json.loads(data)
+        except json.JSONDecodeError:
+            logging.warning(f"Invalid json received: {data}")
+            return
         with self.counter_lock:
             if 'terminate' in payload:
                 self.counter = self.total

--- a/oasislmf/utils/socket_server.py
+++ b/oasislmf/utils/socket_server.py
@@ -62,7 +62,10 @@ class GulProgressServer:
             if 'terminate' in payload:
                 self.counter = self.total
                 self.stop()
-            self.counter += int(payload.get("events_complete", 0))
+            elif "events_complete" in payload:
+                self.counter += int(payload.get("events_complete", 0))
+            else:
+                logging.warning(f"Json received with no valid fields {payload}")
 
     def _read_all(self, client_socket):
         buffer = b""

--- a/tests/utils/test_server.py
+++ b/tests/utils/test_server.py
@@ -64,6 +64,23 @@ def test_server_handles_missing_key():
     server.stop()
 
 
+def test_server_handles_unknown_fields_logs_warning(caplog):
+    port = get_free_port()
+    server = GulProgressServer(10, host="127.0.0.1", port=port)
+    server.start()
+    target = (server.host, server.port)
+    payload = {"unknown_field": "some_value"}
+
+    with caplog.at_level("WARNING", logger="root"):
+        assert oasis_ping_socket(target, json.dumps(payload)) is True
+        time.sleep(0.1)
+
+    assert server.counter == 0
+    assert any("Json received with no valid fields" in r.message for r in caplog.records)
+
+    server.stop()
+
+
 def test_server_handles_invalid_json(caplog):
     port = get_free_port()
     server = GulProgressServer(10, host="127.0.0.1", port=port)

--- a/tests/utils/test_server.py
+++ b/tests/utils/test_server.py
@@ -64,6 +64,22 @@ def test_server_handles_missing_key():
     server.stop()
 
 
+def test_server_handles_invalid_json(caplog):
+    port = get_free_port()
+    server = GulProgressServer(10, host="127.0.0.1", port=port)
+    server.start()
+    target = (server.host, server.port)
+
+    with caplog.at_level("WARNING", logger="root"):
+        assert oasis_ping_socket(target, "not valid json {{{") is True
+        time.sleep(0.1)
+
+    assert server.counter == 0
+    assert any("Invalid json received" in r.message for r in caplog.records)
+
+    server.stop()
+
+
 def test_server_can_stop_and_not_accept():
     port = get_free_port()
     server = GulProgressServer(10, host="127.0.0.1", port=port)


### PR DESCRIPTION
Socket server may receive a ping from outside of oasis- this can currently cause the process to crash
Fix to ensure it must be an Oasis message as all Oasis messages will be JSON format with our keys, so if the message is non json format it will log an issue without breaking