### PR TITLE
fix broken docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ In that case you can run this after installation.
 
 The package provides a built-in lookup framework (`oasislmf.model_preparation.lookup.OasisLookup`) which uses the Rtree Python package, which in turn requires the `libspatialindex` spatial indexing C library.
 
-https://libspatialindex.github.io/index.html
+https://libspatialindex.github.io/
 
 Linux users can install the development version of `libspatialindex` from the command line using `apt`.
 


### PR DESCRIPTION
the docs url in README.md moved.

  before:  https://libspatialindex.github.io/index.html  (404)
  after:   https://libspatialindex.github.io/  (live)

working on building skill at open-source contribution.
please merge if this helps.