### PR TITLE
Fix for ELT sdloss incorrectly reporting 0 for sparse loss distributions

### DIFF
--- a/oasislmf/pytools/elt/manager.py
+++ b/oasislmf/pytools/elt/manager.py
@@ -187,7 +187,7 @@ def read_buffer(
         for l in state["losses_vec"]:
             meanloss += np.float64(l)
         meanloss /= np.float64(n)
-        if state["non_zero_samples"] > 1:
+        if state["len_sample"] > 1:
             sum_sq_dev = np.float64(0.0)
             for l in state["losses_vec"]:
                 diff = np.float64(l) - meanloss


### PR DESCRIPTION
The variance guard in _get_mean_and_sd_loss() checks non_zero_samples > 1 before calculating standard deviation. This means if only 1 sample out of N has a non zero loss, the SD will be set to 0, which I feel is wrong because 0 values are still real observations and should contribute to the variance calculation. 

Also the PLT module already handles this correctly using len_sample != 1, so makes me think this is just an oversight?
