### PR TITLE
fix(hashmap): hash all record fields, not just the last

### DIFF
--- a/oasislmf/pytools/common/hashmap.py
+++ b/oasislmf/pytools/common/hashmap.py
@@ -335,11 +335,11 @@ def fnv1a_overload_record(record, h=init_hash):
             if ftype.bitwidth == 64:
                 src.append("    _buf = np.empty(1, dtype=np.float64)")
                 src.append(f"    _buf[0] = record['{fname}']")
-                src.append(f"    h = (h ^ _buf.view(np.uint64)[0]) * {FNV_PRIME}")
+                src.append("    h = (h ^ _buf.view(np.uint64)[0]) * FNV_PRIME")
             else:  # float32 → zero-extend to 64 bits after bit-cast to uint32
                 src.append("    _buf = np.empty(1, dtype=np.float32)")
                 src.append(f"    _buf[0] = record['{fname}']")
-                src.append(f"    h = (h ^ np.uint64(_buf.view(np.uint32)[0])) * {FNV_PRIME}")
+                src.append("    h = (h ^ np.uint64(_buf.view(np.uint32)[0])) * FNV_PRIME")
         elif isinstance(ftype, nbt.UnicodeCharSeq):
             # Fixed-width unicode (e.g. 'U3') field. str(field) trims trailing
             # NUL padding via numba's UnicodeCharSeq.__len__ (numpy's fixed-
@@ -351,7 +351,7 @@ def fnv1a_overload_record(record, h=init_hash):
         else:
             # int/uint/bool: np.uint64() is already a zero-extension, equivalent to bitcast
             src.append(
-                f"    h = (h ^ np.uint64(record['{fname}'])) * {FNV_PRIME}"
+                f"    h = (h ^ np.uint64(record['{fname}'])) * FNV_PRIME"
             )
     # Final Murmur3 fmix64 — three rounds of shift / mult / shift. See _fmix64().
     src.append("    h ^= h >> np.uint64(33)")


### PR DESCRIPTION
## Summary

Fixes a bug in the structured-record path of the Robin Hood hashmap (`oasislmf/pytools/common/hashmap.py`) where the per-field FNV-1a accumulation **dropped all record fields except the last**, turning distinct keys into true 64-bit hash collisions.

### Root cause

`fnv1a_overload_record` builds the hash impl by string codegen and interpolated the FNV prime into the source as a **bare decimal literal**:

```python
src.append(f"    h = (h ^ np.uint64(record['{fname}'])) * {FNV_PRIME}")
# generates:  h = (h ^ np.uint64(record['areaperil_id'])) * 1099511628211
```

numba types `uint64 * <int literal>` as **int64** (not uint64). `init_hash` (~1.47e19) does not fit in signed int64, so the FNV multiply overflows and collapses to a constant (INT64_MIN), erasing the contribution of every field except the last one. Records differing only in an earlier field therefore hashed identically.

The scalar overload and the unicode branch were already correct because they multiply by the `FNV_PRIME` **name** (dtype uint64), keeping the arithmetic in unsigned 64-bit.

### Impact

`process_vulnerability_weights` (GULMC aggregate vulnerability weights) keys a hashmap on `(areaperil_id, vuln_idx)` records. The bug collapsed ~1248 distinct `areaperil_id`s into a single bucket as genuine 64-bit collisions, far exceeding the 16-slot Robin Hood probe limit. `rehash` cannot separate true collisions (a larger table doesn't change identical hashes), so the build aborted with `Exception: rehashed too many times`.

### Fix

Multiply by the uint64 `FNV_PRIME` name in the float and int branches of the record codegen (3 lines), matching the already-correct scalar/unicode paths.

### Verification

- Record hashes are now distinct per leading field and match an independent pure-Python FNV-1a + fmix64 reference implementation.
- `tests/pytools/common/test_hashmap.py`: **10/10 pass**.
- The **OasisModels `PiWindPostcode/test_2` model run now passes end-to-end** (`oasislmf model run`, exit 0). It previously failed with `rehashed too many times` while building the GULMC shared structures.

<!--start_release_notes-->
Fixed structured-record hashing in the GULMC hashmap so all record fields are mixed into the hash (previously only the last field contributed), which caused `rehashed too many times` failures for aggregate-vulnerability models such as PiWindPostcode.
<!--end_release_notes-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
