### PR TITLE
feature/aal_lec_idx_files

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,27 @@
+def pytest_addoption(parser):
+    parser.addoption(
+        '--gul-rtol', type=float, default=1e-10,
+        help='Relative tolerance between expected values and results, default is "1e-10"'
+    )
+    parser.addoption(
+        '--gul-atol', type=float, default=1e-8,
+        help='Absolute tolerance between expected values and results, default is "1e-8"'
+    )
+    parser.addoption(
+        '--gulmc-generate-missing-expected', action='store_true', default=False,
+        help='If True, generate the expected files for the tests that lack them (e.g., newly added tests). Default: False.'
+    )
+    parser.addoption(
+        '--update-expected', action='store_true', default=False,
+        help='If True, update all the expected files, overwriting them if they exist. Default: False.'
+    )
+    parser.addoption(
+        '--fm-keep-output', action='store_true', default=False,
+        help='If True, keep the test results (useful for debugging purposes). Default: False.'
+    )
+    parser.addoption(
+        '--remine-hash-collisions', action='store_true', default=False,
+        help='If True, brute-force a fresh colliding-int32-keys set for the hashmap '
+             'collision test and print it for paste-back. Use when the hash function '
+             'in oasislmf.pytools.common.hashmap changes. Adds ~5-15 s to the run.'
+    )

--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -731,6 +731,7 @@ class GenerateLosses(GenerateLossesDir):
                         socket_server_size=socket_server_size,
                         socket_server_port=socket_server_port,
                         resource_monitor_interval=self.resource_monitor_interval,
+                        log_level=self.logger.getEffectiveLevel(),
                     )
                     model_runner_module.run(self.settings, **run_args)
                 except TypeError:

--- a/oasislmf/execution/bash.py
+++ b/oasislmf/execution/bash.py
@@ -224,7 +224,7 @@ exit_handler(){
        printf "Script PID:%d, GPID:%s, SPID:%d\n" $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk \'BEGIN { FS = "[ \\t\\n]+" }{ if ($1 >= \'$script_pid\') print}\' | grep -v celery | egrep -v *\\\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk \'BEGIN { FS = "[ \\t\\n]+" }{ if ($1 >= \'$script_pid\') print}\' | grep -v celery | egrep -v \\.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk \'BEGIN { FS = "[ \\t\\n]+" }{ print $1 }\') 2>/dev/null
        exit $exit_code
@@ -2037,6 +2037,7 @@ def bash_params(
     exposure_df_engine="oasis_data_manager.df_reader.reader.OasisPandasReader",
     model_df_engine="oasis_data_manager.df_reader.reader.OasisPandasReader",
     dynamic_footprint=False,
+    log_level=None,
     **kwargs
 ):
     """Build the parameter dict consumed by :func:`create_bash_analysis` and :func:`create_bash_outputs`.
@@ -2084,6 +2085,7 @@ def bash_params(
         exposure_df_engine (str): DataFrame engine for exposure data.
         model_df_engine (str): DataFrame engine for model data.
         dynamic_footprint (bool): Enable dynamic footprint mode.
+        log_level (int or None): Enable logging of pytools subprocesses.
 
     Returns:
         dict: Parameter dictionary ready for unpacking into
@@ -2221,6 +2223,7 @@ def bash_params(
     bash_params['exposure_df_engine'] = exposure_df_engine
     bash_params['model_df_engine'] = model_df_engine
     bash_params['dynamic_footprint'] = dynamic_footprint
+    bash_params['log_level'] = log_level
 
     return bash_params
 
@@ -2373,6 +2376,7 @@ def create_bash_analysis(
     peril_filter,
     model_df_engine='oasis_data_manager.df_reader.reader.OasisPandasReader',
     dynamic_footprint=False,
+    log_level=None,
     **kwargs
 ):
     """Write the main analysis section of the bash script.
@@ -2646,6 +2650,10 @@ def create_bash_analysis(
                 }
             }
             compute_outputs.append(gul_computes)
+
+    # set compute log level through env variable
+    if log_level is not None:
+        print_command(filename, f'export OASIS_PYTOOLS_LOG_LEVEL={log_level}')
 
     do_computes(compute_outputs)
 
@@ -3102,7 +3110,8 @@ def genbash(
     dynamic_footprint=False,
     analysis_pk=None,
     socket_server_size=None,
-    socket_server_port=None
+    socket_server_port=None,
+    log_level=None
 ):
     """
     Generates a bash script containing pytools calculation instructions for an
@@ -3179,7 +3188,8 @@ def genbash(
         peril_filter=peril_filter,
         join_summary_info=join_summary_info,
         model_df_engine=model_df_engine,
-        dynamic_footprint=dynamic_footprint
+        dynamic_footprint=dynamic_footprint,
+        log_level=log_level
     )
 
     # remove the file if it already exists

--- a/oasislmf/execution/runner.py
+++ b/oasislmf/execution/runner.py
@@ -28,6 +28,7 @@ def run(analysis_settings,
         model_df_engine=None,
         dynamic_footprint=False,
         resource_monitor_interval=1,
+        log_level=None,
         **kwargs
         ):
     model_df_engine = model_df_engine or df_engine
@@ -101,6 +102,7 @@ def run(analysis_settings,
         custom_gulcalc_log_finish=custom_gulcalc_log_finish,
         model_df_engine=model_df_engine,
         dynamic_footprint=dynamic_footprint,
+        log_level=log_level,
         **kwargs,
     )
     monitor = ResourceMonitor(

--- a/oasislmf/pytools/aal/manager.py
+++ b/oasislmf/pytools/aal/manager.py
@@ -183,6 +183,19 @@ def sort_and_save_chunk(summaries_data, temp_file_path):
     sorted_chunk.tofile(temp_file_path)
 
 
+def _save_chunk(summaries_data, summaries_idx, path, chunk_index, temp_files, max_summary_id):
+    """Flush summaries_data[:summaries_idx] to a numbered temp file.
+    Returns:
+        chunk_index (int): incremented chunk counter
+        max_summary_id (int): updated running maximum
+    """
+    chunk = summaries_data[:summaries_idx]
+    temp_file_path = Path(path, f"indexed_summaries.part{chunk_index}.bdat")
+    sort_and_save_chunk(chunk, temp_file_path)
+    temp_files.append(temp_file_path)
+    return chunk_index + 1, max(max_summary_id, int(np.max(chunk["summary_id"])))
+
+
 @nb.njit(cache=True, error_model="numpy")
 def merge_sorted_chunks(memmaps):
     """
@@ -267,12 +280,9 @@ def get_summaries_data(
                     fbin, idx_data, cursor, occ_map, summaries_data, summaries_idx, file_index,
                 )
                 if resize_flag:
-                    temp_file_path = Path(path, f"indexed_summaries.part{chunk_index}.bdat")
-                    chunk = summaries_data[:summaries_idx]
-                    sort_and_save_chunk(chunk, temp_file_path)
-                    temp_files.append(temp_file_path)
-                    chunk_index += 1
-                    max_summary_id = max(max_summary_id, int(np.max(chunk["summary_id"])))
+                    chunk_index, max_summary_id = _save_chunk(
+                        summaries_data, summaries_idx, path, chunk_index, temp_files, max_summary_id
+                    )
                     summaries_idx = 0
                 if cursor >= len(idx_data):
                     break
@@ -283,23 +293,17 @@ def get_summaries_data(
                     fbin, offset, occ_map, summaries_data, summaries_idx, file_index,
                 )
                 if resize_flag:
-                    temp_file_path = Path(path, f"indexed_summaries.part{chunk_index}.bdat")
-                    chunk = summaries_data[:summaries_idx]
-                    sort_and_save_chunk(chunk, temp_file_path)
-                    temp_files.append(temp_file_path)
-                    chunk_index += 1
-                    max_summary_id = max(max_summary_id, int(np.max(chunk["summary_id"])))
+                    chunk_index, max_summary_id = _save_chunk(
+                        summaries_data, summaries_idx, path, chunk_index, temp_files, max_summary_id
+                    )
                     summaries_idx = 0
                 if offset >= len(fbin):
                     break
 
     # Write remaining summaries data to temporary file
     if summaries_idx > 0:
-        temp_file_path = Path(path, f"indexed_summaries.part{chunk_index}.bdat")
-        chunk = summaries_data[:summaries_idx]
-        sort_and_save_chunk(chunk, temp_file_path)
-        max_summary_id = max(max_summary_id, int(np.max(chunk["summary_id"])))
-        temp_files.append(temp_file_path)
+        _, max_summary_id = _save_chunk(
+            summaries_data, summaries_idx, path, chunk_index, temp_files, max_summary_id)
 
     memmaps = [np.memmap(temp_file, mode="r", dtype=_SUMMARIES_DTYPE) for temp_file in temp_files]
 
@@ -349,6 +353,8 @@ def summary_index(path, occ_map, stack):
         else:
             idx_handles.append(None)
 
+    # Partial coverage is fine: get_summaries_data dispatches per-file, falling back to
+    # sequential scan for any .bin without a paired .idx.
     if n_idx > 0:
         logger.info(f"Found {n_idx}/{len(files)} .idx file(s) — using direct-seek indexing")
     idx_handles_arg = idx_handles if n_idx > 0 else None
@@ -814,7 +820,6 @@ def calculate_confidence_interval(std_err, confidence_level):
         ((c[2] * p_value + c[1]) * p_value + c[0]) /
         (((d[2] * p_value + d[1]) * p_value + d[0]) * p_value + 1)
     )
-    # Return the confidence interval
     return std_err * z_value
 
 
@@ -971,7 +976,7 @@ def run(
             sample_size,
             max_summary_id,
             files_handles,
-            vec_analytical_aal,  # unique in output_aal
+            vec_analytical_aal,
             vecs_sample_aal,
             vec_used_summary_id,
         )

--- a/oasislmf/pytools/aal/manager.py
+++ b/oasislmf/pytools/aal/manager.py
@@ -12,7 +12,8 @@ import pyarrow.parquet as pq
 
 from oasislmf.pytools.aal.data import AAL_meanonly_dtype, AAL_meanonly_fmt, AAL_meanonly_headers, AAL_dtype, AAL_fmt, AAL_headers, ALCT_dtype, ALCT_fmt, ALCT_headers
 from oasislmf.pytools.common.data import (DEFAULT_BUFFER_SIZE, MEAN_TYPE_ANALYTICAL, MEAN_TYPE_SAMPLE, oasis_int, oasis_float,
-                                          oasis_int_size, oasis_float_size, write_ndarray_to_fmt_csv)
+                                          oasis_int_size, oasis_float_size, write_ndarray_to_fmt_csv,
+                                          summary_stream_index_dtype)
 from oasislmf.pytools.common.event_stream import (MEAN_IDX, MAX_LOSS_IDX, NUMBER_OF_AFFECTED_RISK_IDX, SUMMARY_STREAM_ID,
                                                   init_streams_in, mv_read)
 from oasislmf.pytools.common.input_files import read_occurrence, read_periods
@@ -85,6 +86,8 @@ def process_bin_file(
         # Get the number of rows for the current event_id
         n_rows = occ_map[event_id].shape[0]
 
+        if n_rows > len(summaries_data):
+            raise ValueError("OASIS_AAL_MEMORY is too small: a single event has more occurrences than the entire buffer. Increase OASIS_AAL_MEMORY.")
         if summaries_idx + n_rows >= len(summaries_data):
             # Resize array if full
             return summaries_idx, True, offset
@@ -108,6 +111,64 @@ def process_bin_file(
         offset = skip_losses(fbin, offset)
 
     return summaries_idx, False, offset
+
+
+@nb.njit(cache=True, error_model="numpy")
+def process_idx_file(
+    fbin,
+    idx_data,
+    idx_cursor,
+    occ_map,
+    summaries_data,
+    summaries_idx,
+    file_index,
+):
+    """Use a pre-built .idx file to populate summaries_data without scanning sample records.
+
+    Instead of reading the entire .bin sequentially (including all loss records just to advance
+    the cursor), each .idx entry gives the byte offset of an event header directly. Only the
+    4-byte event_id is read from the .bin per entry; loss records are never touched here.
+
+    Args:
+        fbin (np.memmap): summary binary memmap (dtype u1)
+        idx_data (np.memmap): index file memmap (dtype summary_stream_index_dtype)
+        idx_cursor (int): current position in idx_data to resume from
+        occ_map (nb.typed.Dict): numpy map of event_id -> rows with period_no, occ_date_id
+        summaries_data (ndarray[_SUMMARIES_DTYPE]): output index buffer
+        summaries_idx (int): next free slot in summaries_data
+        file_index (int): which .bin file this is (used as file_idx in output)
+    Returns:
+        summaries_idx (int): updated cursor into summaries_data
+        resize_flag (bool): True if summaries_data is full and must be flushed before resuming
+        idx_cursor (int): position in idx_data to resume from after a flush
+    """
+    n_idx = len(idx_data)
+    while idx_cursor < n_idx:
+        summary_id = idx_data[idx_cursor]['summary_id']
+        offset = idx_data[idx_cursor]['offset']
+
+        event_id, _ = mv_read(fbin, offset, oasis_int, oasis_int_size)
+
+        if event_id not in occ_map:
+            idx_cursor += 1
+            continue
+
+        n_rows = occ_map[event_id].shape[0]
+        if n_rows > len(summaries_data):
+            raise ValueError("OASIS_AAL_MEMORY is too small: a single event has more occurrences than the entire buffer. Increase OASIS_AAL_MEMORY.")
+        if summaries_idx + n_rows >= len(summaries_data):
+            return summaries_idx, True, idx_cursor
+
+        for row in occ_map[event_id]:
+            summaries_data[summaries_idx]['summary_id'] = summary_id
+            summaries_data[summaries_idx]['file_idx'] = file_index
+            summaries_data[summaries_idx]['period_no'] = row['period_no']
+            summaries_data[summaries_idx]['file_offset'] = offset
+            summaries_idx += 1
+
+        idx_cursor += 1
+
+    return summaries_idx, False, idx_cursor
 
 
 def sort_and_save_chunk(summaries_data, temp_file_path):
@@ -164,14 +225,22 @@ def get_summaries_data(
     path,
     files_handles,
     occ_map,
-    aal_max_memory
+    aal_max_memory,
+    idx_handles=None,
 ):
-    """Gets the indexed summaries data, ordered with k-way merge if not enough memory
+    """Gets the indexed summaries data, ordered with k-way merge if not enough memory.
+
+    When idx_handles[i] is not None (a memmap of summary_stream_index_dtype records), uses
+    process_idx_file for that file — seeking directly to each event header via pre-computed
+    offsets, never reading sample records during indexing. Falls back to process_bin_file
+    (full sequential scan) for any file without a paired .idx.
+
     Args:
         path (os.PathLike): Path to the workspace folder containing summary binaries
         files_handles (List[np.memmap]): List of memmaps for summary files data
         occ_map (nb.typed.Dict): numpy map of event_id, period_no, occ_date_id from the occurrence file
         aal_max_memory (float): OASIS_AAL_MEMORY value (has to be passed in as numba won't update from environment variable)
+        idx_handles (List[np.memmap | None] | None): Per-file .idx memmaps, or None to use sequential scan for all files
     Returns:
         memmaps (List[np.memmap]): List of temporary file memmaps
         max_summary_id (int): Max summary ID
@@ -187,40 +256,49 @@ def get_summaries_data(
     summaries_data = np.empty(buffer_size, dtype=_SUMMARIES_DTYPE)
     summaries_idx = 0
     max_summary_id = 0
+
     for file_index, fbin in enumerate(files_handles):
-        offset = oasis_int_size * 3  # Summary stream header size
+        idx_data = idx_handles[file_index] if idx_handles is not None else None
 
-        while True:
-            summaries_idx, resize_flag, offset = process_bin_file(
-                fbin,
-                offset,
-                occ_map,
-                summaries_data,
-                summaries_idx,
-                file_index,
-            )
-
-            # Write new summaries partial file when buffer size or end of summary file reached
-            if resize_flag:
-                temp_file_path = Path(path, f"indexed_summaries.part{chunk_index}.bdat")
-                summaries_data = summaries_data[:summaries_idx]
-                sort_and_save_chunk(summaries_data, temp_file_path)
-                temp_files.append(temp_file_path)
-                chunk_index += 1
-                summaries_idx = 0
-                if len(summaries_data) > 0:
-                    max_summary_id = max(max_summary_id, np.max(summaries_data["summary_id"]))
-
-            # End of file, move to next file
-            if offset >= len(fbin):
-                break
+        if idx_data is not None:
+            cursor = 0
+            while True:
+                summaries_idx, resize_flag, cursor = process_idx_file(
+                    fbin, idx_data, cursor, occ_map, summaries_data, summaries_idx, file_index,
+                )
+                if resize_flag:
+                    temp_file_path = Path(path, f"indexed_summaries.part{chunk_index}.bdat")
+                    chunk = summaries_data[:summaries_idx]
+                    sort_and_save_chunk(chunk, temp_file_path)
+                    temp_files.append(temp_file_path)
+                    chunk_index += 1
+                    max_summary_id = max(max_summary_id, int(np.max(chunk["summary_id"])))
+                    summaries_idx = 0
+                if cursor >= len(idx_data):
+                    break
+        else:
+            offset = oasis_int_size * 3  # Summary stream header size
+            while True:
+                summaries_idx, resize_flag, offset = process_bin_file(
+                    fbin, offset, occ_map, summaries_data, summaries_idx, file_index,
+                )
+                if resize_flag:
+                    temp_file_path = Path(path, f"indexed_summaries.part{chunk_index}.bdat")
+                    chunk = summaries_data[:summaries_idx]
+                    sort_and_save_chunk(chunk, temp_file_path)
+                    temp_files.append(temp_file_path)
+                    chunk_index += 1
+                    max_summary_id = max(max_summary_id, int(np.max(chunk["summary_id"])))
+                    summaries_idx = 0
+                if offset >= len(fbin):
+                    break
 
     # Write remaining summaries data to temporary file
-    summaries_data = summaries_data[:summaries_idx]
-    if len(summaries_data) > 0:
+    if summaries_idx > 0:
         temp_file_path = Path(path, f"indexed_summaries.part{chunk_index}.bdat")
-        sort_and_save_chunk(summaries_data, temp_file_path)
-        max_summary_id = max(max_summary_id, np.max(summaries_data["summary_id"]))
+        chunk = summaries_data[:summaries_idx]
+        sort_and_save_chunk(chunk, temp_file_path)
+        max_summary_id = max(max_summary_id, int(np.max(chunk["summary_id"])))
         temp_files.append(temp_file_path)
 
     memmaps = [np.memmap(temp_file, mode="r", dtype=_SUMMARIES_DTYPE) for temp_file in temp_files]
@@ -229,7 +307,12 @@ def get_summaries_data(
 
 
 def summary_index(path, occ_map, stack):
-    """Index the summary binary outputs
+    """Index the summary binary outputs.
+
+    If a .idx file (summary_stream_index_dtype) exists alongside a .bin file, uses
+    process_idx_file to build the index without scanning sample records. Falls back to
+    process_bin_file (full sequential scan) for any .bin without a paired .idx.
+
     Args:
         path (os.PathLike): Path to the workspace folder containing summary binaries
         occ_map (nb.typed.Dict): numpy map of event_id, period_no, occ_date_id from the occurrence file
@@ -244,19 +327,38 @@ def summary_index(path, occ_map, stack):
     aal_files_folder = Path(path, "aal_files")
     aal_files_folder.mkdir(parents=False, exist_ok=True)
 
-    # Find summary binary files
-    files = [file for file in path.glob("*.bin")]
+    # Find summary binary files (sorted for stable pairing with .idx files)
+    files = sorted(path.glob("*.bin"))
     files_handles = [np.memmap(file, mode="r", dtype="u1") for file in files]
 
     streams_in, (stream_source_type, stream_agg_type, sample_size) = init_streams_in(files, stack)
     if stream_source_type != SUMMARY_STREAM_ID:
         raise RuntimeError(f"Error: Not a summary stream type {stream_source_type}")
 
+    # Pair each .bin with its .idx if present
+    idx_handles = []
+    n_idx = 0
+    for f in files:
+        idx_path = f.with_suffix('.idx')
+        if idx_path.exists():
+            if idx_path.stat().st_size > 0:
+                idx_handles.append(np.memmap(str(idx_path), mode="r", dtype=summary_stream_index_dtype))
+            else:
+                idx_handles.append(np.empty(0, dtype=summary_stream_index_dtype))
+            n_idx += 1
+        else:
+            idx_handles.append(None)
+
+    if n_idx > 0:
+        logger.info(f"Found {n_idx}/{len(files)} .idx file(s) — using direct-seek indexing")
+    idx_handles_arg = idx_handles if n_idx > 0 else None
+
     memmaps, max_summary_id = get_summaries_data(
         aal_files_folder,
         files_handles,
         occ_map,
-        OASIS_AAL_MEMORY
+        OASIS_AAL_MEMORY,
+        idx_handles=idx_handles_arg,
     )
     return files_handles, sample_size, max_summary_id, memmaps
 

--- a/oasislmf/pytools/common/hashmap.py
+++ b/oasislmf/pytools/common/hashmap.py
@@ -335,11 +335,11 @@ def fnv1a_overload_record(record, h=init_hash):
             if ftype.bitwidth == 64:
                 src.append("    _buf = np.empty(1, dtype=np.float64)")
                 src.append(f"    _buf[0] = record['{fname}']")
-                src.append(f"    h = (h ^ _buf.view(np.uint64)[0]) * {FNV_PRIME}")
+                src.append("    h = (h ^ _buf.view(np.uint64)[0]) * FNV_PRIME")
             else:  # float32 → zero-extend to 64 bits after bit-cast to uint32
                 src.append("    _buf = np.empty(1, dtype=np.float32)")
                 src.append(f"    _buf[0] = record['{fname}']")
-                src.append(f"    h = (h ^ np.uint64(_buf.view(np.uint32)[0])) * {FNV_PRIME}")
+                src.append("    h = (h ^ np.uint64(_buf.view(np.uint32)[0])) * FNV_PRIME")
         elif isinstance(ftype, nbt.UnicodeCharSeq):
             # Fixed-width unicode (e.g. 'U3') field. str(field) trims trailing
             # NUL padding via numba's UnicodeCharSeq.__len__ (numpy's fixed-
@@ -351,7 +351,7 @@ def fnv1a_overload_record(record, h=init_hash):
         else:
             # int/uint/bool: np.uint64() is already a zero-extension, equivalent to bitcast
             src.append(
-                f"    h = (h ^ np.uint64(record['{fname}'])) * {FNV_PRIME}"
+                f"    h = (h ^ np.uint64(record['{fname}'])) * FNV_PRIME"
             )
     # Final Murmur3 fmix64 — three rounds of shift / mult / shift. See _fmix64().
     src.append("    h ^= h >> np.uint64(33)")

--- a/oasislmf/pytools/gulmc/cli.py
+++ b/oasislmf/pytools/gulmc/cli.py
@@ -73,7 +73,7 @@ def main():
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     ch.setFormatter(formatter)
     logger.addHandler(ch)
-    logging_level = kwargs.pop('logging_level')
+    logging_level = kwargs.get('logging_level')
     logger.setLevel(logging_level)
 
     if kwargs.pop('create_structures'):

--- a/oasislmf/pytools/gulmc/manager.py
+++ b/oasislmf/pytools/gulmc/manager.py
@@ -341,7 +341,9 @@ def run(run_dir,
             compute_info['event_id'] = event_ids[0]
             event_footprint = event_footprint_obj.get_event(event_ids[0])
 
-            if event_footprint is not None:
+            if event_footprint is None:
+                logger.info(f"event {event_ids[0]} SKIPPED - no footprint")
+            else:
                 Nhaz_arr_this_event, haz_pdf = process_areaperils_in_footprint(
                     event_footprint,
                     item_map_ja_id_ind,
@@ -352,6 +354,7 @@ def run(run_dir,
                 if Nhaz_arr_this_event == 0:
                     # no items to be computed for this event
                     counter += 1
+                    logger.info(f"event {event_ids[0]} SKIPPED - no items")
                     continue
 
                 items_event_data, rng_index, hazard_rng_index, byte_mv = reconstruct_coverages(
@@ -394,6 +397,7 @@ def run(run_dir,
                 compute_info['cdf_cache_ctr'] = 0
 
                 processing_done = False
+                logger.info(f"event {event_ids[0]} STARTED")
                 while not processing_done:
                     try:
                         processing_done = compute_event_losses(

--- a/oasislmf/pytools/lec/aggreports/__init__.py
+++ b/oasislmf/pytools/lec/aggreports/__init__.py
@@ -1,8 +1,8 @@
-__all__ = ["AggReports"]
+__all__ = ["AggReports", "LecConfig", "make_output_fn", "output_for_summary_idx"]
 
 import logging
 from logging import NullHandler
-from .aggreports import AggReports
+from .aggreports import AggReports, LecConfig, make_output_fn, output_for_summary_idx
 
 logger = logging.getLogger(__name__)
 logger.addHandler(NullHandler())

--- a/oasislmf/pytools/lec/aggreports/aggreports.py
+++ b/oasislmf/pytools/lec/aggreports/aggreports.py
@@ -11,7 +11,11 @@ from oasislmf.pytools.lec.aggreports.outputs.sample_mean import output_sample_me
 from oasislmf.pytools.lec.aggreports.outputs.wheatsheaf import fill_wheatsheaf_items
 from oasislmf.pytools.lec.aggreports.outputs.wheatsheaf_mean import fill_wheatsheaf_mean_items, get_wheatsheaf_max_count
 from oasislmf.pytools.lec.aggreports.write_tables import write_ept, write_ept_weighted, write_psept, write_psept_weighted, write_wheatsheaf_mean
-from oasislmf.pytools.lec.data import FULL, MEANDR, MEANSAMPLE, PERSAMPLEMEAN
+from oasislmf.pytools.lec.data import (
+    AEP, AEPTVAR, AGG_FULL_UNCERTAINTY, AGG_SAMPLE_MEAN, AGG_WHEATSHEAF, AGG_WHEATSHEAF_MEAN,
+    FULL, MEANDR, MEANSAMPLE, OCC_FULL_UNCERTAINTY, OCC_SAMPLE_MEAN, OCC_WHEATSHEAF,
+    OCC_WHEATSHEAF_MEAN, OEP, OEPTVAR, PERSAMPLEMEAN,
+)
 from oasislmf.pytools.lec.data import LOSSVEC2MAP_dtype, MEANMAP_dtype, WHEATKEYITEMS_dtype
 
 logger = logging.getLogger(__name__)
@@ -447,3 +451,172 @@ class AggReports():
 
         for data in gen:
             self.output_data(data, "ept")
+
+    def output_for_summary(
+        self,
+        summary_id,
+        outloss_mean_s,
+        row_used_mean_s,
+        outloss_sample_s,
+        row_used_sample_s,
+        output_flags,
+        hasOCC,
+        hasAGG,
+    ):
+        """Output all report types for a single summary_id using per-summary arrays.
+
+        Called only in the idx path. Receives fresh per-summary arrays as explicit
+        arguments and writes directly to output; does not use any pre-computed state
+        from __init__ (self.outloss_mean, self.row_used_indices_*, self.max_summary_id).
+
+        All internal calls use max_summary_id=1 so the numba index functions collapse
+        to zero-based offsets into the single-summary arrays. The write generators
+        therefore emit SummaryId=1, which is corrected inline to the real summary_id
+        before each write.
+        """
+        row_used_indices_mean   = np.flatnonzero(row_used_mean_s)
+        row_used_indices_sample = np.flatnonzero(row_used_sample_s)
+
+        if not len(row_used_indices_mean) and not len(row_used_indices_sample):
+            return
+
+        def _output(gen, out_type):
+            for data in gen:
+                if len(data):
+                    data["SummaryId"] = summary_id
+                self.output_data(data, out_type)
+
+        # ── Mean Damage Ratio ──────────────────────────────────────────────────
+        if self.outmap["ept"]["compute"] and (hasOCC or hasAGG):
+            for eptype, eptype_tvar, outloss_type, wanted in (
+                (OEP, OEPTVAR, "max_out_loss", hasOCC),
+                (AEP, AEPTVAR, "agg_out_loss", hasAGG),
+            ):
+                if not wanted:
+                    continue
+                items = np.zeros(len(row_used_indices_mean), dtype=LOSSVEC2MAP_dtype)
+                items_start_end = np.full((1, 2), -1, dtype=np.int32)
+                has_weights, used_period_no = output_mean_damage_ratio(
+                    items, items_start_end, row_used_indices_mean,
+                    outloss_mean_s[outloss_type], self.period_weights, 1,
+                )
+                unused_pw = self.period_weights[~used_period_no]
+                if has_weights:
+                    _output(write_ept_weighted(items, items_start_end, self.sample_size,
+                                               MEANDR, eptype, eptype_tvar, unused_pw,
+                                               self.use_return_period, self.returnperiods, 1), "ept")
+                else:
+                    _output(write_ept(items, items_start_end, self.no_of_periods,
+                                      MEANDR, eptype, eptype_tvar,
+                                      self.use_return_period, self.returnperiods, 1), "ept")
+
+        # ── Full Uncertainty ───────────────────────────────────────────────────
+        for flag, eptype, eptype_tvar, outloss_type in (
+            (OCC_FULL_UNCERTAINTY, OEP, OEPTVAR, "max_out_loss"),
+            (AGG_FULL_UNCERTAINTY, AEP, AEPTVAR, "agg_out_loss"),
+        ):
+            if not output_flags[flag]:
+                continue
+            items = np.zeros(len(row_used_indices_sample), dtype=LOSSVEC2MAP_dtype)
+            items_start_end = np.full((1, 2), -1, dtype=np.int32)
+            has_weights, used_period_no = output_full_uncertainty(
+                items, items_start_end, row_used_indices_sample,
+                outloss_sample_s[outloss_type], self.period_weights, 1, self.num_sidxs,
+            )
+            unused_pw = self.period_weights[~used_period_no]
+            if has_weights:
+                _output(write_ept_weighted(items, items_start_end, 1,
+                                           FULL, eptype, eptype_tvar, unused_pw,
+                                           self.use_return_period, self.returnperiods, 1), "ept")
+            else:
+                _output(write_ept(items, items_start_end, self.no_of_periods * self.sample_size,
+                                  FULL, eptype, eptype_tvar,
+                                  self.use_return_period, self.returnperiods, 1), "ept")
+
+        # ── Wheatsheaf & Wheatsheaf Mean ───────────────────────────────────────
+        for flag_w, flag_wm, eptype, eptype_tvar, outloss_type in (
+            (OCC_WHEATSHEAF, OCC_WHEATSHEAF_MEAN, OEP, OEPTVAR, "max_out_loss"),
+            (AGG_WHEATSHEAF, AGG_WHEATSHEAF_MEAN, AEP, AEPTVAR, "agg_out_loss"),
+        ):
+            do_wheat      = output_flags[flag_w]
+            do_wheat_mean = output_flags[flag_wm]
+            if not (do_wheat or do_wheat_mean):
+                continue
+
+            wheatsheaf_items = np.zeros(len(row_used_indices_sample), dtype=WHEATKEYITEMS_dtype)
+            wheatsheaf_items_start_end = np.full((self.num_sidxs, 2), -1, dtype=np.int32)
+            has_weights, used_period_no = fill_wheatsheaf_items(
+                wheatsheaf_items, wheatsheaf_items_start_end, row_used_indices_sample,
+                outloss_sample_s[outloss_type], self.period_weights, 1, self.num_sidxs,
+            )
+            unused_pw = self.period_weights[~used_period_no]
+
+            if has_weights:
+                mean_map = None
+                if do_wheat_mean:
+                    mean_map = np.zeros((1, len(self.returnperiods)), dtype=MEANMAP_dtype)
+                if do_wheat:
+                    _output(write_psept_weighted(
+                        wheatsheaf_items, wheatsheaf_items_start_end, self.no_of_periods,
+                        eptype, eptype_tvar, unused_pw, self.use_return_period, self.returnperiods,
+                        1, self.num_sidxs, self.sample_size, mean_map=mean_map,
+                    ), "psept")
+                if do_wheat_mean and mean_map is not None:
+                    _output(write_wheatsheaf_mean(mean_map, eptype, PERSAMPLEMEAN, 1), "ept")
+            else:
+                if do_wheat:
+                    _output(write_psept(
+                        wheatsheaf_items, wheatsheaf_items_start_end, self.no_of_periods,
+                        eptype, eptype_tvar, self.use_return_period, self.returnperiods,
+                        1, self.num_sidxs,
+                    ), "psept")
+                if do_wheat_mean:
+                    maxcounts = get_wheatsheaf_max_count(
+                        wheatsheaf_items, wheatsheaf_items_start_end, 1)
+                    if np.any(maxcounts != -1):
+                        wheatsheaf_mean_items = np.zeros(
+                            np.sum(maxcounts[maxcounts != -1]), dtype=LOSSVEC2MAP_dtype)
+                        wheatsheaf_mean_items_start_end = fill_wheatsheaf_mean_items(
+                            wheatsheaf_mean_items, wheatsheaf_items, wheatsheaf_items_start_end,
+                            maxcounts, 1, self.num_sidxs,
+                        )
+                        _output(write_ept(
+                            wheatsheaf_mean_items, wheatsheaf_mean_items_start_end,
+                            self.no_of_periods, PERSAMPLEMEAN, eptype, eptype_tvar,
+                            self.use_return_period, self.returnperiods, 1,
+                            sample_size=self.sample_size,
+                        ), "ept")
+
+        # ── Sample Mean ────────────────────────────────────────────────────────
+        if self.sample_size == 0:
+            return
+        for flag, eptype, eptype_tvar, outloss_type in (
+            (OCC_SAMPLE_MEAN, OEP, OEPTVAR, "max_out_loss"),
+            (AGG_SAMPLE_MEAN, AEP, AEPTVAR, "agg_out_loss"),
+        ):
+            if not output_flags[flag]:
+                continue
+            reordered = np.zeros(
+                self.no_of_periods,
+                dtype=np.dtype([("row_used", np.bool_), ("value", oasis_float)]),
+            )
+            reorder_losses_by_summary_and_period(
+                reordered, row_used_indices_sample, outloss_sample_s[outloss_type],
+                1, self.no_of_periods, self.num_sidxs, self.sample_size,
+            )
+            row_used_ro = np.flatnonzero(reordered["row_used"])
+            items = np.zeros(len(row_used_ro), dtype=LOSSVEC2MAP_dtype)
+            items_start_end = np.full((1, 2), -1, dtype=np.int32)
+            has_weights, used_period_no = output_sample_mean(
+                items, items_start_end, row_used_ro, reordered["value"],
+                self.period_weights, 1, self.no_of_periods,
+            )
+            unused_pw = self.period_weights[~used_period_no]
+            if has_weights:
+                _output(write_ept_weighted(items, items_start_end, self.sample_size,
+                                           MEANSAMPLE, eptype, eptype_tvar, unused_pw,
+                                           self.use_return_period, self.returnperiods, 1), "ept")
+            else:
+                _output(write_ept(items, items_start_end, self.no_of_periods,
+                                  MEANSAMPLE, eptype, eptype_tvar,
+                                  self.use_return_period, self.returnperiods, 1), "ept")

--- a/oasislmf/pytools/lec/aggreports/aggreports.py
+++ b/oasislmf/pytools/lec/aggreports/aggreports.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 import numpy as np
 import pandas as pd
@@ -21,6 +22,185 @@ from oasislmf.pytools.lec.data import LOSSVEC2MAP_dtype, MEANMAP_dtype, WHEATKEY
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class LecConfig:
+    """Shared per-run configuration passed to output helpers and output_for_summary_idx."""
+    period_weights: np.ndarray
+    max_summary_id: int
+    sample_size: int
+    no_of_periods: int
+    num_sidxs: int
+    use_return_period: bool
+    returnperiods: np.ndarray
+
+
+def make_output_fn(outmap, output_binary, output_parquet):
+    """Return a callable(data, out_type) that writes data in the correct output format."""
+    def output_data(data, out_type):
+        if output_binary:
+            data.tofile(outmap[out_type]["file"])
+        elif output_parquet:
+            data_df = pd.DataFrame(data)
+            data_table = pa.Table.from_pandas(data_df)
+            outmap[out_type]["file"].write_table(data_table)
+        else:
+            write_ndarray_to_fmt_csv(
+                outmap[out_type]["file"],
+                data,
+                outmap[out_type]["headers"],
+                outmap[out_type]["fmt"]
+            )
+    return output_data
+
+
+# ---------------------------------------------------------------------------
+# Shared compute-and-write helpers — arrays pre-allocated by caller
+# (memmap for sequential, np.zeros for idx). alloc_* callables handle late-sized arrays.
+# ---------------------------------------------------------------------------
+
+def _write_mean_damage_ratio(
+    items, items_start_end, row_used_indices_mean, outloss_mean_vals,
+    config, eptype, eptype_tvar, output_fn,
+):
+    has_weights, used_period_no = output_mean_damage_ratio(
+        items, items_start_end, row_used_indices_mean,
+        outloss_mean_vals, config.period_weights, config.max_summary_id,
+    )
+    unused_pw = config.period_weights[~used_period_no]
+    if has_weights:
+        gen = write_ept_weighted(
+            items, items_start_end, config.sample_size, MEANDR,
+            eptype, eptype_tvar, unused_pw,
+            config.use_return_period, config.returnperiods, config.max_summary_id,
+        )
+    else:
+        gen = write_ept(
+            items, items_start_end, config.no_of_periods, MEANDR,
+            eptype, eptype_tvar,
+            config.use_return_period, config.returnperiods, config.max_summary_id,
+        )
+    for data in gen:
+        output_fn(data, "ept")
+
+
+def _write_full_uncertainty(
+    items, items_start_end, row_used_indices_sample, outloss_sample_vals,
+    config, eptype, eptype_tvar, output_fn,
+):
+    has_weights, used_period_no = output_full_uncertainty(
+        items, items_start_end, row_used_indices_sample,
+        outloss_sample_vals, config.period_weights, config.max_summary_id, config.num_sidxs,
+    )
+    unused_pw = config.period_weights[~used_period_no]
+    if has_weights:
+        gen = write_ept_weighted(
+            items, items_start_end, 1, FULL,
+            eptype, eptype_tvar, unused_pw,
+            config.use_return_period, config.returnperiods, config.max_summary_id,
+        )
+    else:
+        gen = write_ept(
+            items, items_start_end, config.no_of_periods * config.sample_size, FULL,
+            eptype, eptype_tvar,
+            config.use_return_period, config.returnperiods, config.max_summary_id,
+        )
+    for data in gen:
+        output_fn(data, "ept")
+
+
+def _write_wheatsheaf(
+    wheatsheaf_items, wheatsheaf_items_start_end, mean_map,
+    row_used_indices_sample, outloss_sample_vals,
+    config, eptype, eptype_tvar, do_wheat, do_wheat_mean, alloc_wm_items, output_fn,
+):
+    """alloc_wm_items: no-weights branch only; np.zeros for idx, memmap lambda for seq."""
+    has_weights, used_period_no = fill_wheatsheaf_items(
+        wheatsheaf_items, wheatsheaf_items_start_end, row_used_indices_sample,
+        outloss_sample_vals, config.period_weights, config.max_summary_id, config.num_sidxs,
+    )
+    unused_pw = config.period_weights[~used_period_no]
+
+    if has_weights:
+        if do_wheat:
+            gen = write_psept_weighted(
+                wheatsheaf_items, wheatsheaf_items_start_end, config.no_of_periods,
+                eptype, eptype_tvar, unused_pw,
+                config.use_return_period, config.returnperiods,
+                config.max_summary_id, config.num_sidxs, config.sample_size, mean_map=mean_map,
+            )
+            for data in gen:
+                output_fn(data, "psept")
+        if do_wheat_mean and mean_map is not None:
+            gen = write_wheatsheaf_mean(mean_map, eptype, PERSAMPLEMEAN, config.max_summary_id)
+            for data in gen:
+                output_fn(data, "ept")
+    else:
+        if do_wheat:
+            gen = write_psept(
+                wheatsheaf_items, wheatsheaf_items_start_end, config.no_of_periods,
+                eptype, eptype_tvar,
+                config.use_return_period, config.returnperiods,
+                config.max_summary_id, config.num_sidxs,
+            )
+            for data in gen:
+                output_fn(data, "psept")
+        if do_wheat_mean:
+            maxcounts = get_wheatsheaf_max_count(
+                wheatsheaf_items, wheatsheaf_items_start_end, config.max_summary_id)
+            if np.any(maxcounts != -1):
+                wm_items = alloc_wm_items(np.sum(maxcounts[maxcounts != -1]))
+                wm_items_start_end = fill_wheatsheaf_mean_items(
+                    wm_items, wheatsheaf_items, wheatsheaf_items_start_end,
+                    maxcounts, config.max_summary_id, config.num_sidxs,
+                )
+                gen = write_ept(
+                    wm_items, wm_items_start_end, config.no_of_periods,
+                    PERSAMPLEMEAN, eptype, eptype_tvar,
+                    config.use_return_period, config.returnperiods, config.max_summary_id,
+                    sample_size=config.sample_size,
+                )
+                for data in gen:
+                    output_fn(data, "ept")
+
+
+def _write_sample_mean(
+    reordered_outlosses, row_used_indices_sample, outloss_sample_vals,
+    config, eptype, eptype_tvar, alloc_items, output_fn,
+):
+    """reordered_outlosses shape: no_of_periods * max_summary_id. alloc_items size is post-computation."""
+    reorder_losses_by_summary_and_period(
+        reordered_outlosses, row_used_indices_sample, outloss_sample_vals,
+        config.max_summary_id, config.no_of_periods, config.num_sidxs, config.sample_size,
+    )
+    row_used_ro = np.flatnonzero(reordered_outlosses["row_used"])
+    items = alloc_items(len(row_used_ro))
+    items_start_end = np.full((config.max_summary_id, 2), -1, dtype=np.int32)
+    has_weights, used_period_no = output_sample_mean(
+        items, items_start_end, row_used_ro, reordered_outlosses["value"],
+        config.period_weights, config.max_summary_id, config.no_of_periods,
+    )
+    unused_pw = config.period_weights[~used_period_no]
+    if has_weights:
+        gen = write_ept_weighted(
+            items, items_start_end, config.sample_size, MEANSAMPLE,
+            eptype, eptype_tvar, unused_pw,
+            config.use_return_period, config.returnperiods, config.max_summary_id,
+        )
+    else:
+        gen = write_ept(
+            items, items_start_end, config.no_of_periods, MEANSAMPLE,
+            eptype, eptype_tvar,
+            config.use_return_period, config.returnperiods, config.max_summary_id,
+        )
+    for data in gen:
+        output_fn(data, "ept")
+
+
+# ---------------------------------------------------------------------------
+# Sequential path — AggReports
+# Allocates memmaps, calls the shared helpers above.
+# ---------------------------------------------------------------------------
+
 class AggReports():
     def __init__(
         self,
@@ -29,13 +209,7 @@ class AggReports():
         row_used_mean,
         outloss_sample,
         row_used_sample,
-        period_weights,
-        max_summary_id,
-        sample_size,
-        no_of_periods,
-        num_sidxs,
-        use_return_period,
-        returnperiods,
+        config,
         lec_files_folder,
         output_binary,
         output_parquet,
@@ -43,33 +217,11 @@ class AggReports():
         self.outmap = outmap
         self.outloss_mean = outloss_mean
         self.outloss_sample = outloss_sample
-        self.period_weights = period_weights
-        self.max_summary_id = max_summary_id
-        self.sample_size = sample_size
-        self.no_of_periods = no_of_periods
-        self.num_sidxs = num_sidxs
-        self.use_return_period = use_return_period
-        self.returnperiods = returnperiods
         self.lec_files_folder = lec_files_folder
-        self.output_binary = output_binary
-        self.output_parquet = output_parquet
         self.row_used_indices_mean = np.flatnonzero(row_used_mean)
         self.row_used_indices_sample = np.flatnonzero(row_used_sample)
-
-    def output_data(self, data, out_type):
-        if self.output_binary:
-            data.tofile(self.outmap[out_type]["file"])
-        elif self.output_parquet:
-            data_df = pd.DataFrame(data)
-            data_table = pa.Table.from_pandas(data_df)
-            self.outmap[out_type]["file"].write_table(data_table)
-        else:
-            write_ndarray_to_fmt_csv(
-                self.outmap[out_type]["file"],
-                data,
-                self.outmap[out_type]["headers"],
-                self.outmap[out_type]["fmt"]
-            )
+        self.config = config
+        self.output_data = make_output_fn(outmap, output_binary, output_parquet)
 
     def output_mean_damage_ratio(self, eptype, eptype_tvar, outloss_type):
         """Output Mean Damage Ratio
@@ -80,65 +232,19 @@ class AggReports():
             eptype_tvar (int): Exceedance Probability Type (Tail Value at Risk)
             outloss_type (string): Which loss to output
         """
-        epcalc = MEANDR
-
-        row_used_indices = self.row_used_indices_mean
-
-        # Allocate storage for the flat data array
-        items_fp = Path(self.lec_files_folder, f"lec_mean_damage_ratio-{outloss_type}-items.bdat")
-        items = np.memmap(items_fp, dtype=LOSSVEC2MAP_dtype, mode="w+", shape=(len(row_used_indices),))
-        # Track start and end indices for each summary_id
-        items_start_end = np.full((self.max_summary_id, 2), -1, dtype=np.int32)
-
-        # Select the correct outloss values based on type
-        # Required if-else condition as njit cannot resolve outloss_type inside []
-        if outloss_type == "agg_out_loss":
-            outloss_vals = self.outloss_mean["agg_out_loss"]
-        elif outloss_type == "max_out_loss":
-            outloss_vals = self.outloss_mean["max_out_loss"]
-        else:
+        if outloss_type not in ("agg_out_loss", "max_out_loss"):
             raise ValueError(f"Error: Unknown outloss_type: {outloss_type}")
-
-        # Populate items and items_start_end
-        has_weights, used_period_no = output_mean_damage_ratio(
-            items,
-            items_start_end,
-            row_used_indices,
-            outloss_vals,
-            self.period_weights,
-            self.max_summary_id,
+        outloss_vals = self.outloss_mean[outloss_type]
+        row_used_indices = self.row_used_indices_mean
+        items = np.memmap(
+            Path(self.lec_files_folder, f"lec_mean_damage_ratio-{outloss_type}-items.bdat"),
+            dtype=LOSSVEC2MAP_dtype, mode="w+", shape=(len(row_used_indices),),
         )
-        unused_period_weights = self.period_weights[~used_period_no]
-
-        if has_weights:
-            gen = write_ept_weighted(
-                items,
-                items_start_end,
-                self.sample_size,
-                epcalc,
-                eptype,
-                eptype_tvar,
-                unused_period_weights,
-                self.use_return_period,
-                self.returnperiods,
-                self.max_summary_id
-            )
-        else:
-            gen = write_ept(
-                items,
-                items_start_end,
-                self.no_of_periods,
-                epcalc,
-                eptype,
-                eptype_tvar,
-                self.use_return_period,
-                self.returnperiods,
-                self.max_summary_id
-
-            )
-
-        for data in gen:
-            self.output_data(data, "ept")
+        items_start_end = np.full((self.config.max_summary_id, 2), -1, dtype=np.int32)
+        _write_mean_damage_ratio(
+            items, items_start_end, row_used_indices, outloss_vals,
+            self.config, eptype, eptype_tvar, self.output_data,
+        )
 
     def output_full_uncertainty(self, eptype, eptype_tvar, outloss_type):
         """Output Full Uncertainty
@@ -149,70 +255,24 @@ class AggReports():
             eptype_tvar (int): Exceedance Probability Type (Tail Value at Risk)
             outloss_type (string): Which loss to output
         """
-        epcalc = FULL
-
-        row_used_indices = self.row_used_indices_sample
-
-        # Allocate storage for the flat data array
-        items_fp = Path(self.lec_files_folder, f"lec_full_uncertainty-{outloss_type}-items.bdat")
-        items = np.memmap(items_fp, dtype=LOSSVEC2MAP_dtype, mode="w+", shape=(len(row_used_indices),))
-        # Track start and end indices for each summary_id
-        items_start_end = np.full((self.max_summary_id, 2), -1, dtype=np.int32)
-
-        # Select the correct outloss values based on type
-        # Required if-else condition as njit cannot resolve outloss_type inside []
-        if outloss_type == "agg_out_loss":
-            outloss_vals = self.outloss_sample["agg_out_loss"]
-        elif outloss_type == "max_out_loss":
-            outloss_vals = self.outloss_sample["max_out_loss"]
-        else:
+        if outloss_type not in ("agg_out_loss", "max_out_loss"):
             raise ValueError(f"Error: Unknown outloss_type: {outloss_type}")
-
-        # Populate items and items_start_end
-        has_weights, used_period_no = output_full_uncertainty(
-            items,
-            items_start_end,
-            row_used_indices,
-            outloss_vals,
-            self.period_weights,
-            self.max_summary_id,
-            self.num_sidxs,
+        outloss_vals = self.outloss_sample[outloss_type]
+        row_used_indices = self.row_used_indices_sample
+        items = np.memmap(
+            Path(self.lec_files_folder, f"lec_full_uncertainty-{outloss_type}-items.bdat"),
+            dtype=LOSSVEC2MAP_dtype, mode="w+", shape=(len(row_used_indices),),
         )
-        unused_period_weights = self.period_weights[~used_period_no]
-
-        if has_weights:
-            gen = write_ept_weighted(
-                items,
-                items_start_end,
-                1,
-                epcalc,
-                eptype,
-                eptype_tvar,
-                unused_period_weights,
-                self.use_return_period,
-                self.returnperiods,
-                self.max_summary_id
-            )
-        else:
-            gen = write_ept(
-                items,
-                items_start_end,
-                self.no_of_periods * self.sample_size,
-                epcalc,
-                eptype,
-                eptype_tvar,
-                self.use_return_period,
-                self.returnperiods,
-                self.max_summary_id
-            )
-
-        for data in gen:
-            self.output_data(data, "ept")
+        items_start_end = np.full((self.config.max_summary_id, 2), -1, dtype=np.int32)
+        _write_full_uncertainty(
+            items, items_start_end, row_used_indices, outloss_vals,
+            self.config, eptype, eptype_tvar, self.output_data,
+        )
 
     def output_wheatsheaf_and_wheatsheafmean(self, eptype, eptype_tvar, outloss_type, output_wheatsheaf, output_wheatsheaf_mean):
         """Output Wheatsheaf and Wheatsheaf Mean
         Wheatsheaf, Per Sample EPT (PSEPT) – this means calculate the EP Curve for each sample and
-        leave it at the sample level of detail, resulting in multiple “curves”.
+        leave it at the sample level of detail, resulting in multiple "curves".
         Wheatsheaf Mean, Per Sample mean EPT – this means average the loss at each return period of
         the Per Sample EPT.
         Args:
@@ -222,137 +282,34 @@ class AggReports():
             output_wheatsheaf (bool): Bool to Output Wheatsheaf
             output_wheatsheaf_mean (bool): Bool to Output Wheatsheaf Mean
         """
-        epcalc = PERSAMPLEMEAN
-
-        row_used_indices = self.row_used_indices_sample
-
-        wheatsheaf_items_file = Path(self.lec_files_folder, f"lec_wheatsheaf-items-{outloss_type}.bdat")
-        wheatsheaf_items = np.memmap(
-            wheatsheaf_items_file,
-            dtype=WHEATKEYITEMS_dtype,
-            mode="w+",
-            shape=(len(row_used_indices)),
-        )
-        # Track start and end indices for each summary_id and sidx
-        wheatsheaf_items_start_end = np.full((self.max_summary_id * self.num_sidxs, 2), -1, dtype=np.int32)
-
-        # Select the correct outloss values based on type
-        # Required if-else condition as njit cannot resolve outloss_type inside []
-        if outloss_type == "agg_out_loss":
-            outloss_vals = self.outloss_sample["agg_out_loss"]
-        elif outloss_type == "max_out_loss":
-            outloss_vals = self.outloss_sample["max_out_loss"]
-        else:
+        if outloss_type not in ("agg_out_loss", "max_out_loss"):
             raise ValueError(f"Error: Unknown outloss_type: {outloss_type}")
-
-        # Populate wheatsheaf_items and wheatsheaf_items_start_end
-        has_weights, used_period_no = fill_wheatsheaf_items(
-            wheatsheaf_items,
-            wheatsheaf_items_start_end,
-            row_used_indices,
-            outloss_vals,
-            self.period_weights,
-            self.max_summary_id,
-            self.num_sidxs,
+        outloss_vals = self.outloss_sample[outloss_type]
+        row_used_indices = self.row_used_indices_sample
+        wh_items = np.memmap(
+            Path(self.lec_files_folder, f"lec_wheatsheaf-items-{outloss_type}.bdat"),
+            dtype=WHEATKEYITEMS_dtype, mode="w+", shape=(len(row_used_indices),),
         )
-        unused_period_weights = self.period_weights[~used_period_no]
-
-        if has_weights:
-            mean_map = None
-
-            if output_wheatsheaf_mean:
-                mean_map_file = Path(self.lec_files_folder, f"lec_wheatsheaf_mean-map-{outloss_type}.bdat")
-                mean_map = np.memmap(
-                    mean_map_file,
-                    dtype=MEANMAP_dtype,
-                    mode="w+",
-                    shape=(self.max_summary_id, len(self.returnperiods)),
-                )
-
-            if output_wheatsheaf:
-                gen = write_psept_weighted(
-                    wheatsheaf_items,
-                    wheatsheaf_items_start_end,
-                    self.no_of_periods,
-                    eptype,
-                    eptype_tvar,
-                    unused_period_weights,
-                    self.use_return_period,
-                    self.returnperiods,
-                    self.max_summary_id,
-                    self.num_sidxs,
-                    self.sample_size,
-                    mean_map=mean_map,
-                )
-                for data in gen:
-                    self.output_data(data, "psept")
-
-            if output_wheatsheaf_mean:
-                gen = write_wheatsheaf_mean(
-                    mean_map,
-                    eptype,
-                    epcalc,
-                    self.max_summary_id,
-                )
-                for data in gen:
-                    self.output_data(data, "ept")
-        else:
-            if output_wheatsheaf:
-                gen = write_psept(
-                    wheatsheaf_items,
-                    wheatsheaf_items_start_end,
-                    self.no_of_periods,
-                    eptype,
-                    eptype_tvar,
-                    self.use_return_period,
-                    self.returnperiods,
-                    self.max_summary_id,
-                    self.num_sidxs,
-                )
-                for data in gen:
-                    self.output_data(data, "psept")
-
-            if not output_wheatsheaf_mean:
-                return
-
-            maxcounts = get_wheatsheaf_max_count(
-                wheatsheaf_items,
-                wheatsheaf_items_start_end,
-                self.max_summary_id,
+        wh_items_start_end = np.full(
+            (self.config.max_summary_id * self.config.num_sidxs, 2), -1, dtype=np.int32,
+        )
+        mean_map = None
+        if output_wheatsheaf_mean:
+            mean_map = np.memmap(
+                Path(self.lec_files_folder, f"lec_wheatsheaf_mean-map-{outloss_type}.bdat"),
+                dtype=MEANMAP_dtype, mode="w+",
+                shape=(self.config.max_summary_id, len(self.config.returnperiods)),
             )
+        wm_items_path = Path(self.lec_files_folder, f"lec_wheatsheaf_mean-items-{outloss_type}.bdat")
 
-            wheatsheaf_mean_items_file = Path(self.lec_files_folder, f"lec_wheatsheaf_mean-items-{outloss_type}.bdat")
-            wheatsheaf_mean_items = np.memmap(
-                wheatsheaf_mean_items_file,
-                dtype=LOSSVEC2MAP_dtype,
-                mode="w+",
-                shape=(np.sum(maxcounts[maxcounts != -1])),
-            )
-
-            wheatsheaf_mean_items_start_end = fill_wheatsheaf_mean_items(
-                wheatsheaf_mean_items,
-                wheatsheaf_items,
-                wheatsheaf_items_start_end,
-                maxcounts,
-                self.max_summary_id,
-                self.num_sidxs,
-            )
-
-            gen = write_ept(
-                wheatsheaf_mean_items,
-                wheatsheaf_mean_items_start_end,
-                self.no_of_periods,
-                epcalc,
-                eptype,
-                eptype_tvar,
-                self.use_return_period,
-                self.returnperiods,
-                self.max_summary_id,
-                sample_size=self.sample_size
-            )
-
-            for data in gen:
-                self.output_data(data, "ept")
+        def alloc_wm_items(size): return np.memmap(
+            wm_items_path, dtype=LOSSVEC2MAP_dtype, mode="w+", shape=(size,)
+        )
+        _write_wheatsheaf(
+            wh_items, wh_items_start_end, mean_map, row_used_indices, outloss_vals,
+            self.config, eptype, eptype_tvar, output_wheatsheaf, output_wheatsheaf_mean,
+            alloc_wm_items, self.output_data,
+        )
 
     def output_sample_mean(self, eptype, eptype_tvar, outloss_type):
         """Output Sample Mean
@@ -363,260 +320,123 @@ class AggReports():
             eptype_tvar (int): Exceedance Probability Type (Tail Value at Risk)
             outloss_type (string): Which loss to output
         """
-        if self.sample_size == 0:
+        if self.config.sample_size == 0:
             logger.warning("aggreports.output_sample_mean, self.sample_size is 0, not outputting any sample mean")
             return
-        epcalc = MEANSAMPLE
-
-        # outloss_sample has all SIDXs plus -2 and -3
-        reordered_outlosses_file = Path(self.lec_files_folder, f"lec_sample_mean-reordered_outlosses-{outloss_type}.bdat")
-        reordered_outlosses = np.memmap(
-            reordered_outlosses_file,
-            dtype=np.dtype([
-                ("row_used", np.bool_),
-                ("value", oasis_float),
-            ]),
-            mode="w+",
-            shape=(self.no_of_periods * self.max_summary_id),
-        )
-
-        # Select the correct outloss values based on type
-        # Required if-else condition as njit cannot resolve outloss_type inside []
-        if outloss_type == "agg_out_loss":
-            outloss_vals = self.outloss_sample["agg_out_loss"]
-        elif outloss_type == "max_out_loss":
-            outloss_vals = self.outloss_sample["max_out_loss"]
-        else:
+        if outloss_type not in ("agg_out_loss", "max_out_loss"):
             raise ValueError(f"Error: Unknown outloss_type: {outloss_type}")
+        outloss_vals = self.outloss_sample[outloss_type]
+        reordered_outlosses = np.memmap(
+            Path(self.lec_files_folder, f"lec_sample_mean-reordered_outlosses-{outloss_type}.bdat"),
+            dtype=np.dtype([("row_used", np.bool_), ("value", oasis_float)]),
+            mode="w+",
+            shape=(self.config.no_of_periods * self.config.max_summary_id),
+        )
+        items_path = Path(self.lec_files_folder, f"lec_sample_mean-{outloss_type}-items.bdat")
 
-        row_used_indices = self.row_used_indices_sample
-
-        # Reorder outlosses by summary_id and period_no
-        reorder_losses_by_summary_and_period(
-            reordered_outlosses,
-            row_used_indices,
-            outloss_vals,
-            self.max_summary_id,
-            self.no_of_periods,
-            self.num_sidxs,
-            self.sample_size,
+        def alloc_items(size): return np.memmap(
+            items_path, dtype=LOSSVEC2MAP_dtype, mode="w+", shape=(size,)
+        )
+        _write_sample_mean(
+            reordered_outlosses, self.row_used_indices_sample, outloss_vals,
+            self.config, eptype, eptype_tvar, alloc_items, self.output_data,
         )
 
-        # Get row indices that are used
-        row_used_indices = np.flatnonzero(reordered_outlosses["row_used"])
 
-        # Allocate storage for the flat data array
-        items_fp = Path(self.lec_files_folder, f"lec_sample_mean-{outloss_type}-items.bdat")
-        items = np.memmap(items_fp, dtype=LOSSVEC2MAP_dtype, mode="w+", shape=(len(row_used_indices),))
-        # Track start and end indices for each summary_id
-        items_start_end = np.full((self.max_summary_id, 2), -1, dtype=np.int32)
+# ---------------------------------------------------------------------------
+# Idx path — output_for_summary_idx
+# Allocates small np.zeros arrays (single summary at a time), calls the same helpers.
+# ---------------------------------------------------------------------------
 
-        # Populate items and items_start_end
-        has_weights, used_period_no = output_sample_mean(
-            items,
-            items_start_end,
-            row_used_indices,
-            reordered_outlosses["value"],
-            self.period_weights,
-            self.max_summary_id,
-            self.no_of_periods,
-        )
-        unused_period_weights = self.period_weights[~used_period_no]
+def output_for_summary_idx(
+    summary_id,
+    outloss_mean_s,
+    row_used_mean_s,
+    outloss_sample_s,
+    row_used_sample_s,
+    output_flags,
+    hasOCC,
+    hasAGG,
+    outmap,
+    config,
+    output_fn,
+):
+    """Output all report types for a single summary_id (idx path).
 
-        if has_weights:
-            gen = write_ept_weighted(
-                items,
-                items_start_end,
-                self.sample_size,
-                epcalc,
-                eptype,
-                eptype_tvar,
-                unused_period_weights,
-                self.use_return_period,
-                self.returnperiods,
-                self.max_summary_id
+    Called once per summary_id. config.max_summary_id must be 1; arrays are sized
+    for a single summary. Write generators emit SummaryId=1, corrected here before each write.
+    """
+    row_used_indices_mean = np.flatnonzero(row_used_mean_s)
+    row_used_indices_sample = np.flatnonzero(row_used_sample_s)
+    if not len(row_used_indices_mean) and not len(row_used_indices_sample):
+        return
+
+    def _out(data, out_type):
+        if len(data):
+            data["SummaryId"] = summary_id
+        output_fn(data, out_type)
+
+    if outmap["ept"]["compute"] and (hasOCC or hasAGG):
+        for eptype, eptype_tvar, outloss_type, wanted in (
+            (OEP, OEPTVAR, "max_out_loss", hasOCC),
+            (AEP, AEPTVAR, "agg_out_loss", hasAGG),
+        ):
+            if not wanted:
+                continue
+            items = np.zeros(len(row_used_indices_mean), dtype=LOSSVEC2MAP_dtype)
+            items_start_end = np.full((1, 2), -1, dtype=np.int32)
+            _write_mean_damage_ratio(
+                items, items_start_end, row_used_indices_mean,
+                outloss_mean_s[outloss_type], config, eptype, eptype_tvar, _out,
             )
-        else:
-            gen = write_ept(
-                items,
-                items_start_end,
-                self.no_of_periods,
-                epcalc,
-                eptype,
-                eptype_tvar,
-                self.use_return_period,
-                self.returnperiods,
-                self.max_summary_id
-            )
 
-        for data in gen:
-            self.output_data(data, "ept")
-
-    def output_for_summary(
-        self,
-        summary_id,
-        outloss_mean_s,
-        row_used_mean_s,
-        outloss_sample_s,
-        row_used_sample_s,
-        output_flags,
-        hasOCC,
-        hasAGG,
+    for flag, eptype, eptype_tvar, outloss_type in (
+        (OCC_FULL_UNCERTAINTY, OEP, OEPTVAR, "max_out_loss"),
+        (AGG_FULL_UNCERTAINTY, AEP, AEPTVAR, "agg_out_loss"),
     ):
-        """Output all report types for a single summary_id using per-summary arrays.
+        if not output_flags[flag]:
+            continue
+        items = np.zeros(len(row_used_indices_sample), dtype=LOSSVEC2MAP_dtype)
+        items_start_end = np.full((1, 2), -1, dtype=np.int32)
+        _write_full_uncertainty(
+            items, items_start_end, row_used_indices_sample,
+            outloss_sample_s[outloss_type], config, eptype, eptype_tvar, _out,
+        )
 
-        Called only in the idx path. Receives fresh per-summary arrays as explicit
-        arguments and writes directly to output; does not use any pre-computed state
-        from __init__ (self.outloss_mean, self.row_used_indices_*, self.max_summary_id).
+    for flag_w, flag_wm, eptype, eptype_tvar, outloss_type in (
+        (OCC_WHEATSHEAF, OCC_WHEATSHEAF_MEAN, OEP, OEPTVAR, "max_out_loss"),
+        (AGG_WHEATSHEAF, AGG_WHEATSHEAF_MEAN, AEP, AEPTVAR, "agg_out_loss"),
+    ):
+        do_wheat = output_flags[flag_w]
+        do_wheat_mean = output_flags[flag_wm]
+        if not (do_wheat or do_wheat_mean):
+            continue
+        wheatsheaf_items = np.zeros(len(row_used_indices_sample), dtype=WHEATKEYITEMS_dtype)
+        wheatsheaf_items_start_end = np.full((config.num_sidxs, 2), -1, dtype=np.int32)
+        mean_map = np.zeros((1, len(config.returnperiods)), dtype=MEANMAP_dtype) if do_wheat_mean else None
+        _write_wheatsheaf(
+            wheatsheaf_items, wheatsheaf_items_start_end, mean_map,
+            row_used_indices_sample, outloss_sample_s[outloss_type],
+            config, eptype, eptype_tvar, do_wheat, do_wheat_mean,
+            lambda size: np.zeros(size, dtype=LOSSVEC2MAP_dtype),
+            _out,
+        )
 
-        All internal calls use max_summary_id=1 so the numba index functions collapse
-        to zero-based offsets into the single-summary arrays. The write generators
-        therefore emit SummaryId=1, which is corrected inline to the real summary_id
-        before each write.
-        """
-        row_used_indices_mean   = np.flatnonzero(row_used_mean_s)
-        row_used_indices_sample = np.flatnonzero(row_used_sample_s)
-
-        if not len(row_used_indices_mean) and not len(row_used_indices_sample):
-            return
-
-        def _output(gen, out_type):
-            for data in gen:
-                if len(data):
-                    data["SummaryId"] = summary_id
-                self.output_data(data, out_type)
-
-        # ── Mean Damage Ratio ──────────────────────────────────────────────────
-        if self.outmap["ept"]["compute"] and (hasOCC or hasAGG):
-            for eptype, eptype_tvar, outloss_type, wanted in (
-                (OEP, OEPTVAR, "max_out_loss", hasOCC),
-                (AEP, AEPTVAR, "agg_out_loss", hasAGG),
-            ):
-                if not wanted:
-                    continue
-                items = np.zeros(len(row_used_indices_mean), dtype=LOSSVEC2MAP_dtype)
-                items_start_end = np.full((1, 2), -1, dtype=np.int32)
-                has_weights, used_period_no = output_mean_damage_ratio(
-                    items, items_start_end, row_used_indices_mean,
-                    outloss_mean_s[outloss_type], self.period_weights, 1,
-                )
-                unused_pw = self.period_weights[~used_period_no]
-                if has_weights:
-                    _output(write_ept_weighted(items, items_start_end, self.sample_size,
-                                               MEANDR, eptype, eptype_tvar, unused_pw,
-                                               self.use_return_period, self.returnperiods, 1), "ept")
-                else:
-                    _output(write_ept(items, items_start_end, self.no_of_periods,
-                                      MEANDR, eptype, eptype_tvar,
-                                      self.use_return_period, self.returnperiods, 1), "ept")
-
-        # ── Full Uncertainty ───────────────────────────────────────────────────
-        for flag, eptype, eptype_tvar, outloss_type in (
-            (OCC_FULL_UNCERTAINTY, OEP, OEPTVAR, "max_out_loss"),
-            (AGG_FULL_UNCERTAINTY, AEP, AEPTVAR, "agg_out_loss"),
-        ):
-            if not output_flags[flag]:
-                continue
-            items = np.zeros(len(row_used_indices_sample), dtype=LOSSVEC2MAP_dtype)
-            items_start_end = np.full((1, 2), -1, dtype=np.int32)
-            has_weights, used_period_no = output_full_uncertainty(
-                items, items_start_end, row_used_indices_sample,
-                outloss_sample_s[outloss_type], self.period_weights, 1, self.num_sidxs,
-            )
-            unused_pw = self.period_weights[~used_period_no]
-            if has_weights:
-                _output(write_ept_weighted(items, items_start_end, 1,
-                                           FULL, eptype, eptype_tvar, unused_pw,
-                                           self.use_return_period, self.returnperiods, 1), "ept")
-            else:
-                _output(write_ept(items, items_start_end, self.no_of_periods * self.sample_size,
-                                  FULL, eptype, eptype_tvar,
-                                  self.use_return_period, self.returnperiods, 1), "ept")
-
-        # ── Wheatsheaf & Wheatsheaf Mean ───────────────────────────────────────
-        for flag_w, flag_wm, eptype, eptype_tvar, outloss_type in (
-            (OCC_WHEATSHEAF, OCC_WHEATSHEAF_MEAN, OEP, OEPTVAR, "max_out_loss"),
-            (AGG_WHEATSHEAF, AGG_WHEATSHEAF_MEAN, AEP, AEPTVAR, "agg_out_loss"),
-        ):
-            do_wheat      = output_flags[flag_w]
-            do_wheat_mean = output_flags[flag_wm]
-            if not (do_wheat or do_wheat_mean):
-                continue
-
-            wheatsheaf_items = np.zeros(len(row_used_indices_sample), dtype=WHEATKEYITEMS_dtype)
-            wheatsheaf_items_start_end = np.full((self.num_sidxs, 2), -1, dtype=np.int32)
-            has_weights, used_period_no = fill_wheatsheaf_items(
-                wheatsheaf_items, wheatsheaf_items_start_end, row_used_indices_sample,
-                outloss_sample_s[outloss_type], self.period_weights, 1, self.num_sidxs,
-            )
-            unused_pw = self.period_weights[~used_period_no]
-
-            if has_weights:
-                mean_map = None
-                if do_wheat_mean:
-                    mean_map = np.zeros((1, len(self.returnperiods)), dtype=MEANMAP_dtype)
-                if do_wheat:
-                    _output(write_psept_weighted(
-                        wheatsheaf_items, wheatsheaf_items_start_end, self.no_of_periods,
-                        eptype, eptype_tvar, unused_pw, self.use_return_period, self.returnperiods,
-                        1, self.num_sidxs, self.sample_size, mean_map=mean_map,
-                    ), "psept")
-                if do_wheat_mean and mean_map is not None:
-                    _output(write_wheatsheaf_mean(mean_map, eptype, PERSAMPLEMEAN, 1), "ept")
-            else:
-                if do_wheat:
-                    _output(write_psept(
-                        wheatsheaf_items, wheatsheaf_items_start_end, self.no_of_periods,
-                        eptype, eptype_tvar, self.use_return_period, self.returnperiods,
-                        1, self.num_sidxs,
-                    ), "psept")
-                if do_wheat_mean:
-                    maxcounts = get_wheatsheaf_max_count(
-                        wheatsheaf_items, wheatsheaf_items_start_end, 1)
-                    if np.any(maxcounts != -1):
-                        wheatsheaf_mean_items = np.zeros(
-                            np.sum(maxcounts[maxcounts != -1]), dtype=LOSSVEC2MAP_dtype)
-                        wheatsheaf_mean_items_start_end = fill_wheatsheaf_mean_items(
-                            wheatsheaf_mean_items, wheatsheaf_items, wheatsheaf_items_start_end,
-                            maxcounts, 1, self.num_sidxs,
-                        )
-                        _output(write_ept(
-                            wheatsheaf_mean_items, wheatsheaf_mean_items_start_end,
-                            self.no_of_periods, PERSAMPLEMEAN, eptype, eptype_tvar,
-                            self.use_return_period, self.returnperiods, 1,
-                            sample_size=self.sample_size,
-                        ), "ept")
-
-        # ── Sample Mean ────────────────────────────────────────────────────────
-        if self.sample_size == 0:
-            return
-        for flag, eptype, eptype_tvar, outloss_type in (
-            (OCC_SAMPLE_MEAN, OEP, OEPTVAR, "max_out_loss"),
-            (AGG_SAMPLE_MEAN, AEP, AEPTVAR, "agg_out_loss"),
-        ):
-            if not output_flags[flag]:
-                continue
-            reordered = np.zeros(
-                self.no_of_periods,
-                dtype=np.dtype([("row_used", np.bool_), ("value", oasis_float)]),
-            )
-            reorder_losses_by_summary_and_period(
-                reordered, row_used_indices_sample, outloss_sample_s[outloss_type],
-                1, self.no_of_periods, self.num_sidxs, self.sample_size,
-            )
-            row_used_ro = np.flatnonzero(reordered["row_used"])
-            items = np.zeros(len(row_used_ro), dtype=LOSSVEC2MAP_dtype)
-            items_start_end = np.full((1, 2), -1, dtype=np.int32)
-            has_weights, used_period_no = output_sample_mean(
-                items, items_start_end, row_used_ro, reordered["value"],
-                self.period_weights, 1, self.no_of_periods,
-            )
-            unused_pw = self.period_weights[~used_period_no]
-            if has_weights:
-                _output(write_ept_weighted(items, items_start_end, self.sample_size,
-                                           MEANSAMPLE, eptype, eptype_tvar, unused_pw,
-                                           self.use_return_period, self.returnperiods, 1), "ept")
-            else:
-                _output(write_ept(items, items_start_end, self.no_of_periods,
-                                  MEANSAMPLE, eptype, eptype_tvar,
-                                  self.use_return_period, self.returnperiods, 1), "ept")
+    if config.sample_size == 0:
+        return
+    for flag, eptype, eptype_tvar, outloss_type in (
+        (OCC_SAMPLE_MEAN, OEP, OEPTVAR, "max_out_loss"),
+        (AGG_SAMPLE_MEAN, AEP, AEPTVAR, "agg_out_loss"),
+    ):
+        if not output_flags[flag]:
+            continue
+        reordered = np.zeros(
+            config.no_of_periods,
+            dtype=np.dtype([("row_used", np.bool_), ("value", oasis_float)]),
+        )
+        _write_sample_mean(
+            reordered, row_used_indices_sample, outloss_sample_s[outloss_type],
+            config, eptype, eptype_tvar,
+            lambda size: np.zeros(size, dtype=LOSSVEC2MAP_dtype),
+            _out,
+        )

--- a/oasislmf/pytools/lec/aggreports/aggreports.py
+++ b/oasislmf/pytools/lec/aggreports/aggreports.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 
-from oasislmf.pytools.common.data import oasis_float, write_ndarray_to_fmt_csv
+from oasislmf.pytools.common.data import oasis_float, periods_dtype, write_ndarray_to_fmt_csv
 from oasislmf.pytools.lec.aggreports.outputs.full_uncertainty import output_full_uncertainty
 from oasislmf.pytools.lec.aggreports.outputs.mean_damage_ratio import output_mean_damage_ratio
 from oasislmf.pytools.lec.aggreports.outputs.sample_mean import output_sample_mean, reorder_losses_by_summary_and_period
@@ -17,7 +17,7 @@ from oasislmf.pytools.lec.data import (
     FULL, MEANDR, MEANSAMPLE, OCC_FULL_UNCERTAINTY, OCC_SAMPLE_MEAN, OCC_WHEATSHEAF,
     OCC_WHEATSHEAF_MEAN, OEP, OEPTVAR, PERSAMPLEMEAN,
 )
-from oasislmf.pytools.lec.data import LOSSVEC2MAP_dtype, MEANMAP_dtype, WHEATKEYITEMS_dtype
+from oasislmf.pytools.lec.data import LOSSVEC2MAP_dtype, MEANMAP_dtype, WHEATKEYITEMS_dtype, EPT_dtype, PSEPT_dtype
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +32,21 @@ class LecConfig:
     num_sidxs: int
     use_return_period: bool
     returnperiods: np.ndarray
+    # Reusable output buffers, allocated once per run and shared across all generator
+    # calls (the write_* generators fully overwrite each row before yielding, so no
+    # re-zeroing is needed). Avoids a ~19 MB allocation on every per-summary call.
+    ept_buffer: np.ndarray   # must have dtype EPT_dtype
+    psept_buffer: np.ndarray  # must have dtype PSEPT_dtype
+
+    def __post_init__(self):
+        if self.period_weights.dtype != periods_dtype:
+            raise TypeError(f"period_weights dtype must be {periods_dtype}, got {self.period_weights.dtype}")
+        if self.returnperiods is not None and self.returnperiods.dtype != np.dtype('i4'):
+            raise TypeError(f"returnperiods dtype must be int32, got {self.returnperiods.dtype}")
+        if self.ept_buffer.dtype != EPT_dtype:
+            raise TypeError(f"ept_buffer dtype must be {EPT_dtype}, got {self.ept_buffer.dtype}")
+        if self.psept_buffer.dtype != PSEPT_dtype:
+            raise TypeError(f"psept_buffer dtype must be {PSEPT_dtype}, got {self.psept_buffer.dtype}")
 
 
 def make_output_fn(outmap, output_binary, output_parquet):
@@ -69,12 +84,14 @@ def _write_mean_damage_ratio(
     unused_pw = config.period_weights[~used_period_no]
     if has_weights:
         gen = write_ept_weighted(
+            config.ept_buffer,
             items, items_start_end, config.sample_size, MEANDR,
             eptype, eptype_tvar, unused_pw,
             config.use_return_period, config.returnperiods, config.max_summary_id,
         )
     else:
         gen = write_ept(
+            config.ept_buffer,
             items, items_start_end, config.no_of_periods, MEANDR,
             eptype, eptype_tvar,
             config.use_return_period, config.returnperiods, config.max_summary_id,
@@ -94,12 +111,14 @@ def _write_full_uncertainty(
     unused_pw = config.period_weights[~used_period_no]
     if has_weights:
         gen = write_ept_weighted(
+            config.ept_buffer,
             items, items_start_end, 1, FULL,
             eptype, eptype_tvar, unused_pw,
             config.use_return_period, config.returnperiods, config.max_summary_id,
         )
     else:
         gen = write_ept(
+            config.ept_buffer,
             items, items_start_end, config.no_of_periods * config.sample_size, FULL,
             eptype, eptype_tvar,
             config.use_return_period, config.returnperiods, config.max_summary_id,
@@ -123,6 +142,7 @@ def _write_wheatsheaf(
     if has_weights:
         if do_wheat:
             gen = write_psept_weighted(
+                config.psept_buffer,
                 wheatsheaf_items, wheatsheaf_items_start_end, config.no_of_periods,
                 eptype, eptype_tvar, unused_pw,
                 config.use_return_period, config.returnperiods,
@@ -131,12 +151,13 @@ def _write_wheatsheaf(
             for data in gen:
                 output_fn(data, "psept")
         if do_wheat_mean and mean_map is not None:
-            gen = write_wheatsheaf_mean(mean_map, eptype, PERSAMPLEMEAN, config.max_summary_id)
+            gen = write_wheatsheaf_mean(config.ept_buffer, mean_map, eptype, PERSAMPLEMEAN, config.max_summary_id)
             for data in gen:
                 output_fn(data, "ept")
     else:
         if do_wheat:
             gen = write_psept(
+                config.psept_buffer,
                 wheatsheaf_items, wheatsheaf_items_start_end, config.no_of_periods,
                 eptype, eptype_tvar,
                 config.use_return_period, config.returnperiods,
@@ -154,6 +175,7 @@ def _write_wheatsheaf(
                     maxcounts, config.max_summary_id, config.num_sidxs,
                 )
                 gen = write_ept(
+                    config.ept_buffer,
                     wm_items, wm_items_start_end, config.no_of_periods,
                     PERSAMPLEMEAN, eptype, eptype_tvar,
                     config.use_return_period, config.returnperiods, config.max_summary_id,
@@ -182,12 +204,14 @@ def _write_sample_mean(
     unused_pw = config.period_weights[~used_period_no]
     if has_weights:
         gen = write_ept_weighted(
+            config.ept_buffer,
             items, items_start_end, config.sample_size, MEANSAMPLE,
             eptype, eptype_tvar, unused_pw,
             config.use_return_period, config.returnperiods, config.max_summary_id,
         )
     else:
         gen = write_ept(
+            config.ept_buffer,
             items, items_start_end, config.no_of_periods, MEANSAMPLE,
             eptype, eptype_tvar,
             config.use_return_period, config.returnperiods, config.max_summary_id,

--- a/oasislmf/pytools/lec/aggreports/write_tables.py
+++ b/oasislmf/pytools/lec/aggreports/write_tables.py
@@ -1,7 +1,6 @@
 import numba as nb
 import numpy as np
 
-from oasislmf.pytools.common.data import DEFAULT_BUFFER_SIZE
 from oasislmf.pytools.lec.data import (EPT_dtype, PSEPT_dtype, TAIL_valtype)
 from oasislmf.pytools.lec.utils import (get_wheatsheaf_items_idx, get_wheatsheaf_items_idx_data)
 
@@ -292,6 +291,7 @@ def write_tvar_wheatsheaf(
 
 @nb.njit(cache=True, error_model="numpy")
 def write_ept(
+    buffer,
     items,
     items_start_end,
     max_retperiod,
@@ -323,7 +323,6 @@ def write_ept(
     Yields:
         buffer (ndarray[EPT_dtype]): Buffered chunks of EPT data
     """
-    buffer = np.zeros(DEFAULT_BUFFER_SIZE, dtype=EPT_dtype)
     bidx = 0
 
     if len(items) == 0 or sample_size == 0:
@@ -472,6 +471,7 @@ def write_ept(
 
 @nb.njit(cache=True, error_model="numpy")
 def write_ept_weighted(
+    buffer,
     items,
     items_start_end,
     cum_weight_constant,
@@ -509,7 +509,6 @@ def write_ept_weighted(
     Yields:
         buffer (ndarray[EPT_dtype]): Buffered chunks of EPT data
     """
-    buffer = np.zeros(DEFAULT_BUFFER_SIZE, dtype=EPT_dtype)
     bidx = 0
 
     if len(items) == 0 or sample_size == 0:
@@ -674,6 +673,7 @@ def write_ept_weighted(
 
 @nb.njit(cache=True, error_model="numpy")
 def write_psept(
+    buffer,
     items,
     items_start_end,
     max_retperiod,
@@ -699,7 +699,6 @@ def write_psept(
     Yields:
         buffer (ndarray[PSEPT_dtype]): Buffered chunks of PSEPT data
     """
-    buffer = np.zeros(DEFAULT_BUFFER_SIZE, dtype=PSEPT_dtype)
     bidx = 0
 
     if len(items) == 0:
@@ -854,6 +853,7 @@ def write_psept(
 
 @nb.njit(cache=True, error_model="numpy")
 def write_psept_weighted(
+    buffer,
     items,
     items_start_end,
     max_retperiod,
@@ -885,7 +885,6 @@ def write_psept_weighted(
     Yields:
         buffer (ndarray[PSEPT_dtype]): Buffered chunks of PSEPT data
     """
-    buffer = np.zeros(DEFAULT_BUFFER_SIZE, dtype=PSEPT_dtype)
     bidx = 0
 
     if len(items) == 0:
@@ -1058,6 +1057,7 @@ def write_psept_weighted(
 
 @nb.njit(cache=True, error_model="numpy")
 def write_wheatsheaf_mean(
+    buffer,
     mean_map,
     eptype,
     epcalc,
@@ -1076,7 +1076,6 @@ def write_wheatsheaf_mean(
     if len(mean_map) == 0:
         return
 
-    buffer = np.zeros(DEFAULT_BUFFER_SIZE, dtype=EPT_dtype)
     bidx = 0
 
     for summary_id in range(1, max_summary_id + 1):

--- a/oasislmf/pytools/lec/manager.py
+++ b/oasislmf/pytools/lec/manager.py
@@ -560,7 +560,7 @@ def run(
             return  # skip sequential path below
 
         # ── Sequential path (no .idx files) ──────────────────────────────────────
-        
+
         # Check required disk space for work bdat files
         num_sidxs = int(sample_size) + 2
         no_of_periods = int(file_data["no_of_periods"])

--- a/oasislmf/pytools/lec/manager.py
+++ b/oasislmf/pytools/lec/manager.py
@@ -16,7 +16,7 @@ from oasislmf.pytools.common.input_files import PERIODS_FILE, read_occurrence, r
 from oasislmf.pytools.lec.data import (AEP, AEPTVAR, AGG_FULL_UNCERTAINTY, AGG_SAMPLE_MEAN, AGG_WHEATSHEAF, AGG_WHEATSHEAF_MEAN,
                                        OCC_FULL_UNCERTAINTY, OCC_SAMPLE_MEAN, OCC_WHEATSHEAF, OCC_WHEATSHEAF_MEAN, OEP, OEPTVAR,
                                        OUTLOSS_DTYPE, EPT_dtype, EPT_fmt, EPT_headers, PSEPT_dtype, PSEPT_fmt, PSEPT_headers)
-from oasislmf.pytools.lec.aggreports import AggReports
+from oasislmf.pytools.lec.aggreports import AggReports, LecConfig, make_output_fn, output_for_summary_idx
 from oasislmf.pytools.lec.utils import get_outloss_mean_idx, get_outloss_sample_idx
 from oasislmf.pytools.utils import redirect_logging
 
@@ -222,7 +222,6 @@ def process_input_file(
     row_used_mean,
     outloss_sample,
     row_used_sample,
-    summary_ids,
     occ_map,
     use_return_period,
     num_sidxs,
@@ -235,7 +234,6 @@ def process_input_file(
         row_used_mean (ndarray[bool]): bool mask for outloss_mean
         outloss_sample (ndarray[OUTLOSS_DTYPE]): ndarray indexed by summary_id, sidx, period_no containing aggregate and max losses
         row_used_sample (ndarray[bool]): bool mask for outloss_sample
-        summary_ids (ndarray[bool]): bool array marking which summary_ids are used
         occ_map (nb.typed.Dict): numpy map of event_id, period_no, occ_date_id from the occurrence file
         use_return_period (bool): Use Return Period file.
         num_sidxs (int): Number of sidxs to consider for outloss_sample
@@ -244,7 +242,6 @@ def process_input_file(
     # Set cursor to end of stream header (stream_type, sample_size, summary_set_id)
     cursor = oasis_int_size * 3
 
-    # Read all samples
     valid_buff = len(fin)
     while cursor < valid_buff:
         event_id, cursor = mv_read(fin, cursor, oasis_int, oasis_int_size)
@@ -261,7 +258,6 @@ def process_input_file(
             continue
 
         filtered_occ_map = occ_map[event_id]
-        summary_ids[summary_id - 1] = True
 
         while cursor < valid_buff:
             sidx, cursor = mv_read(fin, cursor, oasis_int, oasis_int_size)
@@ -292,7 +288,6 @@ def run_lec(
     row_used_mean,
     outloss_sample,
     row_used_sample,
-    summary_ids,
     occ_map,
     use_return_period,
     num_sidxs,
@@ -305,7 +300,6 @@ def run_lec(
         row_used_mean (ndarray[bool]): bool mask for outloss_mean
         outloss_sample (ndarray[OUTLOSS_DTYPE]): ndarray indexed by summary_id, sidx, period_no containing aggregate and max losses
         row_used_sample (ndarray[bool]): bool mask for outloss_sample
-        summary_ids (ndarray[bool]): bool array marking which summary_ids are used
         occ_map (nb.typed.Dict): numpy map of event_id, period_no, occ_date_id from the occurrence file
         use_return_period (bool): Use Return Period file.
         num_sidxs (int): Number of sidxs to consider for outloss_sample
@@ -318,12 +312,35 @@ def run_lec(
             row_used_mean,
             outloss_sample,
             row_used_sample,
-            summary_ids,
             occ_map,
             use_return_period,
             num_sidxs,
             max_summary_id,
         )
+
+
+def _open_output_files(outmap, stack, output_binary, output_parquet, noheader):
+    if output_binary:
+        for out_type in outmap:
+            if not outmap[out_type]["compute"]:
+                continue
+            outmap[out_type]["file"] = stack.enter_context(open(outmap[out_type]["file_path"], 'wb'))
+    elif output_parquet:
+        for out_type in outmap:
+            if not outmap[out_type]["compute"]:
+                continue
+            temp_out_data = np.zeros(DEFAULT_BUFFER_SIZE, dtype=outmap[out_type]["dtype"])
+            temp_df = pd.DataFrame(temp_out_data, columns=outmap[out_type]["headers"])
+            temp_table = pa.Table.from_pandas(temp_df)
+            outmap[out_type]["file"] = pq.ParquetWriter(outmap[out_type]["file_path"], temp_table.schema)
+    else:
+        for out_type in outmap:
+            if not outmap[out_type]["compute"]:
+                continue
+            out_file = stack.enter_context(open(outmap[out_type]["file_path"], 'w'))
+            if not noheader:
+                out_file.write(','.join(outmap[out_type]["headers"]) + '\n')
+            outmap[out_type]["file"] = out_file
 
 
 def run(
@@ -424,6 +441,8 @@ def run(
             else:
                 idx_handles_raw.append(None)
         n_idx = sum(h is not None for h in idx_handles_raw)
+        # All files must have .idx: the merged index covers all files simultaneously,
+        # so a gap would silently drop events from the missing file.
         use_idx_path = n_idx == len(files) and n_idx > 0
         if use_idx_path:
             logger.info("Found %d/%d .idx file(s) — using per-summary-id indexing (reduced disk)", n_idx, len(files))
@@ -484,55 +503,27 @@ def run(
             no_of_periods = int(file_data["no_of_periods"])
 
             # Open output files before the loop so headers are written once
-            if output_binary:
-                for out_type in outmap:
-                    if not outmap[out_type]["compute"]:
-                        continue
-                    out_file = stack.enter_context(open(outmap[out_type]["file_path"], 'wb'))
-                    outmap[out_type]["file"] = out_file
-            elif output_parquet:
-                for out_type in outmap:
-                    if not outmap[out_type]["compute"]:
-                        continue
-                    temp_out_data = np.zeros(DEFAULT_BUFFER_SIZE, dtype=outmap[out_type]["dtype"])
-                    temp_df = pd.DataFrame(temp_out_data, columns=outmap[out_type]["headers"])
-                    temp_table = pa.Table.from_pandas(temp_df)
-                    out_file = pq.ParquetWriter(outmap[out_type]["file_path"], temp_table.schema)
-                    outmap[out_type]["file"] = out_file
-            else:
-                for out_type in outmap:
-                    if not outmap[out_type]["compute"]:
-                        continue
-                    out_file = stack.enter_context(open(outmap[out_type]["file_path"], 'w'))
-                    if not noheader:
-                        out_file.write(','.join(outmap[out_type]["headers"]) + '\n')
-                    outmap[out_type]["file"] = out_file
+            _open_output_files(outmap, stack, output_binary, output_parquet, noheader)
 
-            # In the idx path only output_for_summary is ever called on this instance.
-            # That method takes per-summary arrays as explicit arguments and never reads
-            # self.outloss_mean, self.outloss_sample, self.row_used_indices_mean, or
-            # self.row_used_indices_sample — so the arrays passed here are unused
-            # placeholders that satisfy the constructor signature. max_summary_id=1
-            # is also passed as a placeholder; output_for_summary hardcodes 1 directly.
-            _d_mean = np.zeros(no_of_periods, dtype=OUTLOSS_DTYPE)
-            _d_rw_m = np.zeros(no_of_periods, dtype=np.bool_)
-            _d_samp = np.zeros(no_of_periods * num_sidxs, dtype=OUTLOSS_DTYPE)
-            _d_rw_s = np.zeros(no_of_periods * num_sidxs, dtype=np.bool_)
-            agg = AggReports(
-                outmap, _d_mean, _d_rw_m, _d_samp, _d_rw_s,
-                file_data["period_weights"], 1, sample_size, no_of_periods, num_sidxs,
-                use_return_period, file_data["returnperiods"], lec_files_folder,
-                output_binary, output_parquet,
+            idx_config = LecConfig(
+                period_weights=file_data["period_weights"],
+                max_summary_id=1,
+                sample_size=int(sample_size),
+                no_of_periods=no_of_periods,
+                num_sidxs=num_sidxs,
+                use_return_period=use_return_period,
+                returnperiods=file_data["returnperiods"],
             )
+            output_fn = make_output_fn(outmap, output_binary, output_parquet)
 
             # Per-summary arrays — no × max_summary_id factor
-            outloss_mean_s   = np.zeros(no_of_periods,             dtype=OUTLOSS_DTYPE)
+            outloss_mean_s = np.zeros(no_of_periods, dtype=OUTLOSS_DTYPE)
             outloss_sample_s = np.zeros(no_of_periods * num_sidxs, dtype=OUTLOSS_DTYPE)
-            row_used_mean_s   = np.zeros(no_of_periods,             dtype=np.bool_)
+            row_used_mean_s = np.zeros(no_of_periods, dtype=np.bool_)
             row_used_sample_s = np.zeros(no_of_periods * num_sidxs, dtype=np.bool_)
 
             # Pre-compute uint8 views once — numpy's struct[:]=0 is ~4x slower than raw byte zeroing
-            _mean_bytes   = outloss_mean_s.view(np.uint8)
+            _mean_bytes = outloss_mean_s.view(np.uint8)
             _sample_bytes = outloss_sample_s.view(np.uint8)
 
             for summary_id in unique_summary_ids:
@@ -558,16 +549,16 @@ def run(
                         num_sidxs,
                     )
 
-                agg.output_for_summary(
+                output_for_summary_idx(
                     int(summary_id),
                     outloss_mean_s, row_used_mean_s,
                     outloss_sample_s, row_used_sample_s,
                     output_flags, hasOCC, hasAGG,
+                    outmap=outmap, config=idx_config, output_fn=output_fn,
                 )
             return  # skip sequential path below
 
         # ── Sequential path (no .idx files) ──────────────────────────────────────
-        # Create outloss array maps
         # outloss_mean has only -1 SIDX
         outloss_mean_file = Path(lec_files_folder, "lec_outloss_mean.bdat")
         outloss_mean = np.memmap(
@@ -592,17 +583,13 @@ def run(
         row_used_sample_file = Path(lec_files_folder, "lec_row_used_sample.bdat")
         row_used_sample = np.memmap(row_used_sample_file, dtype=np.bool_, mode="w+", shape=(len(outloss_sample),))
 
-        # Array of Summary IDs found
-        summary_ids = np.zeros((max_summary_id), dtype=np.bool_)
-
-        # Run LEC calculations to populate outloss and summary_ids arrays
+        # Run LEC calculations to populate outloss arrays
         run_lec(
             file_handles,
             outloss_mean,
             row_used_mean,
             outloss_sample,
             row_used_sample,
-            summary_ids,
             file_data["occ_map"],
             use_return_period,
             num_sidxs,
@@ -610,45 +597,23 @@ def run(
         )
 
         # Initialise output files LEC
-        if output_binary:
-            for out_type in outmap:
-                if not outmap[out_type]["compute"]:
-                    continue
-                out_file = stack.enter_context(open(outmap[out_type]["file_path"], 'wb'))
-                outmap[out_type]["file"] = out_file
-        elif output_parquet:
-            for out_type in outmap:
-                if not outmap[out_type]["compute"]:
-                    continue
-                temp_out_data = np.zeros(DEFAULT_BUFFER_SIZE, dtype=outmap[out_type]["dtype"])
-                temp_df = pd.DataFrame(temp_out_data, columns=outmap[out_type]["headers"])
-                temp_table = pa.Table.from_pandas(temp_df)
-                out_file = pq.ParquetWriter(outmap[out_type]["file_path"], temp_table.schema)
-                outmap[out_type]["file"] = out_file
-        else:
-            for out_type in outmap:
-                if not outmap[out_type]["compute"]:
-                    continue
-                out_file = stack.enter_context(open(outmap[out_type]["file_path"], 'w'))
-                if not noheader:
-                    csv_headers = ','.join(outmap[out_type]["headers"])
-                    out_file.write(csv_headers + '\n')
-                outmap[out_type]["file"] = out_file
+        _open_output_files(outmap, stack, output_binary, output_parquet, noheader)
 
         # Output aggregate reports to CSVs
+        seq_config = LecConfig(
+            period_weights=file_data["period_weights"],
+            max_summary_id=max_summary_id,
+            sample_size=int(sample_size),
+            no_of_periods=int(file_data["no_of_periods"]),
+            num_sidxs=num_sidxs,
+            use_return_period=use_return_period,
+            returnperiods=file_data["returnperiods"],
+        )
         agg = AggReports(
             outmap,
-            outloss_mean,
-            row_used_mean,
-            outloss_sample,
-            row_used_sample,
-            file_data["period_weights"],
-            max_summary_id,
-            sample_size,
-            file_data["no_of_periods"],
-            num_sidxs,
-            use_return_period,
-            file_data["returnperiods"],
+            outloss_mean, row_used_mean,
+            outloss_sample, row_used_sample,
+            seq_config,
             lec_files_folder,
             output_binary,
             output_parquet,

--- a/oasislmf/pytools/lec/manager.py
+++ b/oasislmf/pytools/lec/manager.py
@@ -506,6 +506,10 @@ def run(
             # Open output files before the loop so headers are written once
             _open_output_files(outmap, stack, output_binary, output_parquet, noheader)
 
+            # Output buffers allocated once and reused across every per-summary generator
+            # call (the write_* generators overwrite each row before yielding, so no zeroing).
+            ept_buffer = np.empty(DEFAULT_BUFFER_SIZE, dtype=EPT_dtype)
+            psept_buffer = np.empty(DEFAULT_BUFFER_SIZE, dtype=PSEPT_dtype)
             idx_config = LecConfig(
                 period_weights=file_data["period_weights"],
                 max_summary_id=1,
@@ -514,6 +518,8 @@ def run(
                 num_sidxs=num_sidxs,
                 use_return_period=use_return_period,
                 returnperiods=file_data["returnperiods"],
+                ept_buffer=ept_buffer,
+                psept_buffer=psept_buffer,
             )
             output_fn = make_output_fn(outmap, output_binary, output_parquet)
 
@@ -622,6 +628,8 @@ def run(
         _open_output_files(outmap, stack, output_binary, output_parquet, noheader)
 
         # Output aggregate reports to CSVs
+        ept_buffer = np.empty(DEFAULT_BUFFER_SIZE, dtype=EPT_dtype)
+        psept_buffer = np.empty(DEFAULT_BUFFER_SIZE, dtype=PSEPT_dtype)
         seq_config = LecConfig(
             period_weights=file_data["period_weights"],
             max_summary_id=max_summary_id,
@@ -630,6 +638,8 @@ def run(
             num_sidxs=num_sidxs,
             use_return_period=use_return_period,
             returnperiods=file_data["returnperiods"],
+            ept_buffer=ept_buffer,
+            psept_buffer=psept_buffer,
         )
         agg = AggReports(
             outmap,

--- a/oasislmf/pytools/lec/manager.py
+++ b/oasislmf/pytools/lec/manager.py
@@ -1,6 +1,7 @@
 # lec/manager.py
 
 import logging
+import shutil
 import numpy as np
 import numba as nb
 from contextlib import ExitStack
@@ -559,23 +560,44 @@ def run(
             return  # skip sequential path below
 
         # ── Sequential path (no .idx files) ──────────────────────────────────────
+        
+        # Check required disk space for work bdat files
+        num_sidxs = int(sample_size) + 2
+        no_of_periods = int(file_data["no_of_periods"])
+        _mean_elems = no_of_periods * max_summary_id
+        _sample_elems = no_of_periods * num_sidxs * max_summary_id
+        _required_bytes = (
+            _mean_elems * OUTLOSS_DTYPE.itemsize
+            + _sample_elems * OUTLOSS_DTYPE.itemsize
+            + _mean_elems  # row_used_mean (bool_)
+            + _sample_elems  # row_used_sample (bool_)
+        )
+        _free_bytes = shutil.disk_usage(lec_files_folder).free
+        if _required_bytes > _free_bytes:
+            raise RuntimeError(
+                f"Insufficient disk space for lec .bdat files: "
+                f"{_required_bytes / 2**30:.2f} GiB required "
+                f"({no_of_periods} periods × {num_sidxs} sidxs × {max_summary_id} summary_ids), "
+                f"but only {_free_bytes / 2**30:.2f} GiB free at {lec_files_folder}. "
+                f"Run summarypy with -m to generate .idx files and avoid this pre-allocation."
+            )
+
         # outloss_mean has only -1 SIDX
         outloss_mean_file = Path(lec_files_folder, "lec_outloss_mean.bdat")
         outloss_mean = np.memmap(
             outloss_mean_file,
             dtype=OUTLOSS_DTYPE,
             mode="w+",
-            shape=(int(file_data["no_of_periods"]) * max_summary_id),
+            shape=(_mean_elems),
         )
 
         # outloss_sample has all SIDXs plus -2 and -3
-        num_sidxs = int(sample_size) + 2
         outloss_sample_file = Path(lec_files_folder, "lec_outloss_sample.bdat")
         outloss_sample = np.memmap(
             outloss_sample_file,
             dtype=OUTLOSS_DTYPE,
             mode="w+",
-            shape=(int(file_data["no_of_periods"]) * num_sidxs * max_summary_id),
+            shape=(_sample_elems),
         )
 
         row_used_mean_file = Path(lec_files_folder, "lec_row_used_mean.bdat")

--- a/oasislmf/pytools/lec/manager.py
+++ b/oasislmf/pytools/lec/manager.py
@@ -9,7 +9,8 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from oasislmf.pytools.common.data import (DEFAULT_BUFFER_SIZE, oasis_int, oasis_float, oasis_int_size, oasis_float_size)
+from oasislmf.pytools.common.data import (DEFAULT_BUFFER_SIZE, oasis_int, oasis_float, oasis_int_size, oasis_float_size,
+                                          summary_stream_index_dtype)
 from oasislmf.pytools.common.event_stream import MAX_LOSS_IDX, MEAN_IDX, NUMBER_OF_AFFECTED_RISK_IDX, SUMMARY_STREAM_ID, init_streams_in, mv_read
 from oasislmf.pytools.common.input_files import PERIODS_FILE, read_occurrence, read_periods, read_returnperiods
 from oasislmf.pytools.lec.data import (AEP, AEPTVAR, AGG_FULL_UNCERTAINTY, AGG_SAMPLE_MEAN, AGG_WHEATSHEAF, AGG_WHEATSHEAF_MEAN,
@@ -143,6 +144,75 @@ def do_lec_output_agg_summary(
             if loss > outloss_sample[idx]["max_out_loss"]:
                 outloss_sample[idx]["max_out_loss"] = loss
             row_used_sample[idx] = True
+
+
+@nb.njit(cache=True, error_model="numpy")
+def process_summary_entries(
+    fin,
+    offsets,
+    occ_map,
+    use_return_period,
+    outloss_mean_s,
+    row_used_mean_s,
+    outloss_sample_s,
+    row_used_sample_s,
+    num_sidxs,
+):
+    """Process all indexed event blocks for one (summary_id, file) pair in a single call.
+
+    Eliminates per-event Python→numba overhead by looping over all offsets inside numba.
+    offsets should be sorted ascending for best OS page-cache utilisation.
+    """
+    valid_buff = len(fin)
+    for offset in offsets:
+        cursor = offset
+        event_id, cursor = mv_read(fin, cursor, oasis_int, oasis_int_size)
+        _, cursor = mv_read(fin, cursor, oasis_int, oasis_int_size)    # summary_id known from idx
+        _, cursor = mv_read(fin, cursor, oasis_float, oasis_float_size)  # expval
+
+        if event_id not in occ_map:
+            continue
+
+        filtered_occ_map = occ_map[event_id]
+        while cursor < valid_buff:
+            sidx, cursor = mv_read(fin, cursor, oasis_int, oasis_int_size)
+            loss, cursor = mv_read(fin, cursor, oasis_float, oasis_float_size)
+            if sidx == 0:
+                break
+            if sidx == NUMBER_OF_AFFECTED_RISK_IDX or sidx == MAX_LOSS_IDX:
+                continue
+            if loss > 0 or use_return_period:
+                do_lec_output_agg_summary(
+                    1, sidx, loss, filtered_occ_map,
+                    outloss_mean_s, row_used_mean_s,
+                    outloss_sample_s, row_used_sample_s,
+                    num_sidxs, 1,
+                )
+
+
+_MERGED_IDX_DTYPE = np.dtype([
+    ("summary_id", np.int32),
+    ("file_index", np.int32),
+    ("offset", np.int64),
+])
+
+
+def build_merged_idx(idx_handles):
+    """Merge per-file .idx memmaps into one array sorted by summary_id."""
+    parts = []
+    for file_index, idx in enumerate(idx_handles):
+        if idx is None or len(idx) == 0:
+            continue
+        chunk = np.empty(len(idx), dtype=_MERGED_IDX_DTYPE)
+        chunk["summary_id"] = idx["summary_id"]
+        chunk["file_index"] = file_index
+        chunk["offset"] = idx["offset"]
+        parts.append(chunk)
+    if not parts:
+        return np.empty(0, dtype=_MERGED_IDX_DTYPE)
+    merged = np.concatenate(parts)
+    merged.sort(order="summary_id")
+    return merged
 
 
 @nb.njit(cache=True, error_model="numpy")
@@ -334,15 +404,40 @@ def run(
         lec_files_folder = Path(workspace_folder, "lec_files")
         lec_files_folder.mkdir(parents=False, exist_ok=True)
 
-        # Find summary binary files
-        files = [file for file in workspace_folder.glob("*.bin")]
+        # Find summary binary files (sorted for stable pairing with .idx files)
+        files = sorted(workspace_folder.glob("*.bin"))
         file_handles = [np.memmap(file, mode="r", dtype="u1") for file in files]
 
         streams_in, (stream_source_type, stream_agg_type, sample_size) = init_streams_in(files, stack)
         if stream_source_type != SUMMARY_STREAM_ID:
             raise RuntimeError(f"Error: Not a summary stream type {stream_source_type}")
 
-        max_summary_id = get_max_summary_id(file_handles)
+        # Detect .idx files for per-summary streaming path
+        idx_handles_raw = []
+        for f in files:
+            idx_path = f.with_suffix(".idx")
+            if idx_path.exists():
+                if idx_path.stat().st_size > 0:
+                    idx_handles_raw.append(np.memmap(str(idx_path), mode="r", dtype=summary_stream_index_dtype))
+                else:
+                    idx_handles_raw.append(np.empty(0, dtype=summary_stream_index_dtype))
+            else:
+                idx_handles_raw.append(None)
+        n_idx = sum(h is not None for h in idx_handles_raw)
+        use_idx_path = n_idx == len(files) and n_idx > 0
+        if use_idx_path:
+            logger.info("Found %d/%d .idx file(s) — using per-summary-id indexing (reduced disk)", n_idx, len(files))
+            merged = build_merged_idx(idx_handles_raw)
+            unique_summary_ids = np.unique(merged["summary_id"])
+            max_summary_id = int(unique_summary_ids[-1]) if len(unique_summary_ids) > 0 else 0
+        else:
+            if 0 < n_idx < len(files):
+                logger.warning(
+                    "%d/%d .idx files found — all .bin files must have .idx to use index path; "
+                    "falling back to sequential scan", n_idx, len(files)
+                )
+            max_summary_id = get_max_summary_id(file_handles)
+
         if max_summary_id == 0:
             return
 
@@ -383,6 +478,95 @@ def run(
         if not (outmap["ept"]["compute"] or outmap["psept"]["compute"]):
             return
 
+        # ── Per-summary streaming path (idx files present) ───────────────────────
+        if use_idx_path:
+            num_sidxs = int(sample_size) + 2
+            no_of_periods = int(file_data["no_of_periods"])
+
+            # Open output files before the loop so headers are written once
+            if output_binary:
+                for out_type in outmap:
+                    if not outmap[out_type]["compute"]:
+                        continue
+                    out_file = stack.enter_context(open(outmap[out_type]["file_path"], 'wb'))
+                    outmap[out_type]["file"] = out_file
+            elif output_parquet:
+                for out_type in outmap:
+                    if not outmap[out_type]["compute"]:
+                        continue
+                    temp_out_data = np.zeros(DEFAULT_BUFFER_SIZE, dtype=outmap[out_type]["dtype"])
+                    temp_df = pd.DataFrame(temp_out_data, columns=outmap[out_type]["headers"])
+                    temp_table = pa.Table.from_pandas(temp_df)
+                    out_file = pq.ParquetWriter(outmap[out_type]["file_path"], temp_table.schema)
+                    outmap[out_type]["file"] = out_file
+            else:
+                for out_type in outmap:
+                    if not outmap[out_type]["compute"]:
+                        continue
+                    out_file = stack.enter_context(open(outmap[out_type]["file_path"], 'w'))
+                    if not noheader:
+                        out_file.write(','.join(outmap[out_type]["headers"]) + '\n')
+                    outmap[out_type]["file"] = out_file
+
+            # In the idx path only output_for_summary is ever called on this instance.
+            # That method takes per-summary arrays as explicit arguments and never reads
+            # self.outloss_mean, self.outloss_sample, self.row_used_indices_mean, or
+            # self.row_used_indices_sample — so the arrays passed here are unused
+            # placeholders that satisfy the constructor signature. max_summary_id=1
+            # is also passed as a placeholder; output_for_summary hardcodes 1 directly.
+            _d_mean = np.zeros(no_of_periods, dtype=OUTLOSS_DTYPE)
+            _d_rw_m = np.zeros(no_of_periods, dtype=np.bool_)
+            _d_samp = np.zeros(no_of_periods * num_sidxs, dtype=OUTLOSS_DTYPE)
+            _d_rw_s = np.zeros(no_of_periods * num_sidxs, dtype=np.bool_)
+            agg = AggReports(
+                outmap, _d_mean, _d_rw_m, _d_samp, _d_rw_s,
+                file_data["period_weights"], 1, sample_size, no_of_periods, num_sidxs,
+                use_return_period, file_data["returnperiods"], lec_files_folder,
+                output_binary, output_parquet,
+            )
+
+            # Per-summary arrays — no × max_summary_id factor
+            outloss_mean_s   = np.zeros(no_of_periods,             dtype=OUTLOSS_DTYPE)
+            outloss_sample_s = np.zeros(no_of_periods * num_sidxs, dtype=OUTLOSS_DTYPE)
+            row_used_mean_s   = np.zeros(no_of_periods,             dtype=np.bool_)
+            row_used_sample_s = np.zeros(no_of_periods * num_sidxs, dtype=np.bool_)
+
+            # Pre-compute uint8 views once — numpy's struct[:]=0 is ~4x slower than raw byte zeroing
+            _mean_bytes   = outloss_mean_s.view(np.uint8)
+            _sample_bytes = outloss_sample_s.view(np.uint8)
+
+            for summary_id in unique_summary_ids:
+                _mean_bytes[:] = 0
+                _sample_bytes[:] = 0
+                row_used_mean_s[:] = False
+                row_used_sample_s[:] = False
+
+                lo = int(np.searchsorted(merged["summary_id"], summary_id, side="left"))
+                hi = int(np.searchsorted(merged["summary_id"], summary_id, side="right"))
+                entries = merged[lo:hi]
+                for fi in np.unique(entries["file_index"]):
+                    offsets = np.sort(entries[entries["file_index"] == fi]["offset"])
+                    process_summary_entries(
+                        file_handles[int(fi)],
+                        offsets,
+                        file_data["occ_map"],
+                        use_return_period,
+                        outloss_mean_s,
+                        row_used_mean_s,
+                        outloss_sample_s,
+                        row_used_sample_s,
+                        num_sidxs,
+                    )
+
+                agg.output_for_summary(
+                    int(summary_id),
+                    outloss_mean_s, row_used_mean_s,
+                    outloss_sample_s, row_used_sample_s,
+                    output_flags, hasOCC, hasAGG,
+                )
+            return  # skip sequential path below
+
+        # ── Sequential path (no .idx files) ──────────────────────────────────────
         # Create outloss array maps
         # outloss_mean has only -1 SIDX
         outloss_mean_file = Path(lec_files_folder, "lec_outloss_mean.bdat")

--- a/oasislmf/pytools/utils.py
+++ b/oasislmf/pytools/utils.py
@@ -36,13 +36,17 @@ def logging_reset_handlers(logger_name):
         logger.setLevel(logging.NOTSET)
 
 
-def redirect_logging(exec_name, log_dir='./log', log_level=logging.WARNING):
+def redirect_logging(exec_name, log_dir='./log'):
     """
     Decorator that redirects logging output to a file.
 
     Apply to the main run function of a python exec from the pytools directory.
     Only errors will be send to STDERR, all other logging is stored in a file named:
        "<log_dir>/<exec_name>_<PID>.log"
+
+    The log level is determined in the following priority:
+        - OASIS_PYTOOLS_LOG_LEVEL environment variable
+        - wrapped function kwargs `logging_level`
 
     Each log file is timestamped with start / finish times
         ❯ cat log/fmpy_112820.log
@@ -52,7 +56,7 @@ def redirect_logging(exec_name, log_dir='./log', log_level=logging.WARNING):
     Args:
         exec_name (str): The name of the script or function being executed. This will be used as part of the log file name.
         log_dir (str, optional): The path to the directory where log files will be stored. Defaults to './log'.
-        log_level (int or str, optional): The logging level to use. Can be an integer or a string. Defaults to logging.INFO.
+        log_level (int or str, optional): The logging level to use. Can be an integer or a string. See docstring for order of priority of log level set. If no log levels set, then defaults to WARNING.
 
     Returns:
         function: The decorated function.
@@ -75,6 +79,18 @@ def redirect_logging(exec_name, log_dir='./log', log_level=logging.WARNING):
             formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
             log_file = f'{exec_name}_{os.getpid()}_{uuid.uuid4()}.log'
 
+            log_level = os.environ.get('OASIS_PYTOOLS_LOG_LEVEL', None)
+            log_level = kwargs.get('logging_level', None) if log_level is None else log_level
+            # convert to int representation
+            if isinstance(log_level, str):
+                if log_level.isdigit():
+                    log_level = int(log_level)
+                else:
+                    log_level = logging.getLevelName(log_level)
+                    log_level = log_level if isinstance(log_level, int) else None
+
+            log_level = logging.WARNING if log_level is None else log_level
+
             childFileHandler = logging.FileHandler(os.path.join(_log_dir, log_file))
             childFileHandler.setLevel(log_level)
             childFileHandler.setFormatter(formatter)
@@ -92,7 +108,7 @@ def redirect_logging(exec_name, log_dir='./log', log_level=logging.WARNING):
             logger.setLevel(logging.INFO)
             logger.addHandler(rootFileHandler)
 
-            # Set warning log handler
+            # Set warning log handler if not in debug
             warn_logger = logging.getLogger('py.warnings')
             warn_logger.addHandler(rootFileHandler)
 

--- a/oasislmf/utils/log.py
+++ b/oasislmf/utils/log.py
@@ -139,3 +139,27 @@ def oasis_log(*args, **kwargs):
         return actual_oasis_log(args[0])
     else:
         return actual_oasis_log
+
+
+class LoggingContext:
+    def __init__(self, logger, level=None, handler=None, close=True):
+        self.logger = logger
+        self.level = level
+        self.handler = handler
+        self.close = close
+
+    def __enter__(self):
+        if self.level is not None:
+            self.old_level = self.logger.level
+            self.logger.setLevel(self.level)
+        if self.handler:
+            self.logger.addHandler(self.handler)
+
+    def __exit__(self, et, ev, tb):
+        if self.level is not None:
+            self.logger.setLevel(self.old_level)
+        if self.handler:
+            self.logger.removeHandler(self.handler)
+        if self.handler and self.close:
+            self.handler.close()
+        # implicit return of None => don't swallow exceptions

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ description_file = README.md
 [tool:pytest]
 exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,.ropeproject
 python_classes =
+testpaths = tests
 markers =
     jit_compile: marks tests that trigger JIT compilation of Numba functions
 

--- a/tests/computation/data/ord_bash_script_summarypy.sh
+++ b/tests/computation/data/ord_bash_script_summarypy.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code
@@ -143,6 +143,7 @@ mkfifo fifo/ri_S1_plt_ord_P2
 mkfifo fifo/ri_S1_elt_ord_P2
 mkfifo fifo/ri_S1_selt_ord_P2
 
+export OASIS_PYTOOLS_LOG_LEVEL=10
 
 # --- Do reinsurance loss computes ---
 

--- a/tests/computation/test_generate_losses.py
+++ b/tests/computation/test_generate_losses.py
@@ -11,6 +11,7 @@ from hypothesis import strategies as st
 
 from oasislmf.utils.exceptions import OasisException
 from oasislmf.manager import OasisManager
+from oasislmf.utils.log import LoggingContext
 from .data.common import (
     EXPECTED_SUMMARY_INFO_CSV, MIN_RUN_SETTINGS, MIN_LOC, MIN_ACC, MIN_INF, MIN_SCP, MIN_KEYS, MIN_KEYS_ERR, IL_RUN_SETTINGS, RI_RUN_SETTINGS,
     RI_ALL_OUTPUT_SETTINGS, ALL_EXPECTED_SCRIPT, FAKE_MODEL_RUNNER, FAKE_MODEL_RUNNER__OLD, INVALID_RUN_SETTINGS, RI_AAL_SETTINGS,
@@ -238,7 +239,8 @@ class TestGenLosses(ComputationChecker):
                 'summarypy': summary_type == 'summarypy',
                 'summarypy_low_memory': True,
             }
-            with patch.dict(os.environ, {"OASIS_SOCKET_SERVER_PORT": "10006"}):
+            with (patch.dict(os.environ, {"OASIS_SOCKET_SERVER_PORT": "10006"}),
+                  LoggingContext(logging.getLogger("oasislmf"), logging.DEBUG)):
                 self.manager.generate_losses(**call_args)
 
             # Check bash script vs reference

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,32 +12,3 @@ def _use_tmp_log_dir(tmp_path_factory):
     yield
     del os.environ['OASIS_PYTEST_REDIRECT_LOGS']
     del os.environ['OASIS_TMPDIR']
-
-
-def pytest_addoption(parser):
-    parser.addoption(
-        '--gul-rtol', type=float, default=1e-10,
-        help='Relative tolerance between expected values and results, default is "1e-10"'
-    )
-    parser.addoption(
-        '--gul-atol', type=float, default=1e-8,
-        help='Absolute tolerance between expected values and results, default is "1e-8"'
-    )
-    parser.addoption(
-        '--gulmc-generate-missing-expected', action='store_true', default=False,
-        help='If True, generate the expected files for the tests that lack them (e.g., newly added tests). Default: False.'
-    )
-    parser.addoption(
-        '--update-expected', action='store_true', default=False,
-        help='If True, update all the expected files, overwriting them if they exist. Default: False.'
-    )
-    parser.addoption(
-        '--fm-keep-output', action='store_true', default=False,
-        help='If True, keep the test results (useful for debugging purposes). Default: False.'
-    )
-    parser.addoption(
-        '--remine-hash-collisions', action='store_true', default=False,
-        help='If True, brute-force a fresh colliding-int32-keys set for the hashmap '
-             'collision test and print it for paste-back. Use when the hash function '
-             'in oasislmf.pytools.common.hashmap changes. Adds ~5-15 s to the run.'
-    )

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_1_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_1_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_1_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_1_partition.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_1_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.1.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.2.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.3.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.4.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.5.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.6.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.7.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_csv_8_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_1_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_1_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_1_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_1_partition.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_1_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.1.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.2.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.3.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.4.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.5.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.6.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.7.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_fc_8_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_1_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_1_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_1_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_1_partition.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_1_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.1.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.2.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.3.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.4.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.5.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.6.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.7.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.sh
+++ b/tests/model_execution/reference_bash_err/all_outputs_1_parquet_8_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_1_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_1_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_1_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_1_partition.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_1_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.1.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.2.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.3.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.4.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.5.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.6.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.7.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_sample_1_output_8_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_1_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_1_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_1_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.1.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.2.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.3.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.4.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.5.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.6.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.7.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.sh
+++ b/tests/model_execution/reference_bash_err/custom_gul_summarycalc_1_output_8_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_1_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_1_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_1_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_1_partition.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_1_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.1.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.2.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.3.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.4.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.5.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.6.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.7.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_ept_psept_2_output_8_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_1_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_1_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_1_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_1_partition.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_1_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.1.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.2.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.3.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.4.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.5.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.6.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.7.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_palt_output_8_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_1_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_1_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_1_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_1_partition.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_1_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.1.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.2.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.3.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.4.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.5.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.6.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.7.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ord_psept_lec_1_output_8_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_1_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_1_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_1_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_1_partition.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_1_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.1.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.2.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.3.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.4.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.5.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.6.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.7.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.sh
+++ b/tests/model_execution/reference_bash_err/gul_il_ri__pla_csv_8_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_1_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_1_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_1_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_1_partition.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_1_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.1.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.2.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.3.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.4.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.5.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.6.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.7.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_1_output_8_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_1_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_1_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_1_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_1_partition.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_1_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.1.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.2.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.3.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.4.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.5.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.6.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.7.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_ept_2_output_8_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_1_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_1_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_1_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_1_partition.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_1_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.1.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.2.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.3.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.4.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.5.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.6.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.7.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_palt_output_8_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_1_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_1_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_1_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_1_partition.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_1_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.1.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.2.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.3.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.4.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.5.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.6.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.7.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.sh
+++ b/tests/model_execution/reference_bash_err/gul_ord_psept_2_output_8_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_1_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_1_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_1_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.1.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.2.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.3.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.4.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.5.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.6.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.7.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.sh
+++ b/tests/model_execution/reference_bash_err/gul_summarycalc_1_output_8_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_1_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_1_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_1_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_1_partition.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_1_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.1.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.2.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.3.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.4.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.5.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.6.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.7.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.sh
+++ b/tests/model_execution/reference_bash_err/il_only_no_ord_leccalc_output_3_8_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_1_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_1_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_1_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_1_partition.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_1_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.1.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.2.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.3.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.4.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.5.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.6.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.7.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.sh
+++ b/tests/model_execution/reference_bash_err/il_only_summarycalc_1_output_8_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_1_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_1_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_1_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_1_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_1_partition.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_1_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.0.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.0.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.1.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.1.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.2.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.2.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.3.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.3.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.4.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.4.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.5.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.5.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.6.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.6.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.7.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.7.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.output.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.output.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.sh
+++ b/tests/model_execution/reference_bash_err/ri_only_no_ord_leccalc_3_8_partition.sh
@@ -32,7 +32,7 @@ exit_handler(){
 " $script_pid $group_pid $sess_pid >> $LOG_DIR/killout.txt
 
        ps -jf f -g $sess_pid > $LOG_DIR/subprocess_list
-       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v *\\.log$  | egrep -v *startup.sh$ | sort -n -r)
+       PIDS_KILL=$(pgrep -a --pgroup $group_pid | awk 'BEGIN { FS = "[ \t\n]+" }{ if ($1 >= '$script_pid') print}' | grep -v celery | egrep -v \.log$  | egrep -v startup.sh$ | sort -n -r)
        echo "$PIDS_KILL" >> $LOG_DIR/killout.txt
        kill -9 $(echo "$PIDS_KILL" | awk 'BEGIN { FS = "[ \t\n]+" }{ print $1 }') 2>/dev/null
        exit $exit_code

--- a/tests/pytools/aalpy/test_aalpy.py
+++ b/tests/pytools/aalpy/test_aalpy.py
@@ -3,11 +3,38 @@ import os
 import shutil
 from pathlib import Path
 import pandas as pd
+import pytest
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
-from oasislmf.pytools.aal.manager import main
+from oasislmf.pytools.common.data import occurrence_dtype, summary_stream_index_dtype
+from oasislmf.pytools.common.event_stream import SUMMARY_STREAM_ID, stream_info_to_bytes
+from oasislmf.pytools.aal.manager import _SUMMARIES_DTYPE_size, main
 
 TESTS_ASSETS_DIR = Path(__file__).parent.parent.parent.joinpath("assets").joinpath("test_aalpy")
+
+
+def make_idx_from_bin(bin_path: Path, idx_path: Path) -> None:
+    """Scan a summary .bin and write a paired .idx recording each event block's byte offset.
+
+    If the bin contains no data blocks (header only), creates a 0-byte idx to match
+    summarypy --low-memory behaviour for partitions that received no events.
+    """
+    raw = np.fromfile(str(bin_path), dtype=np.int32)
+    pos = 3  # skip 3-int stream header (stream_type, sample_size, summary_set_id)
+    entries = []
+    while pos < len(raw):
+        byte_offset = pos * 4
+        summary_id = int(raw[pos + 1])
+        pos += 3  # event_id, summary_id, expval
+        while pos < len(raw) and raw[pos] != 0:
+            pos += 2  # sidx + loss pair (any non-zero sidx, including special negatives)
+        pos += 2  # terminating (sidx=0, loss=0.0)
+        entries.append((summary_id, byte_offset))
+    if entries:
+        np.array(entries, dtype=summary_stream_index_dtype).tofile(str(idx_path))
+    else:
+        idx_path.touch()  # empty partition → 0-byte idx
 
 
 def case_runner(sub_folder, test_name, out_ext="csv", meanonly=False):
@@ -76,8 +103,6 @@ def case_runner(sub_folder, test_name, out_ext="csv", meanonly=False):
 
 def test_empty_input():
     """Test AAL does not crash and produces no output when summary binary has no loss records"""
-    from oasislmf.pytools.common.event_stream import SUMMARY_STREAM_ID, stream_info_to_bytes
-
     with TemporaryDirectory() as tmp_dir_str:
         tmp_dir = Path(tmp_dir_str)
         input_dir = tmp_dir / "input"
@@ -160,3 +185,127 @@ def test_alct_output_parquet():
     """Tests ALCT output
     """
     case_runner("gul", "alct", "parquet")
+
+
+# ---------------------------------------------------------------------------
+# .idx path tests
+# ---------------------------------------------------------------------------
+
+def test_aal_idx_output_matches_sequential():
+    """AAL .idx path produces identical output to the sequential path."""
+    outfile_name = "py_aalgul.csv"
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str) / "workspace"
+        shutil.copytree(Path(TESTS_ASSETS_DIR, "all_files"), tmp_dir)
+
+        work_dir = tmp_dir / "work" / "gul"
+        for bin_path in sorted(work_dir.glob("*.bin")):
+            make_idx_from_bin(bin_path, bin_path.with_suffix(".idx"))
+
+        out_dir = tmp_dir / "out"
+        out_dir.mkdir()
+        actual_outfile = out_dir / outfile_name
+
+        main(run_dir=tmp_dir, subfolder="gul", ext="csv", aal=actual_outfile)
+
+        expected = np.genfromtxt(tmp_dir / outfile_name, delimiter=',', skip_header=1)
+        actual = np.genfromtxt(actual_outfile, delimiter=',', skip_header=1)
+        assert expected.shape == actual.shape, f"Shape mismatch: {expected.shape} vs {actual.shape}"
+        np.testing.assert_allclose(expected, actual, rtol=1e-5, atol=1e-8,
+                                   err_msg=".idx path output differs from sequential for AAL")
+
+
+def test_aal_idx_empty_file_no_crash():
+    """A 0-byte .idx for an empty partition does not raise ValueError (crash regression).
+
+    summarypy --low-memory creates 0-byte .idx files for partitions that received no
+    events. Before the fix np.memmap raised 'ValueError: cannot mmap an empty file'.
+    """
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str) / "workspace"
+        shutil.copytree(Path(TESTS_ASSETS_DIR, "all_files"), tmp_dir)
+
+        work_dir = tmp_dir / "work" / "gul"
+        for bin_path in sorted(work_dir.glob("*.bin")):
+            make_idx_from_bin(bin_path, bin_path.with_suffix(".idx"))
+
+        # Add an empty partition: header-only .bin + 0-byte .idx
+        stream_hdr = np.frombuffer(stream_info_to_bytes(SUMMARY_STREAM_ID, 1), dtype=np.int32)[0]
+        np.array([stream_hdr, 100, 1], dtype=np.int32).tofile(work_dir / "summarypy9.bin")
+        (work_dir / "summarypy9.idx").touch()
+
+        out_dir = tmp_dir / "out"
+        out_dir.mkdir()
+
+        main(run_dir=tmp_dir, subfolder="gul", ext="csv", aal=out_dir / "py_aalgul.csv")
+        assert (out_dir / "py_aalgul.csv").exists(), "AAL output should be created when populated bins are present"
+
+
+# ---------------------------------------------------------------------------
+# Buffer overflow guard tests
+# ---------------------------------------------------------------------------
+
+def _make_occurrence_with_event(input_dir, event_id, n_periods):
+    """Write an occurrence.bin where event_id appears once in each of n_periods periods."""
+    header = np.array([1, n_periods], dtype=np.int32)  # date_opts=1, no_of_periods
+    records = np.zeros(n_periods, dtype=occurrence_dtype)
+    records["event_id"] = event_id
+    records["period_no"] = np.arange(1, n_periods + 1)
+    with open(input_dir / "occurrence.bin", "wb") as f:
+        f.write(header.tobytes())
+        f.write(records.tobytes())
+
+
+def _make_summary_bin_with_event(work_dir, filename, event_id, summary_id, sample_size=1):
+    """Write a summary .bin containing one event block with one sample loss."""
+    stream_hdr = np.frombuffer(stream_info_to_bytes(SUMMARY_STREAM_ID, sample_size), dtype=np.int32)[0]
+    header = np.array([stream_hdr, sample_size, 1], dtype=np.int32)
+
+    # Pack event_id(i32), summary_id(i32), expval(f32), sidx=1(i32), loss(f32), sidx=0(i32), loss=0(f32)
+    # Build as int32 array, encoding floats via view to avoid struct dependency.
+    block = np.zeros(7, dtype=np.int32)
+    block[0] = event_id
+    block[1] = summary_id
+    block[2] = np.float32(0.0).view(np.int32)   # expval
+    block[3] = 1                                  # sidx
+    block[4] = np.float32(500.0).view(np.int32)  # loss
+    block[5] = 0                                  # terminating sidx=0
+    block[6] = np.float32(0.0).view(np.int32)    # terminating loss=0
+
+    path = work_dir / filename
+    with open(path, "wb") as f:
+        f.write(header.tobytes())
+        f.write(block.tobytes())
+    return path
+
+
+@pytest.mark.parametrize("use_idx", [False, True], ids=["sequential", "idx"])
+def test_aal_oversize_event_raises(use_idx):
+    """ValueError is raised when a single event's occurrence count exceeds the buffer size.
+
+    Sets OASIS_AAL_MEMORY to exactly one buffer slot (buffer_size=1) and creates an
+    event that maps to two periods (n_rows=2), so n_rows > buffer_size triggers the guard
+    in both process_bin_file (sequential path) and process_idx_file (idx path).
+    """
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        input_dir = tmp_dir / "input"
+        work_dir = tmp_dir / "work" / "gul"
+        input_dir.mkdir(parents=True)
+        work_dir.mkdir(parents=True)
+
+        # event_id=1 in 2 periods → n_rows=2
+        _make_occurrence_with_event(input_dir, event_id=1, n_periods=2)
+        bin_path = _make_summary_bin_with_event(work_dir, "summarypy1.bin", event_id=1, summary_id=1)
+
+        if use_idx:
+            make_idx_from_bin(bin_path, bin_path.with_suffix(".idx"))
+
+        out_dir = tmp_dir / "out"
+        out_dir.mkdir()
+
+        # buffer_size = int(tiny_memory * 1024**3 / _SUMMARIES_DTYPE_size) = 1
+        tiny_memory = _SUMMARIES_DTYPE_size / 1024 ** 3
+        with patch("oasislmf.pytools.aal.manager.OASIS_AAL_MEMORY", tiny_memory):
+            with pytest.raises(ValueError, match="OASIS_AAL_MEMORY is too small"):
+                main(run_dir=tmp_dir, subfolder="gul", ext="csv", aal=out_dir / "aal.csv")

--- a/tests/pytools/aalpy/test_aalpy.py
+++ b/tests/pytools/aalpy/test_aalpy.py
@@ -7,34 +7,12 @@ import pytest
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
-from oasislmf.pytools.common.data import occurrence_dtype, summary_stream_index_dtype
+from oasislmf.pytools.common.data import occurrence_dtype
 from oasislmf.pytools.common.event_stream import SUMMARY_STREAM_ID, stream_info_to_bytes
 from oasislmf.pytools.aal.manager import _SUMMARIES_DTYPE_size, main
+from tests.pytools.utils import make_idx_from_bin
 
 TESTS_ASSETS_DIR = Path(__file__).parent.parent.parent.joinpath("assets").joinpath("test_aalpy")
-
-
-def make_idx_from_bin(bin_path: Path, idx_path: Path) -> None:
-    """Scan a summary .bin and write a paired .idx recording each event block's byte offset.
-
-    If the bin contains no data blocks (header only), creates a 0-byte idx to match
-    summarypy --low-memory behaviour for partitions that received no events.
-    """
-    raw = np.fromfile(str(bin_path), dtype=np.int32)
-    pos = 3  # skip 3-int stream header (stream_type, sample_size, summary_set_id)
-    entries = []
-    while pos < len(raw):
-        byte_offset = pos * 4
-        summary_id = int(raw[pos + 1])
-        pos += 3  # event_id, summary_id, expval
-        while pos < len(raw) and raw[pos] != 0:
-            pos += 2  # sidx + loss pair (any non-zero sidx, including special negatives)
-        pos += 2  # terminating (sidx=0, loss=0.0)
-        entries.append((summary_id, byte_offset))
-    if entries:
-        np.array(entries, dtype=summary_stream_index_dtype).tofile(str(idx_path))
-    else:
-        idx_path.touch()  # empty partition → 0-byte idx
 
 
 def case_runner(sub_folder, test_name, out_ext="csv", meanonly=False):
@@ -237,8 +215,39 @@ def test_aal_idx_empty_file_no_crash():
         out_dir = tmp_dir / "out"
         out_dir.mkdir()
 
-        main(run_dir=tmp_dir, subfolder="gul", ext="csv", aal=out_dir / "py_aalgul.csv")
-        assert (out_dir / "py_aalgul.csv").exists(), "AAL output should be created when populated bins are present"
+        outfile_name = "py_aalgul.csv"
+        main(run_dir=tmp_dir, subfolder="gul", ext="csv", aal=out_dir / outfile_name)
+
+        expected = np.genfromtxt(tmp_dir / outfile_name, delimiter=',', skip_header=1)
+        actual = np.genfromtxt(out_dir / outfile_name, delimiter=',', skip_header=1)
+        assert expected.shape == actual.shape, f"Shape mismatch: {expected.shape} vs {actual.shape}"
+        np.testing.assert_allclose(expected, actual, rtol=1e-5, atol=1e-8,
+                                   err_msg="Empty partition changed AAL output")
+
+
+def test_aal_idx_partial_coverage_mixed_dispatch():
+    """Partial .idx coverage uses per-file mixed dispatch: indexed files use process_idx_file,
+    files without .idx use process_bin_file. Output must match full sequential golden."""
+    outfile_name = "py_aalgul.csv"
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str) / "workspace"
+        shutil.copytree(Path(TESTS_ASSETS_DIR, "all_files"), tmp_dir)
+
+        work_dir = tmp_dir / "work" / "gul"
+        bins = sorted(work_dir.glob("*.bin"))
+        # Only provide idx for the first bin → it uses process_idx_file, the rest use process_bin_file
+        make_idx_from_bin(bins[0], bins[0].with_suffix(".idx"))
+
+        out_dir = tmp_dir / "out"
+        out_dir.mkdir()
+
+        main(run_dir=tmp_dir, subfolder="gul", ext="csv", aal=out_dir / outfile_name)
+
+        expected = np.genfromtxt(tmp_dir / outfile_name, delimiter=',', skip_header=1)
+        actual = np.genfromtxt(out_dir / outfile_name, delimiter=',', skip_header=1)
+        assert expected.shape == actual.shape, f"Shape mismatch: {expected.shape} vs {actual.shape}"
+        np.testing.assert_allclose(expected, actual, rtol=1e-5, atol=1e-8,
+                                   err_msg="Mixed idx/sequential dispatch changed AAL output")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/pytools/lecpy/test_lecpy.py
+++ b/tests/pytools/lecpy/test_lecpy.py
@@ -1,9 +1,11 @@
 import shutil
 from pathlib import Path
-import pandas as pd
+from unittest.mock import patch
 from tempfile import TemporaryDirectory
 
 import numpy as np
+import pandas as pd
+import pytest
 from oasislmf.pytools.common.data import summary_stream_index_dtype
 from oasislmf.pytools.common.event_stream import SUMMARY_STREAM_ID, stream_info_to_bytes
 from oasislmf.pytools.lec.data import EPT_dtype, PSEPT_dtype
@@ -307,6 +309,28 @@ def test_lec_idx_empty_file_no_crash():
         )
         assert (out_dir / "py_ept.csv").exists(), "EPT output should be created when populated bins are present"
         assert (out_dir / "py_psept.csv").exists(), "PSEPT output should be created when populated bins are present"
+
+
+def test_lec_sequential_raises_on_insufficient_disk():
+    """Sequential path raises RuntimeError before allocating .bdat files when disk is full."""
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str) / "workspace"
+        shutil.copytree(Path(TESTS_ASSETS_DIR, "lec"), tmp_dir)
+
+        # No .idx files → sequential path is taken
+        out_dir = tmp_dir / "out"
+        out_dir.mkdir()
+
+        real = shutil.disk_usage("/")
+        fake_usage = type(real)(total=real.total, used=real.used, free=0)
+
+        with patch("oasislmf.pytools.lec.manager.shutil.disk_usage", return_value=fake_usage):
+            with pytest.raises(RuntimeError, match="Insufficient disk space"):
+                main(
+                    run_dir=tmp_dir, subfolder="gul", use_return_period=False,
+                    ept=out_dir / "py_ept.csv", psept=out_dir / "py_psept.csv", ext="csv",
+                    **_ALL_OUTPUT_FLAGS,
+                )
 
 
 def test_lec_idx_partial_coverage_falls_back_to_sequential():

--- a/tests/pytools/lecpy/test_lecpy.py
+++ b/tests/pytools/lecpy/test_lecpy.py
@@ -6,35 +6,13 @@ from tempfile import TemporaryDirectory
 import numpy as np
 import pandas as pd
 import pytest
-from oasislmf.pytools.common.data import occurrence_dtype, summary_stream_index_dtype
+from oasislmf.pytools.common.data import occurrence_dtype
 from oasislmf.pytools.common.event_stream import SUMMARY_STREAM_ID, stream_info_to_bytes
 from oasislmf.pytools.lec.data import EPT_dtype, PSEPT_dtype
 from oasislmf.pytools.lec.manager import main
+from tests.pytools.utils import make_idx_from_bin
 
 TESTS_ASSETS_DIR = Path(__file__).parent.parent.parent.joinpath("assets").joinpath("test_lecpy")
-
-
-def make_idx_from_bin(bin_path: Path, idx_path: Path) -> None:
-    """Scan a summary .bin and write a paired .idx recording each event block's byte offset.
-
-    If the bin contains no data blocks (header only), creates a 0-byte idx to match
-    summarypy --low-memory behaviour for partitions that received no events.
-    """
-    raw = np.fromfile(str(bin_path), dtype=np.int32)
-    pos = 3  # skip 3-int stream header (stream_type, sample_size, summary_set_id)
-    entries = []
-    while pos < len(raw):
-        byte_offset = pos * 4
-        summary_id = int(raw[pos + 1])
-        pos += 3  # event_id, summary_id, expval
-        while pos < len(raw) and raw[pos] != 0:
-            pos += 2  # sidx + loss pair (any non-zero sidx, including special negatives)
-        pos += 2  # terminating (sidx=0, loss=0.0)
-        entries.append((summary_id, byte_offset))
-    if entries:
-        np.array(entries, dtype=summary_stream_index_dtype).tofile(str(idx_path))
-    else:
-        idx_path.touch()  # empty partition → 0-byte idx
 
 
 def case_runner(sub_folder, test_name, out_ext="csv", use_return_period=False):

--- a/tests/pytools/lecpy/test_lecpy.py
+++ b/tests/pytools/lecpy/test_lecpy.py
@@ -4,10 +4,35 @@ import pandas as pd
 from tempfile import TemporaryDirectory
 
 import numpy as np
+from oasislmf.pytools.common.data import summary_stream_index_dtype
+from oasislmf.pytools.common.event_stream import SUMMARY_STREAM_ID, stream_info_to_bytes
 from oasislmf.pytools.lec.data import EPT_dtype, PSEPT_dtype
 from oasislmf.pytools.lec.manager import main
 
 TESTS_ASSETS_DIR = Path(__file__).parent.parent.parent.joinpath("assets").joinpath("test_lecpy")
+
+
+def make_idx_from_bin(bin_path: Path, idx_path: Path) -> None:
+    """Scan a summary .bin and write a paired .idx recording each event block's byte offset.
+
+    If the bin contains no data blocks (header only), creates a 0-byte idx to match
+    summarypy --low-memory behaviour for partitions that received no events.
+    """
+    raw = np.fromfile(str(bin_path), dtype=np.int32)
+    pos = 3  # skip 3-int stream header (stream_type, sample_size, summary_set_id)
+    entries = []
+    while pos < len(raw):
+        byte_offset = pos * 4
+        summary_id = int(raw[pos + 1])
+        pos += 3  # event_id, summary_id, expval
+        while pos < len(raw) and raw[pos] != 0:
+            pos += 2  # sidx + loss pair (any non-zero sidx, including special negatives)
+        pos += 2  # terminating (sidx=0, loss=0.0)
+        entries.append((summary_id, byte_offset))
+    if entries:
+        np.array(entries, dtype=summary_stream_index_dtype).tofile(str(idx_path))
+    else:
+        idx_path.touch()  # empty partition → 0-byte idx
 
 
 def case_runner(sub_folder, test_name, out_ext="csv", use_return_period=False):
@@ -103,8 +128,6 @@ def case_runner(sub_folder, test_name, out_ext="csv", use_return_period=False):
 
 def test_empty_input():
     """Test LEC does not crash and produces no output when summary binary has no loss records"""
-    from oasislmf.pytools.common.event_stream import SUMMARY_STREAM_ID, stream_info_to_bytes
-
     with TemporaryDirectory() as tmp_dir_str:
         tmp_dir = Path(tmp_dir_str)
         work_dir = tmp_dir / "work" / "gul"
@@ -212,3 +235,104 @@ def test_lec_output_parquet():
     """Tests LEC output with no period weights, and with return_periods flag False
     """
     case_runner("gul", "lec", "parquet", use_return_period=False)
+
+
+# ---------------------------------------------------------------------------
+# .idx path tests
+# ---------------------------------------------------------------------------
+
+_ALL_OUTPUT_FLAGS = dict(
+    agg_full_uncertainty=True, agg_wheatsheaf=True,
+    agg_sample_mean=True, agg_wheatsheaf_mean=True,
+    occ_full_uncertainty=True, occ_wheatsheaf=True,
+    occ_sample_mean=True, occ_wheatsheaf_mean=True,
+)
+
+
+def test_lec_idx_output_matches_sequential():
+    """LEC .idx path produces identical EPT/PSEPT output to the sequential path."""
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str) / "workspace"
+        shutil.copytree(Path(TESTS_ASSETS_DIR, "lec"), tmp_dir)
+
+        work_dir = tmp_dir / "work" / "gul"
+        for bin_path in sorted(work_dir.glob("*.bin")):
+            make_idx_from_bin(bin_path, bin_path.with_suffix(".idx"))
+
+        out_dir = tmp_dir / "out"
+        out_dir.mkdir()
+        actual_ept = out_dir / "py_ept.csv"
+        actual_psept = out_dir / "py_psept.csv"
+
+        main(
+            run_dir=tmp_dir, subfolder="gul", use_return_period=False,
+            ept=actual_ept, psept=actual_psept, ext="csv",
+            **_ALL_OUTPUT_FLAGS,
+        )
+
+        for out_file, golden_name in [(actual_ept, "py_ept.csv"), (actual_psept, "py_psept.csv")]:
+            expected = np.genfromtxt(tmp_dir / golden_name, delimiter=',', skip_header=1)
+            actual = np.genfromtxt(out_file, delimiter=',', skip_header=1)
+            assert expected.shape == actual.shape, f"Shape mismatch for {golden_name}: {expected.shape} vs {actual.shape}"
+            np.testing.assert_allclose(expected, actual, rtol=1e-5, atol=1e-8,
+                                       err_msg=f".idx path output differs from sequential for {golden_name}")
+
+
+def test_lec_idx_empty_file_no_crash():
+    """A 0-byte .idx for an empty partition does not raise ValueError (crash regression).
+
+    summarypy --low-memory creates 0-byte .idx files for partitions that received no
+    events. Before the fix np.memmap raised 'ValueError: cannot mmap an empty file'.
+    """
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str) / "workspace"
+        shutil.copytree(Path(TESTS_ASSETS_DIR, "lec"), tmp_dir)
+
+        work_dir = tmp_dir / "work" / "gul"
+        for bin_path in sorted(work_dir.glob("*.bin")):
+            make_idx_from_bin(bin_path, bin_path.with_suffix(".idx"))
+
+        # Add an empty partition: header-only .bin + 0-byte .idx
+        stream_hdr = np.frombuffer(stream_info_to_bytes(SUMMARY_STREAM_ID, 1), dtype=np.int32)[0]
+        np.array([stream_hdr, 100, 1], dtype=np.int32).tofile(work_dir / "summarypy9.bin")
+        (work_dir / "summarypy9.idx").touch()
+
+        out_dir = tmp_dir / "out"
+        out_dir.mkdir()
+
+        main(
+            run_dir=tmp_dir, subfolder="gul", use_return_period=False,
+            ept=out_dir / "py_ept.csv", psept=out_dir / "py_psept.csv", ext="csv",
+            **_ALL_OUTPUT_FLAGS,
+        )
+        assert (out_dir / "py_ept.csv").exists(), "EPT output should be created when populated bins are present"
+        assert (out_dir / "py_psept.csv").exists(), "PSEPT output should be created when populated bins are present"
+
+
+def test_lec_idx_partial_coverage_falls_back_to_sequential():
+    """Partial .idx coverage (not all .bin files have .idx) triggers sequential fallback with correct output."""
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str) / "workspace"
+        shutil.copytree(Path(TESTS_ASSETS_DIR, "lec"), tmp_dir)
+
+        work_dir = tmp_dir / "work" / "gul"
+        bins = sorted(work_dir.glob("*.bin"))
+        # Only provide idx for the first bin → triggers warning + sequential fallback
+        make_idx_from_bin(bins[0], bins[0].with_suffix(".idx"))
+
+        out_dir = tmp_dir / "out"
+        out_dir.mkdir()
+        actual_ept = out_dir / "py_ept.csv"
+        actual_psept = out_dir / "py_psept.csv"
+
+        main(
+            run_dir=tmp_dir, subfolder="gul", use_return_period=False,
+            ept=actual_ept, psept=actual_psept, ext="csv",
+            **_ALL_OUTPUT_FLAGS,
+        )
+
+        for out_file, golden_name in [(actual_ept, "py_ept.csv"), (actual_psept, "py_psept.csv")]:
+            expected = np.genfromtxt(tmp_dir / golden_name, delimiter=',', skip_header=1)
+            actual = np.genfromtxt(out_file, delimiter=',', skip_header=1)
+            assert expected.shape == actual.shape, f"Shape mismatch for {golden_name}: {expected.shape} vs {actual.shape}"
+            np.testing.assert_allclose(expected, actual, rtol=1e-5, atol=1e-8)

--- a/tests/pytools/lecpy/test_lecpy.py
+++ b/tests/pytools/lecpy/test_lecpy.py
@@ -6,7 +6,7 @@ from tempfile import TemporaryDirectory
 import numpy as np
 import pandas as pd
 import pytest
-from oasislmf.pytools.common.data import summary_stream_index_dtype
+from oasislmf.pytools.common.data import occurrence_dtype, summary_stream_index_dtype
 from oasislmf.pytools.common.event_stream import SUMMARY_STREAM_ID, stream_info_to_bytes
 from oasislmf.pytools.lec.data import EPT_dtype, PSEPT_dtype
 from oasislmf.pytools.lec.manager import main
@@ -360,3 +360,88 @@ def test_lec_idx_partial_coverage_falls_back_to_sequential():
             actual = np.genfromtxt(out_file, delimiter=',', skip_header=1)
             assert expected.shape == actual.shape, f"Shape mismatch for {golden_name}: {expected.shape} vs {actual.shape}"
             np.testing.assert_allclose(expected, actual, rtol=1e-5, atol=1e-8)
+
+
+def _build_multi_summary_run(tmp_dir, n_summaries, n_events=60, sample_size=20, n_periods=80, n_files=3, seed=11):
+    """Build a multi-summary, partitioned summary stream + occurrence/returnperiods for buffer tests.
+
+    Events are split across n_files (partition-by-event); every summary_id appears in each
+    file for the events that landed there — mirroring a real partitioned run. A paired .idx
+    is generated for each .bin so the per-summary-id path is taken.
+    """
+    rng = np.random.default_rng(seed)
+    input_dir = tmp_dir / "input"
+    work_dir = tmp_dir / "work" / "gul"
+    input_dir.mkdir(parents=True)
+    work_dir.mkdir(parents=True)
+
+    event_ids = np.arange(1, n_events + 1, dtype=np.int32)
+    recs = np.zeros(n_events, dtype=occurrence_dtype)
+    recs["event_id"] = event_ids
+    recs["period_no"] = (event_ids % n_periods) + 1
+    with open(input_dir / "occurrence.bin", "wb") as f:
+        f.write(np.array([1, n_periods], dtype=np.int32).tobytes())
+        f.write(recs.tobytes())
+    np.array([1000, 500, 250, 100, 50, 25, 10, 5, 2], dtype=np.int32).tofile(input_dir / "returnperiods.bin")
+
+    stream_hdr = np.frombuffer(stream_info_to_bytes(SUMMARY_STREAM_ID, sample_size), dtype=np.int32)[0]
+    sidxs = np.array([-1] + list(range(1, sample_size + 1)), dtype=np.int32)  # mean + samples
+    for fi, events in enumerate(np.array_split(event_ids, n_files), start=1):
+        rows = [np.array([stream_hdr, sample_size, 1], dtype=np.int32)]
+        for ev in events:
+            for sid in range(1, n_summaries + 1):
+                block = np.empty(3 + 2 * (len(sidxs) + 1), dtype=np.int32)
+                block[0] = ev
+                block[1] = sid
+                block[2] = np.float32(0.0).view(np.int32)  # expval
+                pos = 3
+                for s, loss in zip(sidxs, rng.uniform(1.0, 1000.0, len(sidxs)).astype(np.float32)):
+                    block[pos] = s
+                    block[pos + 1] = loss.view(np.int32)
+                    pos += 2
+                block[pos] = 0                               # terminating sidx
+                block[pos + 1] = np.float32(0.0).view(np.int32)
+                rows.append(block)
+        np.concatenate(rows).tofile(work_dir / f"summarypy{fi}.bin")
+    for b in sorted(work_dir.glob("*.bin")):
+        make_idx_from_bin(b, b.with_suffix(".idx"))
+
+
+def test_lec_idx_reused_buffer_matches_sequential_multi_summary():
+    """Per-summary .idx path matches the dense path across many summaries (reused-buffer guard).
+
+    The write_* generators share one output buffer across all per-summary calls. This builds
+    a many-summary run (so the buffer is reused hundreds of times) and asserts the .idx output
+    is byte-identical to the dense path — catching any stale data leaking between calls.
+    use_return_period=True keeps the dense wheatsheaf-mean path off its empty-mean_map edge.
+    """
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str) / "workspace"
+        _build_multi_summary_run(tmp_dir, n_summaries=120)
+
+        seq_dir = tmp_dir / "out_seq"
+        idx_dir = tmp_dir / "out_idx"
+        seq_dir.mkdir()
+        idx_dir.mkdir()
+
+        # Sequential (dense) path: remove .idx files
+        work_dir = tmp_dir / "work" / "gul"
+        for idx in work_dir.glob("*.idx"):
+            idx.unlink()
+        main(run_dir=tmp_dir, subfolder="gul", use_return_period=True,
+             ept=seq_dir / "py_ept.csv", psept=seq_dir / "py_psept.csv", ext="csv", **_ALL_OUTPUT_FLAGS)
+
+        # Per-summary .idx path: regenerate .idx files
+        for b in sorted(work_dir.glob("*.bin")):
+            make_idx_from_bin(b, b.with_suffix(".idx"))
+        main(run_dir=tmp_dir, subfolder="gul", use_return_period=True,
+             ept=idx_dir / "py_ept.csv", psept=idx_dir / "py_psept.csv", ext="csv", **_ALL_OUTPUT_FLAGS)
+
+        for name in ("py_ept.csv", "py_psept.csv"):
+            a = np.genfromtxt(seq_dir / name, delimiter=',', skip_header=1)
+            b = np.genfromtxt(idx_dir / name, delimiter=',', skip_header=1)
+            a = a[np.lexsort(a.T[::-1])]
+            b = b[np.lexsort(b.T[::-1])]
+            assert a.shape == b.shape, f"Shape mismatch for {name}: {a.shape} vs {b.shape}"
+            np.testing.assert_allclose(a, b, rtol=1e-5, atol=1e-8,
+                                       err_msg=f".idx (reused buffer) differs from sequential for {name}")

--- a/tests/pytools/utils.py
+++ b/tests/pytools/utils.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+import numpy as np
+from oasislmf.pytools.common.data import summary_stream_index_dtype
+
+
+def make_idx_from_bin(bin_path: Path, idx_path: Path) -> None:
+    """Scan a summary .bin and write a paired .idx recording each event block's byte offset.
+
+    If the bin contains no data blocks (header only), creates a 0-byte idx to match
+    summarypy --low-memory behaviour for partitions that received no events.
+    """
+    raw = np.fromfile(str(bin_path), dtype=np.int32)
+    pos = 3  # skip 3-int stream header (stream_type, sample_size, summary_set_id)
+    entries = []
+    while pos < len(raw):
+        byte_offset = pos * 4
+        summary_id = int(raw[pos + 1])
+        pos += 3  # event_id, summary_id, expval
+        while pos < len(raw) and raw[pos] != 0:
+            pos += 2  # sidx + loss pair (any non-zero sidx, including special negatives)
+        pos += 2  # terminating (sidx=0, loss=0.0)
+        entries.append((summary_id, byte_offset))
+    if entries:
+        np.array(entries, dtype=summary_stream_index_dtype).tofile(str(idx_path))
+    else:
+        idx_path.touch()  # empty partition → 0-byte idx


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### feature/aal_lec_idx_files

Implements per-summary-id processing in `lecpy` and `aalpy` using binary `.idx` side-files, eliminating the large intermediate `.bdat` files that caused excessive disk usage on large per-location runs.

#### Changes
- `lec/manager.py`, `aal/manager.py`: when `.idx` files are present (generated by `summarypy -m`), process one `summary_id` at a time using `.idx` offsets, bounding peak disk to `O(periods × sidxs)` regardless of location count
- Falls back to the existing dense memmap path when `.idx` files are absent
- `lec/manager.py`: adds a best-effort disk space pre-check on the fallback path — raises a clear error before allocation rather than failing mid-run or silently filling the disk. When multiple lecpy instances run concurrently (e.g. gul/il/ri in parallel), the check can pass for all instances simultaneously even if their combined allocation exceeds available space; the idx path avoids this entirely
- `lec/aggreports/aggreports.py`: refactor to support the new per-summary processing path
- Tests added for both `aalpy` and `lecpy` covering the idx and fallback path

#### Benchmarks

**LEC results:**
<img width="1200" height="1560" alt="image" src="https://github.com/user-attachments/assets/7477dd31-79a3-4c13-99ad-b2f468e011d3" />

**AAL results:**
<img width="1200" height="1560" alt="image" src="https://github.com/user-attachments/assets/c7ea14aa-a90f-4b86-9474-397492991feb" />


closes https://github.com/OasisLMF/OasisLMF/issues/1995
<!--end_release_notes-->
