### PR TITLE
perf(pytools): speed up stream read_buffer with a packed structured-dtype view

### DIFF
--- a/oasislmf/execution/bash.py
+++ b/oasislmf/execution/bash.py
@@ -1659,7 +1659,7 @@ def get_getmodel_cmd(
 
     else:
         modelcmd = get_modelcmd(modelpy_server, peril_filter)
-        gulcmd = get_gulcmd(gulmc, gul_random_generator, False, 0, False, 0, False, [], model_df_engine=model_df_engine)
+        gulcmd = get_gulcmd(gulmc, gul_random_generator, False, 0, False, 0, model_df_engine=model_df_engine)
         cmd += f'{modelcmd} | {gulcmd} -S{number_of_samples} -L{gul_threshold}'
 
     cmd = '{} -a{}'.format(cmd, gul_alloc_rule)

--- a/oasislmf/pytools/converters/bintocsv/utils/fm.py
+++ b/oasislmf/pytools/converters/bintocsv/utils/fm.py
@@ -2,7 +2,8 @@
 import logging
 import numba as nb
 import numpy as np
-from oasislmf.pytools.common.data import DEFAULT_BUFFER_SIZE, oasis_int, oasis_int_size, oasis_float, oasis_float_size, write_ndarray_to_fmt_csv
+from oasislmf.pytools.common.data import (DEFAULT_BUFFER_SIZE, oasis_int, oasis_int_size, loss_pair_dtype, loss_pair_size,
+                                          write_ndarray_to_fmt_csv)
 from oasislmf.pytools.common.event_stream import (
     FM_STREAM_ID, GUL_STREAM_ID, LOSS_STREAM_ID, EventReader, init_streams_in, mv_read
 )
@@ -66,27 +67,32 @@ def read_buffer(byte_mv, cursor, valid_buff, event_id, item_id, data, idxs, stat
                 break  # Not enough for whole summary header
 
         if state["reading_losses"]:
-            if valid_buff - cursor < oasis_int_size + oasis_float_size:
+            # View the whole remaining (sidx, loss) payload once as a packed
+            # structured array instead of two mv_read slice+casts per pair.
+            n_pairs = (valid_buff - cursor) // loss_pair_size
+            if n_pairs == 0:
                 break  # Not enough for whole record
 
-            # Read sidx
-            sidx, cursor = mv_read(byte_mv, cursor, oasis_int, oasis_int_size)
-            if sidx == 0:  # sidx == 0, end of record
-                cursor += oasis_float_size  # Read extra 0 for end of record
-                _reset_state()
-                continue
+            sidx_loss_view = byte_mv[cursor:cursor + n_pairs * loss_pair_size].view(loss_pair_dtype)
+            for k in range(n_pairs):
+                sidx = sidx_loss_view[k]["sidx"]
+                if sidx == 0:  # sidx == 0, end of record (loss field is the trailing 0)
+                    cursor += (k + 1) * loss_pair_size
+                    _reset_state()
+                    break
 
-            # Read loss
-            loss, cursor = mv_read(byte_mv, cursor, oasis_float, oasis_float_size)
-            data[idx]["event_id"] = event_id
-            data[idx]["output_id"] = item_id
-            data[idx]["sidx"] = sidx
-            data[idx]["loss"] = loss
-            idx += 1
-            if idx >= data.shape[0]:
-                # Output array is full
-                _update_idxs()
-                return cursor, event_id, item_id, 1
+                data[idx]["event_id"] = event_id
+                data[idx]["output_id"] = item_id
+                data[idx]["sidx"] = sidx
+                data[idx]["loss"] = sidx_loss_view[k]["loss"]
+                idx += 1
+                if idx >= data.shape[0]:
+                    # Output array is full
+                    cursor += (k + 1) * loss_pair_size
+                    _update_idxs()
+                    return cursor, event_id, item_id, 1
+            else:
+                cursor += n_pairs * loss_pair_size
         else:
             pass  # Should never reach here
 

--- a/oasislmf/pytools/converters/bintocsv/utils/gul.py
+++ b/oasislmf/pytools/converters/bintocsv/utils/gul.py
@@ -2,7 +2,8 @@
 import logging
 import numba as nb
 import numpy as np
-from oasislmf.pytools.common.data import DEFAULT_BUFFER_SIZE, oasis_int, oasis_int_size, oasis_float, oasis_float_size, write_ndarray_to_fmt_csv
+from oasislmf.pytools.common.data import (DEFAULT_BUFFER_SIZE, oasis_int, oasis_int_size, loss_pair_dtype, loss_pair_size,
+                                          write_ndarray_to_fmt_csv)
 from oasislmf.pytools.common.event_stream import (
     GUL_STREAM_ID, LOSS_STREAM_ID, EventReader, init_streams_in, mv_read
 )
@@ -66,27 +67,32 @@ def read_buffer(byte_mv, cursor, valid_buff, event_id, item_id, data, idxs, stat
                 break  # Not enough for whole summary header
 
         if state["reading_losses"]:
-            if valid_buff - cursor < oasis_int_size + oasis_float_size:
+            # View the whole remaining (sidx, loss) payload once as a packed
+            # structured array instead of two mv_read slice+casts per pair.
+            n_pairs = (valid_buff - cursor) // loss_pair_size
+            if n_pairs == 0:
                 break  # Not enough for whole record
 
-            # Read sidx
-            sidx, cursor = mv_read(byte_mv, cursor, oasis_int, oasis_int_size)
-            if sidx == 0:  # sidx == 0, end of record
-                cursor += oasis_float_size  # Read extra 0 for end of record
-                _reset_state()
-                continue
+            sidx_loss_view = byte_mv[cursor:cursor + n_pairs * loss_pair_size].view(loss_pair_dtype)
+            for k in range(n_pairs):
+                sidx = sidx_loss_view[k]["sidx"]
+                if sidx == 0:  # sidx == 0, end of record (loss field is the trailing 0)
+                    cursor += (k + 1) * loss_pair_size
+                    _reset_state()
+                    break
 
-            # Read loss
-            loss, cursor = mv_read(byte_mv, cursor, oasis_float, oasis_float_size)
-            data[idx]["event_id"] = event_id
-            data[idx]["item_id"] = item_id
-            data[idx]["sidx"] = sidx
-            data[idx]["loss"] = loss
-            idx += 1
-            if idx >= data.shape[0]:
-                # Output array is full
-                _update_idxs()
-                return cursor, event_id, item_id, 1
+                data[idx]["event_id"] = event_id
+                data[idx]["item_id"] = item_id
+                data[idx]["sidx"] = sidx
+                data[idx]["loss"] = sidx_loss_view[k]["loss"]
+                idx += 1
+                if idx >= data.shape[0]:
+                    # Output array is full
+                    cursor += (k + 1) * loss_pair_size
+                    _update_idxs()
+                    return cursor, event_id, item_id, 1
+            else:
+                cursor += n_pairs * loss_pair_size
         else:
             pass  # Should never reach here
 

--- a/oasislmf/pytools/fm/stream_sparse.py
+++ b/oasislmf/pytools/fm/stream_sparse.py
@@ -54,7 +54,7 @@ import logging
 from oasislmf.pytools.common.event_stream import (stream_info_to_bytes, LOSS_STREAM_ID, ITEM_STREAM, PIPE_CAPACITY, EventReader,
                                                   MAX_LOSS_IDX, CHANCE_OF_LOSS_IDX, TIV_IDX, MEAN_IDX,
                                                   mv_read, mv_write_item_header, mv_write_sidx_loss, mv_write_delimiter, write_mv_to_stream)
-from oasislmf.pytools.common.data import oasis_int, oasis_int_size, oasis_float, oasis_float_size
+from oasislmf.pytools.common.data import oasis_int, oasis_int_size, oasis_float_size, loss_pair_dtype, loss_pair_size
 
 logger = logging.getLogger(__name__)
 
@@ -177,11 +177,22 @@ def read_buffer(byte_mv, cursor, valid_buff, event_id, item_id,
     while True:
         if item_id:
             # --- Reading (sidx, loss) pairs for current item ---
-            if valid_buff - cursor < (oasis_int_size + oasis_float_size):
+            # View the whole remaining payload once as packed (sidx, loss) pairs
+            # instead of two mv_read slice+casts per pair.
+            n_pairs = (valid_buff - cursor) // loss_pair_size
+            if n_pairs == 0:
                 break  # Need more data
-            sidx, cursor = mv_read(byte_mv, cursor, oasis_int, oasis_int_size)
-            if sidx:
-                loss, cursor = mv_read(byte_mv, cursor, oasis_float, oasis_float_size)
+            sidx_loss_view = byte_mv[cursor:cursor + n_pairs * loss_pair_size].view(loss_pair_dtype)
+            for k in range(n_pairs):
+                sidx = sidx_loss_view[k]['sidx']
+                if not sidx:
+                    # sidx == 0: Item delimiter reached
+                    reset_empty_items(compute_idx, sidx_indptr, sidx_val, loss_val, computes)
+                    cursor += (k + 1) * loss_pair_size  # consume pairs incl. delimiter
+                    item_id = 0  # Return to header-reading state
+                    break
+
+                loss = sidx_loss_view[k]['loss']
                 loss = 0 if np.isnan(loss) else loss
 
                 # Process the (sidx, loss) pair
@@ -195,10 +206,7 @@ def read_buffer(byte_mv, cursor, valid_buff, event_id, item_id,
                         # Regular sample or special index (-5, -3, -1, 1..N)
                         add_new_loss(sidx, loss, compute_idx['next_compute_i'], sidx_indptr, sidx_val, loss_val)
             else:
-                # sidx == 0: Item delimiter reached
-                reset_empty_items(compute_idx, sidx_indptr, sidx_val, loss_val, computes)
-                cursor += oasis_float_size  # Skip the delimiter's loss value
-                item_id = 0  # Return to header-reading state
+                cursor += n_pairs * loss_pair_size
         else:
             # --- Reading event_id + item_id header ---
             if valid_buff - cursor < 2 * oasis_int_size:

--- a/oasislmf/pytools/pla/streams.py
+++ b/oasislmf/pytools/pla/streams.py
@@ -2,9 +2,9 @@ import numba as nb
 import numpy as np
 import logging
 
-from oasislmf.pytools.common.data import oasis_int, oasis_int_size, oasis_float, oasis_float_size
+from oasislmf.pytools.common.data import oasis_int, oasis_int_size, loss_pair_dtype, loss_pair_size
 from oasislmf.pytools.common.event_stream import (EventReader, get_and_check_header_in, stream_info_to_bytes, write_mv_to_stream,
-                                                  mv_read, mv_write, PIPE_CAPACITY)
+                                                  mv_read, PIPE_CAPACITY)
 
 logger = logging.getLogger(__name__)
 
@@ -33,22 +33,31 @@ def read_buffer(byte_mv, cursor, valid_buff, event_id, item_id, items_amps, plaf
         factor = plafactors.get((event_id, items_amps[item_id]), default_factor)
     while True:
         if item_id:
-            if valid_buff - cursor < (oasis_int_size + oasis_float_size):
+            # View the whole remaining (sidx, loss) payload once and apply the
+            # factor in place, instead of mv_read sidx + mv_read loss + mv_write
+            # per pair. The view shares memory with byte_mv, so writing the loss
+            # field updates the buffer that is bulk-copied to out_byte_mv below.
+            n_pairs = (valid_buff - cursor) // loss_pair_size
+            if n_pairs == 0:
                 break
-            sidx, cursor = mv_read(byte_mv, cursor, oasis_int, oasis_int_size)
-            if sidx:
-                loss, _ = mv_read(byte_mv, cursor, oasis_float, oasis_float_size)
+            sidx_loss_view = byte_mv[cursor:cursor + n_pairs * loss_pair_size].view(loss_pair_dtype)
+            for k in range(n_pairs):
+                sidx = sidx_loss_view[k]['sidx']
+                if not sidx:
+                    ##### do item exit ####
+                    ##########
+                    cursor += (k + 1) * loss_pair_size
+                    item_id = 0
+                    break
+
+                loss = sidx_loss_view[k]['loss']
                 loss = 0 if np.isnan(loss) else loss
 
                 ###### do loss read ######
-                cursor = mv_write(byte_mv, cursor, oasis_float, oasis_float_size, loss * factor)
+                sidx_loss_view[k]['loss'] = loss * factor
                 ##########
-
             else:
-                ##### do item exit ####
-                ##########
-                cursor += oasis_float_size
-                item_id = 0
+                cursor += n_pairs * loss_pair_size
         else:
             if valid_buff - cursor < 2 * oasis_int_size:
                 break
@@ -66,22 +75,29 @@ def read_buffer(byte_mv, cursor, valid_buff, event_id, item_id, items_amps, plaf
 def read_buffer_uniform(byte_mv, cursor, valid_buff, event_id, item_id, items_amps, plafactors, default_factor, out_byte_mv, out_cursor):
     while True:
         if item_id:
-            if valid_buff - cursor < (oasis_int_size + oasis_float_size):
+            # View the whole remaining (sidx, loss) payload once and apply the
+            # uniform factor in place (see read_buffer for details).
+            n_pairs = (valid_buff - cursor) // loss_pair_size
+            if n_pairs == 0:
                 break
-            sidx, cursor = mv_read(byte_mv, cursor, oasis_int, oasis_int_size)
-            if sidx:
-                loss, _ = mv_read(byte_mv, cursor, oasis_float, oasis_float_size)
+            sidx_loss_view = byte_mv[cursor:cursor + n_pairs * loss_pair_size].view(loss_pair_dtype)
+            for k in range(n_pairs):
+                sidx = sidx_loss_view[k]['sidx']
+                if not sidx:
+                    ##### do item exit ####
+                    ##########
+                    cursor += (k + 1) * loss_pair_size
+                    item_id = 0
+                    break
+
+                loss = sidx_loss_view[k]['loss']
                 loss = 0 if np.isnan(loss) else loss
 
                 ###### do loss read ######
-                cursor = mv_write(byte_mv, cursor, oasis_float, oasis_float_size, loss * default_factor)
+                sidx_loss_view[k]['loss'] = loss * default_factor
                 ##########
-
             else:
-                ##### do item exit ####
-                ##########
-                cursor += oasis_float_size
-                item_id = 0
+                cursor += n_pairs * loss_pair_size
         else:
             if valid_buff - cursor < 2 * oasis_int_size:
                 break

--- a/tests/model_execution/test_bash.py
+++ b/tests/model_execution/test_bash.py
@@ -318,6 +318,25 @@ class Genbash_LoadBalancer_and_gulpy(GenbashBase):
         cls.num_fm_per_lb = 2
         cls.gulmc = False
 
+    def test_gulpy_pipeline_renders(self):
+        """gulmc=False must render the modelpy|gulpy pipeline without error.
+
+        Regression test: the gulpy branch of get_getmodel_cmd passed conflicting
+        arguments to get_gulcmd, raising a TypeError during bash generation and
+        breaking every gulpy run. Note this class sets cls.gulmc=False, but the
+        genbash() helper resolves ``gulmc or self.gulmc`` so gulmc=False must be
+        passed explicitly to actually exercise the gulpy path (otherwise the
+        True default wins and gulmc is rendered instead).
+        """
+        name = "gul_summarycalc_1_output"
+        self.genbash(name, 1, gulmc=False)
+        with open(self._get_output_filename(name, 1), encoding='utf-8') as f:
+            script = f.read()
+        # gulpy command rendered (bare 'gulmc'/'gulpy' also appear in proc_list,
+        # so key on the actual invocation with its --random-generator flag).
+        self.assertIn("gulpy --random-generator", script)
+        self.assertNotIn("gulmc --random-generator", script)
+
 
 # Special case: Custom gulcalc tests
 class Genbash_CustomGulcalc(GenbashBase):


### PR DESCRIPTION
## Summary

Extends the `summarypy` `read_buffer` optimisation from #1992 to the remaining
pytools stream readers. In the hot loop, each `(sidx, loss)` pair was read with
two `mv_read` calls — each a `byte_mv[c:c+n].view(dtype)[0]` slice+cast. This
replaces them with a **single `.view(loss_pair_dtype)`** over the contiguous
payload, iterating by field — removing two slice+casts per pair.

Files (output is **byte-identical** to before in every case):
- `converters/bintocsv/utils/gul.py`, `fm.py` — bulk-view the whole payload
- `fm/stream_sparse.py` — the `fmpy` input reader
- `pla/streams.py` — `read_buffer` + `read_buffer_uniform`, viewing the payload
  once and writing `loss * factor` back **through the view** in place

Also includes a small, independent fix needed to run `gulpy` at all:
`get_getmodel_cmd`'s `gulmc=False` branch passed conflicting args to
`get_gulcmd` (`TypeError: got multiple values for argument 'model_df_engine'`).

## Performance (Piwind)

Isolated read-path micro-benchmarks (median, `~/venv_3.12`):

| tool | read path | end-to-end |
|------|----------:|-----------:|
| bintocsv gul | ~6.4× | ~1.40× |
| bintocsv fm | ~4.5× | ~1.35× |
| plapy (read+modify+write) | — | ~3.2× |
| fmpy | ~2× (read path) | see below |

**fmpy: ~10% faster end-to-end on Piwind** (local full runs: ~143s → ~122s,
consistent across 2/2 runs). The gain is largest where stream reading is a real
fraction of the work (converters, plapy); for tools dominated by downstream
compute it is smaller.

`elt`/`plt` were evaluated too but reverted — the per-pair view there was within
run-to-run noise (no reliable win), so they're left unchanged.

## Testing
`tests/pytools/{converters,fm,pla,summarypy,eltpy,pltpy}` and
`tests/fm/test_fmpy.py` pass; output verified byte-identical (md5) before/after
on captured Piwind GUL/FM/summary streams.

<!--start_release_notes-->
- Speed up pytools stream `read_buffer` (bintocsv gul/fm converters, fmpy input
  reader, plapy) via a packed structured-dtype view, ~10% faster fmpy on Piwind;
  output unchanged.
- Fix a `TypeError` in `get_getmodel_cmd` that broke `gulpy` (gulmc=False) runs.
<!--end_release_notes-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)