### PR TITLE
Fix gulmc crash when no dynamic_model_adjustment step (item_adjustments.csv absent)

### DIFF
--- a/oasislmf/pytools/gulmc/items.py
+++ b/oasislmf/pytools/gulmc/items.py
@@ -299,10 +299,9 @@ def get_dynamic_footprint_adjustments(input_path):
     adjustments_fn = os.path.join(input_path, 'item_adjustments.csv')
     if os.path.isfile(adjustments_fn):
         adjustments_tb = np.loadtxt(adjustments_fn, dtype=ItemAdjustment, delimiter=",", skiprows=1, ndmin=1)
-    else:
-        items_fp = os.path.join(input_path, 'items.csv')
-        items_tb = np.loadtxt(items_fp, dtype=items_dtype, delimiter=",", skiprows=1, ndmin=1)
-        adjustments_tb = np.array([(i[0], 0, 0) for i in items_tb], dtype=ItemAdjustment)
+    else: # Fall back to the items file (items.bin or items.csv) with zero adjustments.
+        items_tb = read_items(input_path)
+        adjustments_tb = np.array([(i['item_id'], 0, 0) for i in items_tb], dtype=ItemAdjustment)
 
     return adjustments_tb
 

--- a/oasislmf/pytools/gulmc/items.py
+++ b/oasislmf/pytools/gulmc/items.py
@@ -299,7 +299,7 @@ def get_dynamic_footprint_adjustments(input_path):
     adjustments_fn = os.path.join(input_path, 'item_adjustments.csv')
     if os.path.isfile(adjustments_fn):
         adjustments_tb = np.loadtxt(adjustments_fn, dtype=ItemAdjustment, delimiter=",", skiprows=1, ndmin=1)
-    else: # Fall back to the items file (items.bin or items.csv) with zero adjustments.
+    else:  # Fall back to the items file (items.bin or items.csv) with zero adjustments.
         items_tb = read_items(input_path)
         adjustments_tb = np.array([(i['item_id'], 0, 0) for i in items_tb], dtype=ItemAdjustment)
 

--- a/tests/pytools/gulmc/test_gulmc.py
+++ b/tests/pytools/gulmc/test_gulmc.py
@@ -3,14 +3,17 @@ This file tests gulmc functionality
 """
 import filecmp
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Tuple
 from unittest.mock import patch
+import numpy as np
 import pandas as pd
 import pytest
 
+from oasislmf.pytools.gulmc.items import get_dynamic_footprint_adjustments
 from oasislmf.pytools.gulmc.manager import run as run_gulmc
 from oasislmf.pytools.utils import assert_allclose
 from oasislmf.pytools.converters.bintocsv.manager import bintocsv
@@ -346,3 +349,25 @@ def test_adjustments(test_model: Tuple[str, str]):
             # remove temporary file
             file_out.unlink()
             file_out.with_suffix('.csv').unlink()
+
+
+def test_get_dynamic_footprint_adjustments_without_item_adjustments_bin_only():
+    """Regression test for issue #2015.
+
+    When the keys stage does not run a `dynamic_model_adjustment` step,
+    `item_adjustments.csv` is absent and the items file only exists as
+    `items.bin`. The fallback must read the binary items file (rather than
+    hard-coding `items.csv`) and return zero adjustments per item.
+    """
+    src_items_bin = TESTS_ASSETS_DIR.joinpath("test_adjustments_1", "input", "items.bin")
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        # only items.bin is present: no item_adjustments.csv and no items.csv
+        shutil.copy(src_items_bin, tmp_dir.joinpath("items.bin"))
+
+        adjustments = get_dynamic_footprint_adjustments(str(tmp_dir))
+
+        assert len(adjustments) == 1
+        assert adjustments[0]["item_id"] == 1
+        assert np.all(adjustments["intensity_adjustment"] == 0)
+        assert np.all(adjustments["return_period"] == 0)


### PR DESCRIPTION
## Summary

Fixes #2015.

When the keys stage does not run a `dynamic_model_adjustment` step, no `item_adjustments.csv` is generated. The fallback in `get_dynamic_footprint_adjustments` (`oasislmf/pytools/gulmc/items.py`) hard-coded `items.csv`, but in a normal run the items file only exists as `items.bin` — so gulmc crashed with:

```
FileNotFoundError: .../input/items.csv not found.
```

## Fix

Use the existing `read_items()` helper, which already handles both `items.bin` (memmap) and `items.csv`, and return zero adjustments per item when `item_adjustments.csv` is absent.

## Test

Added `test_get_dynamic_footprint_adjustments_without_item_adjustments_bin_only`, which copies only `items.bin` (no `item_adjustments.csv`, no `items.csv`) into a temp directory and asserts the fallback returns zero adjustments. Verified the test fails on the previous code (`FileNotFoundError`) and passes with the fix.

<!--start_release_notes-->
- Fixed a crash in gulmc for dynamic footprint models when the keys stage does not include a `dynamic_model_adjustment` step: the missing `item_adjustments.csv` fallback now reads `items.bin` as well as `items.csv`.
<!--end_release_notes-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)