### PR TITLE
Fix ValueError: cannot convert NA to integer for acc_idx #1989

### DIFF
--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -871,7 +871,7 @@ def get_il_input_items(
                     continue
 
                 # reset non layered agg_id
-                layered_agg_id = gul_inputs_df[gul_inputs_df['layer_id'] > 1]["agg_id_prev"].unique()
+                layered_agg_id = gul_inputs_df[gul_inputs_df['layer_id'] > 0]["agg_id_prev"].unique()
                 gul_inputs_df['layer_id'] = gul_inputs_df['layer_id'].where(gul_inputs_df['agg_id_prev'].isin(layered_agg_id), 0)
 
                 # get all rows with terms in term_df_source and determine the correct FMTermGroupID


### PR DESCRIPTION
## Bug: `ValueError: cannot convert NA to integer` for `acc_idx` on single-layer policies

**OasisLMF version:** 2.5.4  
**Affected file:** `oasislmf/preparation/il_inputs.py` 

---

## Description

Running a model with a single account (trivial case) still fails with:

```
ValueError: cannot convert NA to integer: Error while type casting for column 'acc_idx'
```

**location.csv**
```csv
PortNumber,AccNumber,LocNumber,...,OEDVersion
1,1,312,...,4.0.0
```

**account.csv**
```csv
AccNumber,PortNumber,PolNumber,AccCurrency,PolPerilsCovered,OEDVersion
1,1,1,AUD,BBF,4.0.0
```

## Root Cause

In `get_il_input_items`, the `acc_idx` column is joined onto `gul_inputs_df` via a left merge at line ~1259:

```python
gul_inputs_df = (
    gul_inputs_df
    .merge(accounts_df[acc_idx_col + ['acc_idx']].drop_duplicates(subset=acc_idx_col),
           how='left', validate='many_to_one'))
```

For a single-layer policy, `layer_id == 1` int the account_df but `layer_id == 0` in the 
gul_inputs_df at this point. Meaning that the join leaves the gul_inputs_df with 'acc_idx == NaN' 

The first assignment of the ["layer_id"] occurs at line ~764 with a blanket assignment of 1. 
This is later set as 0 at line ~874.

```python
layered_agg_id = gul_inputs_df[gul_inputs_df['layer_id'] > 1]["agg_id_prev"].unique()
gul_inputs_df['layer_id'] = gul_inputs_df['layer_id'].where(gul_inputs_df['agg_id_prev'].isin(layered_agg_id), 0)
```

The condition `layer_id > 1` (strictly greater than) misses single-layer policies where `layer_id == 1`, so `layered_agg_id` is empty:

```python
layered_agg_id
# array([], dtype=int32)
```

This causes `.where(...isin(layered_agg_id), 0)` to zero-out **all** `layer_id` values. With `layer_id` reset to `0`, the subsequent merge on `acc_idx_col` (which includes `layer_id`) fails to match any rows in `accounts_df`, resulting in `acc_idx = <NA>` for all rows, which then fails the integer cast.

## Fix

Change `> 1` to `> 0` so single-layer policies (`layer_id == 1`) are correctly included:

```python
# before
layered_agg_id = gul_inputs_df[gul_inputs_df['layer_id'] > 1]["agg_id_prev"].unique()

# after
layered_agg_id = gul_inputs_df[gul_inputs_df['layer_id'] > 0]["agg_id_prev"].unique()
```

## Testing
This was then retested and the result seem fine with the trivial and non trivial case.
As we typically test on ELT/AEP/OEP with simple portfolios i am unsure what would be the 
best stress this. Though I will be rerunning on our test suite i expect this patch to work.

This is still a naive fix and i cannot ensure that this doesnt cause any upstream issues,
mainly due to not being able to know or test the full scope of this change.

