### PR TITLE
Fix CI unittest flags on Pytest 9.1

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,27 @@
+def pytest_addoption(parser):
+    parser.addoption(
+        '--gul-rtol', type=float, default=1e-10,
+        help='Relative tolerance between expected values and results, default is "1e-10"'
+    )
+    parser.addoption(
+        '--gul-atol', type=float, default=1e-8,
+        help='Absolute tolerance between expected values and results, default is "1e-8"'
+    )
+    parser.addoption(
+        '--gulmc-generate-missing-expected', action='store_true', default=False,
+        help='If True, generate the expected files for the tests that lack them (e.g., newly added tests). Default: False.'
+    )
+    parser.addoption(
+        '--update-expected', action='store_true', default=False,
+        help='If True, update all the expected files, overwriting them if they exist. Default: False.'
+    )
+    parser.addoption(
+        '--fm-keep-output', action='store_true', default=False,
+        help='If True, keep the test results (useful for debugging purposes). Default: False.'
+    )
+    parser.addoption(
+        '--remine-hash-collisions', action='store_true', default=False,
+        help='If True, brute-force a fresh colliding-int32-keys set for the hashmap '
+             'collision test and print it for paste-back. Use when the hash function '
+             'in oasislmf.pytools.common.hashmap changes. Adds ~5-15 s to the run.'
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ description_file = README.md
 [tool:pytest]
 exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,.ropeproject
 python_classes =
+testpaths = tests
 markers =
     jit_compile: marks tests that trigger JIT compilation of Numba functions
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,5 +12,3 @@ def _use_tmp_log_dir(tmp_path_factory):
     yield
     del os.environ['OASIS_PYTEST_REDIRECT_LOGS']
     del os.environ['OASIS_TMPDIR']
-
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,30 +14,3 @@ def _use_tmp_log_dir(tmp_path_factory):
     del os.environ['OASIS_TMPDIR']
 
 
-def pytest_addoption(parser):
-    parser.addoption(
-        '--gul-rtol', type=float, default=1e-10,
-        help='Relative tolerance between expected values and results, default is "1e-10"'
-    )
-    parser.addoption(
-        '--gul-atol', type=float, default=1e-8,
-        help='Absolute tolerance between expected values and results, default is "1e-8"'
-    )
-    parser.addoption(
-        '--gulmc-generate-missing-expected', action='store_true', default=False,
-        help='If True, generate the expected files for the tests that lack them (e.g., newly added tests). Default: False.'
-    )
-    parser.addoption(
-        '--update-expected', action='store_true', default=False,
-        help='If True, update all the expected files, overwriting them if they exist. Default: False.'
-    )
-    parser.addoption(
-        '--fm-keep-output', action='store_true', default=False,
-        help='If True, keep the test results (useful for debugging purposes). Default: False.'
-    )
-    parser.addoption(
-        '--remine-hash-collisions', action='store_true', default=False,
-        help='If True, brute-force a fresh colliding-int32-keys set for the hashmap '
-             'collision test and print it for paste-back. Use when the hash function '
-             'in oasislmf.pytools.common.hashmap changes. Adds ~5-15 s to the run.'
-    )


### PR DESCRIPTION
<!--start_release_notes-->
### Fix CI for Pytest 9.1
main fails due to how the newer pytest package loads conftest.py
<!--end_release_notes-->


**Example:** 
https://github.com/OasisLMF/OasisLMF/actions/runs/27533211303/job/81389900877