### PR TITLE
fix(lookup): assume EPSG:4326 when geometry file has no CRS metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 OasisLMF Changelog
 ==================
 
+`2.5.5`_
+ ---------
+* [#2023](https://github.com/OasisLMF/OasisLMF/pull/2023) - fix(lookup): assume EPSG:4326 and warn when geometry file has no CRS metadata
+
 `2.5.4`_
  ---------
 * [#1940](https://github.com/OasisLMF/OasisLMF/pull/1940) - enhancement/profile check script
@@ -26,6 +30,7 @@ OasisLMF Changelog
 * [#1994](https://github.com/OasisLMF/OasisLMF/pull/1994) - fix summarypy missing dtypes
 * [#1997](https://github.com/OasisLMF/OasisLMF/pull/1997) - Fix for ci error
 * [#1999](https://github.com/OasisLMF/OasisLMF/pull/1999) - fix/input_gen_status
+.. _`2.5.5`:  https://github.com/OasisLMF/OasisLMF/compare/2.5.4...2.5.5
 .. _`2.5.4`:  https://github.com/OasisLMF/OasisLMF/compare/2.5.3...2.5.4
 
 `2.5.3`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,6 @@
 OasisLMF Changelog
 ==================
 
-`2.5.5`_
- ---------
-* [#2023](https://github.com/OasisLMF/OasisLMF/pull/2023) - fix(lookup): assume EPSG:4326 and warn when geometry file has no CRS metadata
-
 `2.5.4`_
  ---------
 * [#1940](https://github.com/OasisLMF/OasisLMF/pull/1940) - enhancement/profile check script
@@ -30,7 +26,6 @@ OasisLMF Changelog
 * [#1994](https://github.com/OasisLMF/OasisLMF/pull/1994) - fix summarypy missing dtypes
 * [#1997](https://github.com/OasisLMF/OasisLMF/pull/1997) - Fix for ci error
 * [#1999](https://github.com/OasisLMF/OasisLMF/pull/1999) - fix/input_gen_status
-.. _`2.5.5`:  https://github.com/OasisLMF/OasisLMF/compare/2.5.4...2.5.5
 .. _`2.5.4`:  https://github.com/OasisLMF/OasisLMF/compare/2.5.3...2.5.4
 
 `2.5.3`_

--- a/oasislmf/lookup/builtin.py
+++ b/oasislmf/lookup/builtin.py
@@ -710,6 +710,11 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
             raise OasisException(f"Unrecognised Geopandas read type {file_type}")
 
         if gdf_geometry.crs is None:
+            warnings.warn(
+                f"Geometry file '{file_path}' has no CRS metadata — assuming EPSG:4326. "
+                "Re-save the file with a CRS to suppress this warning.",
+                UserWarning,
+            )
             gdf_geometry = gdf_geometry.set_crs("EPSG:4326")
 
         if nearest_neighbor_max_distance > 0:

--- a/oasislmf/lookup/builtin.py
+++ b/oasislmf/lookup/builtin.py
@@ -709,6 +709,9 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
         else:
             raise OasisException(f"Unrecognised Geopandas read type {file_type}")
 
+        if gdf_geometry.crs is None:
+            gdf_geometry = gdf_geometry.set_crs("EPSG:4326")
+
         if nearest_neighbor_max_distance > 0:
             if BallTree is None:
                 raise OasisException(f"scikit-learn modules are needed for rtree with nearest_neighbor_max_distance, {OPT_INSTALL_MESSAGE}")


### PR DESCRIPTION
## Summary

- Geometry files (e.g. parquet) generated with older geopandas versions may lack embedded CRS metadata, resulting in `CRS: None`
- Newer geopandas enforces CRS matching on `gpd.sjoin()`, crashing with a `Use to_crs() to reproject` error
- After reading the geometry file, fall back to `set_crs("EPSG:4326")` if no CRS is present

Fixes #2022

## Test plan

- [ ] Run rtree lookup with a parquet geometry file that has no embedded CRS — confirm no crash
- [ ] Run rtree lookup with a parquet geometry file that has EPSG:4326 embedded — confirm no change in behaviour
- [ ] Run rtree lookup with a shapefile (has CRS) — confirm no change in behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)