### PR TITLE
fix(ri): always use net retained output for RI layer losses (#1877)

### DIFF
--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -971,7 +971,7 @@ class GenerateLossesDeterministic(ComputationStep):
                                 files_out=[ri_layer_bin_fp],
                                 low_memory=self.fmpy_low_memory,
                                 sort_output=self.fmpy_sort_output,
-                                net_loss='' if self.net_ri else None,
+                                net_loss='',
                                 storage_method='sparse',
                             )
                             bintocsv(ri_layer_bin_fp, ri_layer_fp, "fm")
@@ -989,9 +989,7 @@ class GenerateLossesDeterministic(ComputationStep):
                         return rils
 
                     for i in range(1, ri_layers + 1):
-                        rils = run_ri_layer(i)
-                        if i in [1, ri_layers]:
-                            losses['ri'] = rils
+                        losses['ri'] = run_ri_layer(i)
 
         return losses
 

--- a/oasislmf/preparation/reinsurance_layer.py
+++ b/oasislmf/preparation/reinsurance_layer.py
@@ -489,7 +489,9 @@ def write_files_for_reinsurance(ri_info_df, ri_scope_df, xref_descriptions_df, o
                 ['level_id', 'agg_id', 'layer_id', 'profile_id']
             ].reset_index(drop=True)
             fm_policytc_df['level_id'] = fm_policytc_df['level_id'] - 1
-            # Net losses across all layers is associated to the max layer ID.
+            # fmpy outputs net_loss[layer_i] = IL - sum(ceded_1..i), so pointing
+            # fm_xref to the maximum layer gives the final net retained after all
+            # parallel treaties at this inuring priority.
             fm_xref_df['layer_id'] = fm_policytc_df['layer_id'].max()
 
             _log_dataframe(logger, {'fm_programme_df': fm_programme_df, 'fm_profile_df': fm_profile_df,


### PR DESCRIPTION
## Summary

- Fixes #1877: when a reinsurance contract has multiple FM layers (parallel treaties at the same inuring priority), only the last layer's loss was captured in the output
- Changed `net_loss='' if self.net_ri else None` → `net_loss=''` in the RI fmpy call so net retained is always used
- Simplified the RI loop by removing the redundant `if i in [1, ri_layers]` condition (it was already only keeping the last layer anyway)
- Updated the `fm_xref` comment in `reinsurance_layer.py` to explain why `layer_id=max` is correct

## Root cause

`GenerateLossesDeterministic` defaulted to `net_ri=False`, causing `net_loss=None` (gross/ceded output) to be passed to fmpy. Since `fm_xref` maps all items to the maximum FM layer ID, this only captured the last treaty layer's ceded amounts — earlier layers were silently dropped.

## Why `net_loss=''` is always correct

fmpy uses a cumulative formula: `net_loss[layer_i] = IL - sum(ceded_1..i)`. Pointing `fm_xref` to `layer_id=max` therefore gives the **final net retained after all parallel treaties** at one inuring priority — including items covered only by earlier layers. This holds for both:
- A single RI directory with N FM layers (parallel treaties)
- Multiple RI directories (sequential inuring priorities) — each `ri{i}.bin` correctly feeds the next directory as net retained input

Using `net_loss=None` was also wrong for multi-directory RI because ceded amounts were written to `ri{i}.bin` and then passed as input to the next inuring priority directory, which expects net retained values. The formula in `exposure.py` also always interprets `rils` as net retained (`total_ri_ceded = total_il - rils.loss_ri.sum()`), making `net_loss=None` semantically inconsistent.

## Test plan

- [x] `tests/fm/test_fmpy.py` — all 21 FM acceptance tests pass (including `test_reinsurance4` and `test_issues`)
- [x] `tests/computation/test_generate_losses.py` — all 23 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)