### PR TITLE
perf(lecpy): chunk .idx summaries (K) to remove the per-summary slowdown

### DIFF
--- a/oasislmf/pytools/lec/aggreports/aggreports.py
+++ b/oasislmf/pytools/lec/aggreports/aggreports.py
@@ -349,7 +349,7 @@ class AggReports():
 # ---------------------------------------------------------------------------
 
 def output_for_summary_idx(
-    summary_id,
+    chunk_ids,
     outloss_mean_s,
     row_used_mean_s,
     outloss_sample_s,
@@ -361,10 +361,12 @@ def output_for_summary_idx(
     config,
     output_fn,
 ):
-    """Output all report types for a single summary_id (idx path).
+    """Output all report types for a chunk of summary_ids (idx path).
 
-    Called once per summary_id. config.max_summary_id must be 1; arrays are sized
-    for a single summary. Write generators emit SummaryId=1, corrected here before each write.
+    Called once per chunk. config.max_summary_id must equal len(chunk_ids); arrays are
+    sized for that many summaries. Write generators emit a 1-based local SummaryId
+    (1..len(chunk_ids)); it is remapped to the real summary_id before each write.
+    chunk_ids of length 1 reproduces the original strict per-summary behaviour.
     """
     row_used_indices_mean = np.flatnonzero(row_used_mean_s)
     row_used_indices_sample = np.flatnonzero(row_used_sample_s)
@@ -373,7 +375,7 @@ def output_for_summary_idx(
 
     def _out(data, out_type):
         if len(data):
-            data["SummaryId"] = summary_id
+            data["SummaryId"] = chunk_ids[data["SummaryId"] - 1]  # local slot → real summary_id
         output_fn(data, out_type)
 
     if outmap["ept"]["compute"] and (hasOCC or hasAGG):
@@ -384,7 +386,7 @@ def output_for_summary_idx(
             if not wanted:
                 continue
             items = np.zeros(len(row_used_indices_mean), dtype=LOSSVEC2MAP_dtype)
-            items_start_end = np.full((1, 2), -1, dtype=np.int32)
+            items_start_end = np.full((config.max_summary_id, 2), -1, dtype=np.int32)
             _write_mean_damage_ratio(
                 items, items_start_end, row_used_indices_mean,
                 outloss_mean_s[outloss_type], config, eptype, eptype_tvar, _out,
@@ -397,7 +399,7 @@ def output_for_summary_idx(
         if not output_flags[flag]:
             continue
         items = np.zeros(len(row_used_indices_sample), dtype=LOSSVEC2MAP_dtype)
-        items_start_end = np.full((1, 2), -1, dtype=np.int32)
+        items_start_end = np.full((config.max_summary_id, 2), -1, dtype=np.int32)
         _write_full_uncertainty(
             items, items_start_end, row_used_indices_sample,
             outloss_sample_s[outloss_type], config, eptype, eptype_tvar, _out,
@@ -412,8 +414,8 @@ def output_for_summary_idx(
         if not (do_wheat or do_wheat_mean):
             continue
         wheatsheaf_items = np.zeros(len(row_used_indices_sample), dtype=WHEATKEYITEMS_dtype)
-        wheatsheaf_items_start_end = np.full((config.num_sidxs, 2), -1, dtype=np.int32)
-        mean_map = np.zeros((1, len(config.returnperiods)), dtype=MEANMAP_dtype) if do_wheat_mean else None
+        wheatsheaf_items_start_end = np.full((config.max_summary_id * config.num_sidxs, 2), -1, dtype=np.int32)
+        mean_map = np.zeros((config.max_summary_id, len(config.returnperiods)), dtype=MEANMAP_dtype) if do_wheat_mean else None
         _write_wheatsheaf(
             wheatsheaf_items, wheatsheaf_items_start_end, mean_map,
             row_used_indices_sample, outloss_sample_s[outloss_type],
@@ -431,7 +433,7 @@ def output_for_summary_idx(
         if not output_flags[flag]:
             continue
         reordered = np.zeros(
-            config.no_of_periods,
+            config.no_of_periods * config.max_summary_id,
             dtype=np.dtype([("row_used", np.bool_), ("value", oasis_float)]),
         )
         _write_sample_mean(

--- a/oasislmf/pytools/lec/manager.py
+++ b/oasislmf/pytools/lec/manager.py
@@ -1,6 +1,7 @@
 # lec/manager.py
 
 import logging
+import os
 import shutil
 import numpy as np
 import numba as nb
@@ -23,6 +24,11 @@ from oasislmf.pytools.utils import redirect_logging
 
 
 logger = logging.getLogger(__name__)
+
+# Number of summary_ids processed together per chunk in the .idx path. K=1 is the
+# original strict per-summary behaviour; larger K amortises the fixed per-call kernel
+# and CSV-write overhead while keeping peak working memory at O(periods × sidxs × K).
+LEC_IDX_CHUNK_SIZE = int(os.environ.get("OASIS_LEC_IDX_CHUNK", "64"))
 
 
 def read_input_files(
@@ -151,6 +157,7 @@ def do_lec_output_agg_summary(
 def process_summary_entries(
     fin,
     offsets,
+    local_sids,
     occ_map,
     use_return_period,
     outloss_mean_s,
@@ -158,15 +165,19 @@ def process_summary_entries(
     outloss_sample_s,
     row_used_sample_s,
     num_sidxs,
+    max_summary_id,
 ):
-    """Process all indexed event blocks for one (summary_id, file) pair in a single call.
+    """Process all indexed event blocks for one (chunk, file) pair in a single call.
 
     Eliminates per-event Python→numba overhead by looping over all offsets inside numba.
-    offsets should be sorted ascending for best OS page-cache utilisation.
+    offsets should be sorted ascending for best OS page-cache utilisation; local_sids[i]
+    is the 1-based slot (within the chunk) that offsets[i]'s summary maps to, and
+    max_summary_id is the chunk size used as the stride into the output arrays.
     """
     valid_buff = len(fin)
-    for offset in offsets:
-        cursor = offset
+    for i in range(len(offsets)):
+        cursor = offsets[i]
+        local_sid = local_sids[i]
         event_id, cursor = mv_read(fin, cursor, oasis_int, oasis_int_size)
         _, cursor = mv_read(fin, cursor, oasis_int, oasis_int_size)    # summary_id known from idx
         _, cursor = mv_read(fin, cursor, oasis_float, oasis_float_size)  # expval
@@ -184,10 +195,10 @@ def process_summary_entries(
                 continue
             if loss > 0 or use_return_period:
                 do_lec_output_agg_summary(
-                    1, sidx, loss, filtered_occ_map,
+                    local_sid, sidx, loss, filtered_occ_map,
                     outloss_mean_s, row_used_mean_s,
                     outloss_sample_s, row_used_sample_s,
-                    num_sidxs, 1,
+                    num_sidxs, max_summary_id,
                 )
 
 
@@ -506,41 +517,59 @@ def run(
             # Open output files before the loop so headers are written once
             _open_output_files(outmap, stack, output_binary, output_parquet, noheader)
 
+            output_fn = make_output_fn(outmap, output_binary, output_parquet)
+
+            # Process summaries in chunks of K to amortise the fixed per-call kernel and
+            # CSV-write overhead, while keeping peak working memory at O(periods × sidxs × K).
+            chunk_size = max(1, LEC_IDX_CHUNK_SIZE)
+
             idx_config = LecConfig(
                 period_weights=file_data["period_weights"],
-                max_summary_id=1,
+                max_summary_id=chunk_size,
                 sample_size=int(sample_size),
                 no_of_periods=no_of_periods,
                 num_sidxs=num_sidxs,
                 use_return_period=use_return_period,
                 returnperiods=file_data["returnperiods"],
             )
-            output_fn = make_output_fn(outmap, output_binary, output_parquet)
 
-            # Per-summary arrays — no × max_summary_id factor
-            outloss_mean_s = np.zeros(no_of_periods, dtype=OUTLOSS_DTYPE)
-            outloss_sample_s = np.zeros(no_of_periods * num_sidxs, dtype=OUTLOSS_DTYPE)
-            row_used_mean_s = np.zeros(no_of_periods, dtype=np.bool_)
-            row_used_sample_s = np.zeros(no_of_periods * num_sidxs, dtype=np.bool_)
+            # Per-chunk arrays — sized for K summaries (not the full max_summary_id)
+            outloss_mean_s = np.zeros(no_of_periods * chunk_size, dtype=OUTLOSS_DTYPE)
+            outloss_sample_s = np.zeros(no_of_periods * num_sidxs * chunk_size, dtype=OUTLOSS_DTYPE)
+            row_used_mean_s = np.zeros(no_of_periods * chunk_size, dtype=np.bool_)
+            row_used_sample_s = np.zeros(no_of_periods * num_sidxs * chunk_size, dtype=np.bool_)
 
             # Pre-compute uint8 views once — numpy's struct[:]=0 is ~4x slower than raw byte zeroing
             _mean_bytes = outloss_mean_s.view(np.uint8)
             _sample_bytes = outloss_sample_s.view(np.uint8)
 
-            for summary_id in unique_summary_ids:
+            merged_sids = merged["summary_id"]
+            for start in range(0, len(unique_summary_ids), chunk_size):
+                chunk_ids = unique_summary_ids[start:start + chunk_size]
+                kc = len(chunk_ids)
+                idx_config.max_summary_id = kc  # array stride for this chunk
+
                 _mean_bytes[:] = 0
                 _sample_bytes[:] = 0
                 row_used_mean_s[:] = False
                 row_used_sample_s[:] = False
 
-                lo = int(np.searchsorted(merged["summary_id"], summary_id, side="left"))
-                hi = int(np.searchsorted(merged["summary_id"], summary_id, side="right"))
+                # merged is sorted by summary_id, so this chunk is one contiguous slice
+                lo = int(np.searchsorted(merged_sids, chunk_ids[0], side="left"))
+                hi = int(np.searchsorted(merged_sids, chunk_ids[-1], side="right"))
                 entries = merged[lo:hi]
+                # 1-based slot within the chunk for each entry's summary_id
+                local = (np.searchsorted(chunk_ids, entries["summary_id"]) + 1).astype(np.int32)
+
                 for fi in np.unique(entries["file_index"]):
-                    offsets = np.sort(entries[entries["file_index"] == fi]["offset"])
+                    fmask = entries["file_index"] == fi
+                    offsets = entries["offset"][fmask]
+                    lsids = local[fmask]
+                    order = np.argsort(offsets, kind="stable")  # ascending offsets for page-cache
                     process_summary_entries(
                         file_handles[int(fi)],
-                        offsets,
+                        offsets[order],
+                        lsids[order],
                         file_data["occ_map"],
                         use_return_period,
                         outloss_mean_s,
@@ -548,10 +577,11 @@ def run(
                         outloss_sample_s,
                         row_used_sample_s,
                         num_sidxs,
+                        kc,
                     )
 
                 output_for_summary_idx(
-                    int(summary_id),
+                    chunk_ids,
                     outloss_mean_s, row_used_mean_s,
                     outloss_sample_s, row_used_sample_s,
                     output_flags, hasOCC, hasAGG,

--- a/tests/pytools/lecpy/test_lecpy.py
+++ b/tests/pytools/lecpy/test_lecpy.py
@@ -6,7 +6,7 @@ from tempfile import TemporaryDirectory
 import numpy as np
 import pandas as pd
 import pytest
-from oasislmf.pytools.common.data import summary_stream_index_dtype
+from oasislmf.pytools.common.data import occurrence_dtype, summary_stream_index_dtype
 from oasislmf.pytools.common.event_stream import SUMMARY_STREAM_ID, stream_info_to_bytes
 from oasislmf.pytools.lec.data import EPT_dtype, PSEPT_dtype
 from oasislmf.pytools.lec.manager import main
@@ -360,3 +360,86 @@ def test_lec_idx_partial_coverage_falls_back_to_sequential():
             actual = np.genfromtxt(out_file, delimiter=',', skip_header=1)
             assert expected.shape == actual.shape, f"Shape mismatch for {golden_name}: {expected.shape} vs {actual.shape}"
             np.testing.assert_allclose(expected, actual, rtol=1e-5, atol=1e-8)
+
+
+def _build_multi_summary_run(tmp_dir, n_summaries, n_events=40, sample_size=20, n_periods=50, n_files=3, seed=7):
+    """Build a minimal multi-summary, partitioned summary stream + occurrence for chunking tests.
+
+    Events are split across n_files (partition-by-event); every summary_id appears in each
+    file for the events that landed there — mirroring a real partitioned run. A paired .idx
+    is generated for each .bin so the per-summary-id (chunked) path is taken.
+    """
+    rng = np.random.default_rng(seed)
+    input_dir = tmp_dir / "input"
+    work_dir = tmp_dir / "work" / "gul"
+    input_dir.mkdir(parents=True)
+    work_dir.mkdir(parents=True)
+
+    event_ids = np.arange(1, n_events + 1, dtype=np.int32)
+    recs = np.zeros(n_events, dtype=occurrence_dtype)
+    recs["event_id"] = event_ids
+    recs["period_no"] = (event_ids % n_periods) + 1
+    with open(input_dir / "occurrence.bin", "wb") as f:
+        f.write(np.array([1, n_periods], dtype=np.int32).tobytes())
+        f.write(recs.tobytes())
+
+    stream_hdr = np.frombuffer(stream_info_to_bytes(SUMMARY_STREAM_ID, sample_size), dtype=np.int32)[0]
+    sidxs = np.array([-1] + list(range(1, sample_size + 1)), dtype=np.int32)  # mean + samples
+    for fi, events in enumerate(np.array_split(event_ids, n_files), start=1):
+        rows = [np.array([stream_hdr, sample_size, 1], dtype=np.int32)]
+        for ev in events:
+            for sid in range(1, n_summaries + 1):
+                block = np.empty(3 + 2 * (len(sidxs) + 1), dtype=np.int32)
+                block[0] = ev
+                block[1] = sid
+                block[2] = np.float32(0.0).view(np.int32)  # expval
+                pos = 3
+                for s, loss in zip(sidxs, rng.uniform(1.0, 1000.0, len(sidxs)).astype(np.float32)):
+                    block[pos] = s
+                    block[pos + 1] = loss.view(np.int32)
+                    pos += 2
+                block[pos] = 0                               # terminating sidx
+                block[pos + 1] = np.float32(0.0).view(np.int32)
+                rows.append(block)
+        np.concatenate(rows).tofile(work_dir / f"summarypy{fi}.bin")
+    for b in sorted(work_dir.glob("*.bin")):
+        make_idx_from_bin(b, b.with_suffix(".idx"))
+
+
+def _run_lec_idx(tmp_dir, out_name, chunk_size):
+    out_dir = tmp_dir / out_name
+    out_dir.mkdir()
+    with patch("oasislmf.pytools.lec.manager.LEC_IDX_CHUNK_SIZE", chunk_size):
+        main(
+            run_dir=tmp_dir, subfolder="gul", use_return_period=False,
+            ept=out_dir / "py_ept.csv", psept=out_dir / "py_psept.csv", ext="csv",
+            **_ALL_OUTPUT_FLAGS,
+        )
+    return out_dir
+
+
+@pytest.mark.parametrize("chunk_size", [7, 23, 1000], ids=["k7_partial_last", "k_exact", "k_single_chunk"])
+def test_lec_idx_chunking_invariant_to_k(chunk_size):
+    """Chunked idx output is identical to the strict per-summary (K=1) path for any K.
+
+    K=1 is already pinned to the sequential golden by test_lec_idx_output_matches_sequential,
+    so equality with K=1 transitively validates each chunk size — in particular the
+    local-slot → real-summary_id remap across chunk boundaries, including a partial final
+    chunk (n_summaries=23 is not a multiple of 7) and the whole-run single-chunk case.
+    """
+    n_summaries = 23
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str) / "workspace"
+        _build_multi_summary_run(tmp_dir, n_summaries=n_summaries)
+
+        baseline = _run_lec_idx(tmp_dir, "out_k1", 1)
+        chunked = _run_lec_idx(tmp_dir, f"out_k{chunk_size}", chunk_size)
+
+        for name in ("py_ept.csv", "py_psept.csv"):
+            a = np.genfromtxt(baseline / name, delimiter=',', skip_header=1)
+            b = np.genfromtxt(chunked / name, delimiter=',', skip_header=1)
+            a = a[np.lexsort(a.T[::-1])]
+            b = b[np.lexsort(b.T[::-1])]
+            assert a.shape == b.shape, f"Shape mismatch for {name} at K={chunk_size}: {a.shape} vs {b.shape}"
+            np.testing.assert_allclose(a, b, rtol=1e-5, atol=1e-8,
+                                       err_msg=f"chunk_size={chunk_size} differs from K=1 for {name}")


### PR DESCRIPTION
## Summary

Stacked on top of #2014 (base branch: `feature/aal_lec_idx_files`).

The `.idx` path in #2014 processes **one `summary_id` at a time**. That bounds peak working disk to `O(periods × sidxs)` and eliminates the giant `.bdat` files, but on data that *would* have fit the dense buffers it runs **~2× slower** than the dense path.

Profiling (cProfile, 500 summaries) showed the slowdown is **not** the index/seek machinery — `run()`'s own time (stream read + `build_merged_idx` + per-summary `process_summary_entries`) is identical to the dense path. The cost is **amortisation loss**: the four report kernels (`_write_wheatsheaf`, `_write_full_uncertainty`, `_write_sample_mean`, `_write_mean_damage_ratio`) and the CSV writer are invoked **2 × N_summaries** times on tiny single-summary arrays instead of **twice** on batched arrays (9.7k → 144k Python calls).

## Change

Process summaries in **chunks of K** (`OASIS_LEC_IDX_CHUNK`, default 64), sizing the per-chunk buffers `O(periods × sidxs × K)`:

- `merged` idx is already sorted by `summary_id`, so each chunk is one **contiguous slice** — no extra bookkeeping.
- A vectorised local-slot map (`searchsorted`) lets the **existing K-generic kernels** run once per chunk; `process_summary_entries` writes at the local slot, and `output_for_summary_idx` remaps the kernel's local `SummaryId` back to the real id.
- **K=1 reproduces the original strict per-summary behaviour exactly.**

No change to the dense fallback, the all-or-nothing `.idx` gating, or output format.

## Performance (synthetic: 2000 summaries, 120 events, 50 samples, 200 periods; warm cache, NVMe)

| path | time | vs dense | peak disk | working RAM |
|---|---:|---:|---:|---:|
| dense `.bdat` | 32.9 s | 1.00× | 1221 MB | — |
| idx **K=1** (current #2014) | 59.1 s | 1.79× | 0 MB | 0.1 MB |
| idx **K=8** | 32.6 s | 0.99× | 0 MB | 0.7 MB |
| idx **K=32** | 28.5 s | **0.87×** | 0 MB | 2.9 MB |
| idx **K=64** (default) | 30.3 s | 0.92× | 0 MB | 5.8 MB |

Crossover is **K≈8**; from **K≥32 the idx path is faster than dense** (it avoids the `.bdat` write/read and the `get_max_summary_id` pre-scan) while keeping peak disk at zero and RAM bounded by K. EPT/PSEPT output is **byte-identical** to the dense golden at every K.

This turns the `.idx` path from a space-for-time trade-off into a strict improvement — worth considering making it the default path rather than an opt-in.

## Testing

- New `test_lec_idx_chunking_invariant_to_k` (K = 7 / 23 / 1000, incl. a partial final chunk and a single whole-run chunk) asserts byte-identical EPT/PSEPT vs the K=1 baseline — validating the local→global `summary_id` remap across chunk boundaries.
- Existing `test_lec_idx_output_matches_sequential`, `test_lec_idx_empty_file_no_crash` still pass.

<!--start_release_notes-->
- Process `lecpy` `.idx` summaries in configurable chunks of K (`OASIS_LEC_IDX_CHUNK`, default 64), removing the ~2× per-summary slowdown of the index path while keeping peak working disk at zero; output is unchanged.
<!--end_release_notes-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
