### PR TITLE
FIX: Use areaperil_int type for footprint carry-state scalars

### DIFF
--- a/docs/source/environment-variables.rst
+++ b/docs/source/environment-variables.rst
@@ -1,0 +1,54 @@
+Environment Variables
+=====================
+
+OasisLMF uses environment variables to control runtime behaviour that must be
+set before the package is imported. These are distinct from the JSON
+configuration file options (see :doc:`options_config_file`).
+
+Numeric Type Configuration
+--------------------------
+
+The following variables control the numeric precision of internal data types.
+They are read once at import time, so they must be set in the shell before
+running any ``oasislmf`` command or importing the package.
+
+``OASIS_AREAPERIL_TYPE``
+    Controls the integer type used for AreaPeril IDs.
+    Default: ``u4`` (uint32, max value 4,294,967,295).
+    Set to ``u8`` (uint64) for models with AreaPeril IDs exceeding this limit.
+
+    .. code-block:: bash
+
+        export OASIS_AREAPERIL_TYPE=u8
+        oasislmf model run ...
+
+``OASIS_FLOAT``
+    Controls floating-point precision for loss values.
+    Default: ``f4`` (float32). Set to ``f8`` (float64) for higher numerical
+    precision at the cost of increased memory usage and slower computation.
+
+    .. code-block:: bash
+
+        export OASIS_FLOAT=f8
+
+``OASIS_INT``
+    Controls integer precision for loss values.
+    Default: ``i4`` (int32). Set to ``i8`` (int64) for extended range.
+
+    .. code-block:: bash
+
+        export OASIS_INT=i8
+
+.. note::
+
+   All three variables must be consistent with the binary model data files
+   on disk. Changing them without regenerating model data will produce
+   incorrect results. See issue `#1990
+   <https://github.com/OasisLMF/OasisLMF/issues/1990>`_ for details on
+   cache-related pitfalls when changing these values between runs.
+
+Logging
+-------
+
+See :doc:`logging-configuration` for the ``OASIS_PACKAGE_LOG_LEVEL`` and
+related logging environment variables.

--- a/docs/source/environment-variables.rst
+++ b/docs/source/environment-variables.rst
@@ -32,7 +32,7 @@ running any ``oasislmf`` command or importing the package.
         export OASIS_FLOAT=f8
 
 ``OASIS_INT``
-    Controls integer precision for loss values.
+    Controls integer precision for internal Oasis fields for example `SummaryId`.
     Default: ``i4`` (int32). Set to ``i8`` (int64) for extended range.
 
     .. code-block:: bash

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,6 +33,7 @@ in this process. It includes:
    building-and-running-models
    logging-configuration
    options_config_file
+   environment-variables
 
 Indices and tables
 ==================

--- a/oasislmf/pytools/converters/csvtobin/utils/footprint.py
+++ b/oasislmf/pytools/converters/csvtobin/utils/footprint.py
@@ -26,7 +26,7 @@ import zlib
 import numba as nb
 import numpy as np
 
-from oasislmf.pytools.common.data import resolve_file
+from oasislmf.pytools.common.data import areaperil_int, resolve_file
 from oasislmf.pytools.converters.csvtobin.utils.common import iter_csv_as_ndarray
 from oasislmf.pytools.converters.data import TOOL_INFO
 from oasislmf.pytools.getmodel.common import Event_dtype, EventIndexBin_dtype, EventIndexBinZ_dtype
@@ -202,12 +202,12 @@ def footprint_tobin(
 
     # Validation carry state (dummy initial values; first_chunk=True prevents their use)
     prev_sort_event = np.int32(0)
-    prev_sort_areaperil = np.uint32(0)
+    prev_sort_areaperil = areaperil_int.type(0)
     prev_prob_event = np.int32(0)
-    prev_prob_areaperil = np.uint32(0)
+    prev_prob_areaperil = areaperil_int.type(0)
     running_sum = np.float64(0.0)
     prev_dup_event = np.int32(0)
-    prev_dup_areaperil = np.uint32(0)
+    prev_dup_areaperil = areaperil_int.type(0)
     prev_dup_intensity = np.int32(0)
 
     # Partial-event buffer for events that span chunk boundaries

--- a/oasislmf/pytools/converters/csvtobin/utils/footprint.py
+++ b/oasislmf/pytools/converters/csvtobin/utils/footprint.py
@@ -26,7 +26,7 @@ import zlib
 import numba as nb
 import numpy as np
 
-from oasislmf.pytools.common.data import areaperil_int, resolve_file
+from oasislmf.pytools.common.data import resolve_file
 from oasislmf.pytools.converters.csvtobin.utils.common import iter_csv_as_ndarray
 from oasislmf.pytools.converters.data import TOOL_INFO
 from oasislmf.pytools.getmodel.common import Event_dtype, EventIndexBin_dtype, EventIndexBinZ_dtype
@@ -202,12 +202,12 @@ def footprint_tobin(
 
     # Validation carry state (dummy initial values; first_chunk=True prevents their use)
     prev_sort_event = np.int32(0)
-    prev_sort_areaperil = areaperil_int.type(0)
+    prev_sort_areaperil = dtype['areaperil_id'].type(0)
     prev_prob_event = np.int32(0)
-    prev_prob_areaperil = areaperil_int.type(0)
+    prev_prob_areaperil = dtype['areaperil_id'].type(0)
     running_sum = np.float64(0.0)
     prev_dup_event = np.int32(0)
-    prev_dup_areaperil = areaperil_int.type(0)
+    prev_dup_areaperil = dtype['areaperil_id'].type(0)
     prev_dup_intensity = np.int32(0)
 
     # Partial-event buffer for events that span chunk boundaries

--- a/tests/pytools/converters/test_large_areaperil_ids.py
+++ b/tests/pytools/converters/test_large_areaperil_ids.py
@@ -1,0 +1,101 @@
+"""Regression tests for large AreaPeril IDs exceeding uint32 range.
+
+The default OASIS_AREAPERIL_TYPE is u4 (uint32, max 4,294,967,295). Models with
+AreaPeril IDs exceeding this limit produce silent data corruption: pandas 3.x
+silently wraps the value mod 2^32 rather than raising an error.
+
+Setting OASIS_AREAPERIL_TYPE=u8 (uint64) before importing oasislmf fixes this.
+The carry-state scalars in the footprint validator must also use the correct type
+so Numba JIT functions receive consistent argument types across chunk boundaries.
+
+Reference: https://github.com/OasisLMF/OasisLMF/issues/2011
+"""
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+import numpy as np
+
+import oasislmf.pytools.converters.csvtobin.utils.footprint as footprint_utils
+from oasislmf.pytools.converters.csvtobin.manager import csvtobin
+from oasislmf.pytools.converters.data import TOOL_INFO
+
+LARGE_AREAPERIL_ID = 50_776_441_987  # 50,776,441,987 > uint32 max (4,294,967,295)
+
+FOOTPRINT_CSV = (
+    b"event_id,areaperil_id,intensity_bin_id,probability\n"
+    b"1,50776441987,1,1.0\n"
+)
+
+_CSVTOBIN_KWARGS = dict(
+    file_type="footprint",
+    zip_files=False,
+    max_intensity_bin_idx=1,
+    no_intensity_uncertainty=True,
+    decompressed_size=False,
+    no_validation=False,
+)
+
+_U8_FOOTPRINT_DTYPE = np.dtype([
+    ("event_id", np.int32),
+    ("areaperil_id", np.uint64),
+    ("intensity_bin_id", np.int32),
+    ("probability", np.float32),
+])
+
+_U8_EVENT_DTYPE = np.dtype([
+    ("areaperil_id", np.uint64),
+    ("intensity_bin_id", np.int32),
+    ("probability", np.float32),
+])
+
+
+def test_uint32_silently_truncates_large_areaperil_id():
+    """pandas silently wraps areaperil_id values beyond 4,294,967,295 when dtype=uint32.
+
+    This is the root cause of issue #2011: pd.read_csv with dtype=uint32 silently
+    truncates large integer values rather than raising an error.
+
+    50,776,441,987 % 2^32 = 3,531,801,731
+    """
+    import io
+    import pandas as pd
+
+    df = pd.read_csv(
+        io.BytesIO(FOOTPRINT_CSV),
+        dtype={"areaperil_id": np.uint32},
+    )
+    stored = int(df["areaperil_id"][0])
+
+    assert stored != LARGE_AREAPERIL_ID
+    assert stored == LARGE_AREAPERIL_ID % (2 ** 32)
+
+
+def test_large_areaperil_id_preserved_with_uint64():
+    """uint64 preserves areaperil_id values > uint32 max through the full conversion.
+
+    Simulates OASIS_AREAPERIL_TYPE=u8 by patching the three dtype objects that
+    the footprint converter uses: the CSV read dtype, the carry-state areaperil
+    type, and the binary output dtype. All must agree for Numba JIT validation to
+    receive consistent argument types across chunk boundaries.
+    """
+    with (
+        TemporaryDirectory() as tmp,
+        mock.patch.dict(TOOL_INFO["footprint"], {"dtype": _U8_FOOTPRINT_DTYPE}),
+        mock.patch.object(footprint_utils, "areaperil_int", np.dtype("u8")),
+        mock.patch.object(footprint_utils, "Event_dtype", _U8_EVENT_DTYPE),
+    ):
+        csv_path = Path(tmp) / "footprint.csv"
+        csv_path.write_bytes(FOOTPRINT_CSV)
+
+        csvtobin(
+            file_in=csv_path,
+            file_out=Path(tmp) / "footprint.bin",
+            idx_file_out=Path(tmp) / "footprint.idx",
+            **_CSVTOBIN_KWARGS,
+        )
+
+        data = np.fromfile(Path(tmp) / "footprint.bin", dtype=_U8_EVENT_DTYPE, offset=8)
+        stored_id = int(data["areaperil_id"][0])
+
+    assert stored_id == LARGE_AREAPERIL_ID

--- a/tests/pytools/converters/test_large_areaperil_ids.py
+++ b/tests/pytools/converters/test_large_areaperil_ids.py
@@ -50,27 +50,6 @@ _U8_EVENT_DTYPE = np.dtype([
 ])
 
 
-def test_uint32_silently_truncates_large_areaperil_id():
-    """pandas silently wraps areaperil_id values beyond 4,294,967,295 when dtype=uint32.
-
-    This is the root cause of issue #2011: pd.read_csv with dtype=uint32 silently
-    truncates large integer values rather than raising an error.
-
-    50,776,441,987 % 2^32 = 3,531,801,731
-    """
-    import io
-    import pandas as pd
-
-    df = pd.read_csv(
-        io.BytesIO(FOOTPRINT_CSV),
-        dtype={"areaperil_id": np.uint32},
-    )
-    stored = int(df["areaperil_id"][0])
-
-    assert stored != LARGE_AREAPERIL_ID
-    assert stored == LARGE_AREAPERIL_ID % (2 ** 32)
-
-
 def test_large_areaperil_id_preserved_with_uint64():
     """uint64 preserves areaperil_id values > uint32 max through the full conversion.
 
@@ -82,7 +61,6 @@ def test_large_areaperil_id_preserved_with_uint64():
     with (
         TemporaryDirectory() as tmp,
         mock.patch.dict(TOOL_INFO["footprint"], {"dtype": _U8_FOOTPRINT_DTYPE}),
-        mock.patch.object(footprint_utils, "areaperil_int", np.dtype("u8")),
         mock.patch.object(footprint_utils, "Event_dtype", _U8_EVENT_DTYPE),
     ):
         csv_path = Path(tmp) / "footprint.csv"


### PR DESCRIPTION
## Summary

  The carry-state scalars in `footprint_tobin` (`prev_sort_areaperil`,
  `prev_prob_areaperil`, `prev_dup_areaperil`) were hardcoded as `np.uint32(0)`.
  When `OASIS_AREAPERIL_TYPE=u8`, CSV chunks are read with `uint64` areaperil_id
  values, causing a type mismatch in the Numba JIT validation functions that
  receive these scalars as cross-chunk carry state.

  Changed the three scalars to `areaperil_int.type(0)` so they always match the
  configured areaperil type.

  Fixes #2011.

  ## Changes

  - `oasislmf/pytools/converters/csvtobin/utils/footprint.py`: replace hardcoded
    `np.uint32(0)` carry-state scalars with `areaperil_int.type(0)`
  - `tests/pytools/converters/test_large_areaperil_ids.py`: regression tests
    demonstrating the silent uint32 truncation and verifying the uint64 fix
  - `docs/source/environment-variables.rst`: new page documenting
    `OASIS_AREAPERIL_TYPE`, `OASIS_FLOAT`, and `OASIS_INT` with usage example