### PR TITLE
backport/2018-gulmc-missing-item-adjustments-2015

### DIFF
--- a/oasislmf/pytools/gulmc/manager.py
+++ b/oasislmf/pytools/gulmc/manager.py
@@ -100,9 +100,8 @@ def get_dynamic_footprint_adjustments(input_path):
     if os.path.isfile(adjustments_fn):
         adjustments_tb = np.loadtxt(adjustments_fn, dtype=ItemAdjustment, delimiter=",", skiprows=1, ndmin=1)
     else:
-        items_fp = os.path.join(input_path, 'items.csv')
-        items_tb = np.loadtxt(items_fp, dtype=items_dtype, delimiter=",", skiprows=1, ndmin=1)
-        adjustments_tb = np.array([(i[0], 0, 0) for i in items_tb], dtype=ItemAdjustment)
+        items_tb = read_items(input_path)
+        adjustments_tb = np.array([(i['item_id'], 0, 0) for i in items_tb], dtype=ItemAdjustment)
 
     return adjustments_tb
 

--- a/tests/pytools/gulmc/test_gulmc.py
+++ b/tests/pytools/gulmc/test_gulmc.py
@@ -3,15 +3,17 @@ This file tests gulmc functionality
 """
 import filecmp
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Tuple
 from unittest.mock import patch
+import numpy as np
 import pandas as pd
 import pytest
 
-from oasislmf.pytools.gulmc.manager import run as run_gulmc
+from oasislmf.pytools.gulmc.manager import run as run_gulmc, get_dynamic_footprint_adjustments
 from oasislmf.pytools.utils import assert_allclose
 
 # get tests dirs
@@ -355,3 +357,25 @@ def test_adjustments(test_model: Tuple[str, str]):
             # remove temporary file
             file_out.unlink()
             file_out.with_suffix('.csv').unlink()
+
+
+def test_get_dynamic_footprint_adjustments_without_item_adjustments_bin_only():
+    """Regression test for issue #2015.
+
+    When the keys stage does not run a `dynamic_model_adjustment` step,
+    `item_adjustments.csv` is absent and the items file only exists as
+    `items.bin`. The fallback must read the binary items file (rather than
+    hard-coding `items.csv`) and return zero adjustments per item.
+    """
+    src_items_bin = TESTS_ASSETS_DIR.joinpath("test_adjustments_1", "input", "items.bin")
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        # only items.bin is present: no item_adjustments.csv and no items.csv
+        shutil.copy(src_items_bin, tmp_dir.joinpath("items.bin"))
+
+        adjustments = get_dynamic_footprint_adjustments(str(tmp_dir))
+
+        assert len(adjustments) == 1
+        assert adjustments[0]["item_id"] == 1
+        assert np.all(adjustments["intensity_adjustment"] == 0)
+        assert np.all(adjustments["return_period"] == 0)


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
- Fixed a crash in gulmc for dynamic footprint models when the keys stage does not include a `dynamic_model_adjustment` step: the missing `item_adjustments.csv` fallback now reads `items.bin` as well as `items.csv`.
<!--end_release_notes-->

