### PR TITLE
enhance/occurrence_structure

### DIFF
--- a/oasislmf/pytools/aal/manager.py
+++ b/oasislmf/pytools/aal/manager.py
@@ -16,7 +16,7 @@ from oasislmf.pytools.common.data import (DEFAULT_BUFFER_SIZE, MEAN_TYPE_ANALYTI
                                           summary_stream_index_dtype)
 from oasislmf.pytools.common.event_stream import (MEAN_IDX, MAX_LOSS_IDX, NUMBER_OF_AFFECTED_RISK_IDX, SUMMARY_STREAM_ID,
                                                   init_streams_in, mv_read)
-from oasislmf.pytools.common.input_files import occ_get, read_occurrence_id_index_csr, read_periods
+from oasislmf.pytools.common.input_files import occ_get, read_occurrence, read_periods
 from oasislmf.pytools.common.utils.nb_heapq import heap_pop, heap_push, init_heap
 from oasislmf.pytools.utils import redirect_logging
 
@@ -378,7 +378,7 @@ def read_input_files(run_dir):
     Returns:
         file_data (Dict[str, Any]): A dict of relevent data extracted from files
     """
-    occ_csr, date_algorithm, granular_date, no_of_periods = read_occurrence_id_index_csr(Path(run_dir, "input"))
+    occ_csr, date_algorithm, granular_date, no_of_periods = read_occurrence(Path(run_dir, "input"))
     period_weights = read_periods(no_of_periods, Path(run_dir, "input"))
 
     file_data = {

--- a/oasislmf/pytools/aal/manager.py
+++ b/oasislmf/pytools/aal/manager.py
@@ -15,7 +15,8 @@ from oasislmf.pytools.common.data import (DEFAULT_BUFFER_SIZE, MEAN_TYPE_ANALYTI
                                           oasis_int_size, oasis_float_size, write_ndarray_to_fmt_csv)
 from oasislmf.pytools.common.event_stream import (MEAN_IDX, MAX_LOSS_IDX, NUMBER_OF_AFFECTED_RISK_IDX, SUMMARY_STREAM_ID,
                                                   init_streams_in, mv_read)
-from oasislmf.pytools.common.input_files import read_occurrence, read_periods
+from oasislmf.pytools.common.id_index import get_idx as id_index_get_idx, NOT_FOUND as OCC_IDX_NOT_FOUND
+from oasislmf.pytools.common.input_files import read_occurrence_id_index_csr, read_periods
 from oasislmf.pytools.common.utils.nb_heapq import heap_pop, heap_push, init_heap
 from oasislmf.pytools.utils import redirect_logging
 
@@ -51,7 +52,9 @@ _SUMMARIES_DTYPE_size = _SUMMARIES_DTYPE.itemsize
 def process_bin_file(
     fbin,
     offset,
-    occ_map,
+    event_id_index,
+    occ_offsets,
+    occ_flat,
     summaries_data,
     summaries_idx,
     file_index,
@@ -60,7 +63,9 @@ def process_bin_file(
     Args:
         fbin (np.memmap): summary binary memmap
         offset (int): file offset to read from
-        occ_map (nb.typed.Dict): numpy map of event_id, period_no, occ_date_id from the occurrence file
+        event_id_index (ndarray[uint32]): id_index array for event lookup
+        occ_offsets (ndarray[int64]): CSR offsets into occ_flat, length = n_unique_events + 1
+        occ_flat (ndarray): structured array [(period_no, occ_date_id)] sorted by event_id
         summaries_data (ndarray[_SUMMARIES_DTYPE]): Index summary data (summaries.idx data)
         summaries_idx (int): current index reached in summaries_data
         file_index (int): Summary bin file index
@@ -74,8 +79,8 @@ def process_bin_file(
         event_id, cursor = mv_read(fbin, cursor, oasis_int, oasis_int_size)
         summary_id, cursor = mv_read(fbin, cursor, oasis_int, oasis_int_size)
 
-        if event_id not in occ_map:
-            # If the event_id doesn't exist in occ_map, continue with the next
+        _occ_i = id_index_get_idx(event_id_index, nb.int32(event_id))
+        if _occ_i == OCC_IDX_NOT_FOUND:
             offset = cursor
             # Skip over Expval and losses
             _, offset = mv_read(fbin, offset, oasis_float, oasis_float_size)
@@ -83,15 +88,15 @@ def process_bin_file(
             continue
 
         # Get the number of rows for the current event_id
-        n_rows = occ_map[event_id].shape[0]
+        n_rows = nb.int64(occ_offsets[_occ_i + 1] - occ_offsets[_occ_i])
 
         if summaries_idx + n_rows >= len(summaries_data):
             # Resize array if full
             return summaries_idx, True, offset
 
         # Now fill the summaries_data with the rows that match the current event_id
-        current_row = 0
-        for row in occ_map[event_id]:
+        current_row = nb.int64(0)
+        for row in occ_flat[occ_offsets[_occ_i]:occ_offsets[_occ_i + 1]]:
             summaries_data[summaries_idx]["summary_id"] = summary_id
             summaries_data[summaries_idx]["file_idx"] = file_index
             summaries_data[summaries_idx]["period_no"] = row["period_no"]
@@ -163,14 +168,18 @@ def merge_sorted_chunks(memmaps):
 def get_summaries_data(
     path,
     files_handles,
-    occ_map,
+    event_id_index,
+    occ_offsets,
+    occ_flat,
     aal_max_memory
 ):
     """Gets the indexed summaries data, ordered with k-way merge if not enough memory
     Args:
         path (os.PathLike): Path to the workspace folder containing summary binaries
         files_handles (List[np.memmap]): List of memmaps for summary files data
-        occ_map (nb.typed.Dict): numpy map of event_id, period_no, occ_date_id from the occurrence file
+        event_id_index (ndarray[uint32]): id_index array for event lookup
+        occ_offsets (ndarray[int64]): CSR offsets into occ_flat, length = n_unique_events + 1
+        occ_flat (ndarray): structured array [(period_no, occ_date_id)] sorted by event_id
         aal_max_memory (float): OASIS_AAL_MEMORY value (has to be passed in as numba won't update from environment variable)
     Returns:
         memmaps (List[np.memmap]): List of temporary file memmaps
@@ -194,7 +203,9 @@ def get_summaries_data(
             summaries_idx, resize_flag, offset = process_bin_file(
                 fbin,
                 offset,
-                occ_map,
+                event_id_index,
+                occ_offsets,
+                occ_flat,
                 summaries_data,
                 summaries_idx,
                 file_index,
@@ -228,11 +239,13 @@ def get_summaries_data(
     return memmaps, max_summary_id
 
 
-def summary_index(path, occ_map, stack):
+def summary_index(path, event_id_index, occ_offsets, occ_flat, stack):
     """Index the summary binary outputs
     Args:
         path (os.PathLike): Path to the workspace folder containing summary binaries
-        occ_map (nb.typed.Dict): numpy map of event_id, period_no, occ_date_id from the occurrence file
+        event_id_index (ndarray[uint32]): id_index array for event lookup
+        occ_offsets (ndarray[int64]): CSR offsets into occ_flat, length = n_unique_events + 1
+        occ_flat (ndarray): structured array [(period_no, occ_date_id)] sorted by event_id
         stack (ExitStack): Exit stack
     Returns:
         files_handles (List[np.memmap]): List of memmaps for summary files data
@@ -255,7 +268,9 @@ def summary_index(path, occ_map, stack):
     memmaps, max_summary_id = get_summaries_data(
         aal_files_folder,
         files_handles,
-        occ_map,
+        event_id_index,
+        occ_offsets,
+        occ_flat,
         OASIS_AAL_MEMORY
     )
     return files_handles, sample_size, max_summary_id, memmaps
@@ -268,11 +283,13 @@ def read_input_files(run_dir):
     Returns:
         file_data (Dict[str, Any]): A dict of relevent data extracted from files
     """
-    occ_map, date_algorithm, granular_date, no_of_periods = read_occurrence(Path(run_dir, "input"))
+    (event_id_index, occ_offsets, occ_flat), date_algorithm, granular_date, no_of_periods = read_occurrence_id_index_csr(Path(run_dir, "input"))
     period_weights = read_periods(no_of_periods, Path(run_dir, "input"))
 
     file_data = {
-        "occ_map": occ_map,
+        "event_id_index": event_id_index,
+        "occ_offsets": occ_offsets,
+        "occ_flat": occ_flat,
         "date_algorithm": date_algorithm,
         "granular_date": granular_date,
         "no_of_periods": no_of_periods,
@@ -850,7 +867,9 @@ def run(
         file_data = read_input_files(run_dir)
         files_handles, sample_size, max_summary_id, memmaps = summary_index(
             workspace_folder,
-            file_data["occ_map"],
+            file_data["event_id_index"],
+            file_data["occ_offsets"],
+            file_data["occ_flat"],
             stack
         )
         if max_summary_id == 0:

--- a/oasislmf/pytools/aal/manager.py
+++ b/oasislmf/pytools/aal/manager.py
@@ -15,8 +15,7 @@ from oasislmf.pytools.common.data import (DEFAULT_BUFFER_SIZE, MEAN_TYPE_ANALYTI
                                           oasis_int_size, oasis_float_size, write_ndarray_to_fmt_csv)
 from oasislmf.pytools.common.event_stream import (MEAN_IDX, MAX_LOSS_IDX, NUMBER_OF_AFFECTED_RISK_IDX, SUMMARY_STREAM_ID,
                                                   init_streams_in, mv_read)
-from oasislmf.pytools.common.id_index import get_idx as id_index_get_idx, NOT_FOUND as OCC_IDX_NOT_FOUND
-from oasislmf.pytools.common.input_files import read_occurrence_id_index_csr, read_periods
+from oasislmf.pytools.common.input_files import occ_get, read_occurrence_id_index_csr, read_periods
 from oasislmf.pytools.common.utils.nb_heapq import heap_pop, heap_push, init_heap
 from oasislmf.pytools.utils import redirect_logging
 
@@ -52,9 +51,7 @@ _SUMMARIES_DTYPE_size = _SUMMARIES_DTYPE.itemsize
 def process_bin_file(
     fbin,
     offset,
-    event_id_index,
-    occ_offsets,
-    occ_flat,
+    occ_csr,
     summaries_data,
     summaries_idx,
     file_index,
@@ -63,9 +60,7 @@ def process_bin_file(
     Args:
         fbin (np.memmap): summary binary memmap
         offset (int): file offset to read from
-        event_id_index (ndarray[uint32]): id_index array for event lookup
-        occ_offsets (ndarray[int64]): CSR offsets into occ_flat, length = n_unique_events + 1
-        occ_flat (ndarray): structured array [(period_no, occ_date_id)] sorted by event_id
+        occ_csr (OccurrenceCSR): id_index-backed CSR occurrence map
         summaries_data (ndarray[_SUMMARIES_DTYPE]): Index summary data (summaries.idx data)
         summaries_idx (int): current index reached in summaries_data
         file_index (int): Summary bin file index
@@ -79,8 +74,8 @@ def process_bin_file(
         event_id, cursor = mv_read(fbin, cursor, oasis_int, oasis_int_size)
         summary_id, cursor = mv_read(fbin, cursor, oasis_int, oasis_int_size)
 
-        _occ_i = id_index_get_idx(event_id_index, nb.int32(event_id))
-        if _occ_i == OCC_IDX_NOT_FOUND:
+        occ_rows = occ_get(occ_csr, event_id)
+        if len(occ_rows) == 0:
             offset = cursor
             # Skip over Expval and losses
             _, offset = mv_read(fbin, offset, oasis_float, oasis_float_size)
@@ -88,7 +83,7 @@ def process_bin_file(
             continue
 
         # Get the number of rows for the current event_id
-        n_rows = nb.int64(occ_offsets[_occ_i + 1] - occ_offsets[_occ_i])
+        n_rows = nb.int64(len(occ_rows))
 
         if summaries_idx + n_rows >= len(summaries_data):
             # Resize array if full
@@ -96,7 +91,7 @@ def process_bin_file(
 
         # Now fill the summaries_data with the rows that match the current event_id
         current_row = nb.int64(0)
-        for row in occ_flat[occ_offsets[_occ_i]:occ_offsets[_occ_i + 1]]:
+        for row in occ_rows:
             summaries_data[summaries_idx]["summary_id"] = summary_id
             summaries_data[summaries_idx]["file_idx"] = file_index
             summaries_data[summaries_idx]["period_no"] = row["period_no"]
@@ -168,18 +163,14 @@ def merge_sorted_chunks(memmaps):
 def get_summaries_data(
     path,
     files_handles,
-    event_id_index,
-    occ_offsets,
-    occ_flat,
+    occ_csr,
     aal_max_memory
 ):
     """Gets the indexed summaries data, ordered with k-way merge if not enough memory
     Args:
         path (os.PathLike): Path to the workspace folder containing summary binaries
         files_handles (List[np.memmap]): List of memmaps for summary files data
-        event_id_index (ndarray[uint32]): id_index array for event lookup
-        occ_offsets (ndarray[int64]): CSR offsets into occ_flat, length = n_unique_events + 1
-        occ_flat (ndarray): structured array [(period_no, occ_date_id)] sorted by event_id
+        occ_csr (OccurrenceCSR): id_index-backed CSR occurrence map
         aal_max_memory (float): OASIS_AAL_MEMORY value (has to be passed in as numba won't update from environment variable)
     Returns:
         memmaps (List[np.memmap]): List of temporary file memmaps
@@ -203,9 +194,7 @@ def get_summaries_data(
             summaries_idx, resize_flag, offset = process_bin_file(
                 fbin,
                 offset,
-                event_id_index,
-                occ_offsets,
-                occ_flat,
+                occ_csr,
                 summaries_data,
                 summaries_idx,
                 file_index,
@@ -239,13 +228,11 @@ def get_summaries_data(
     return memmaps, max_summary_id
 
 
-def summary_index(path, event_id_index, occ_offsets, occ_flat, stack):
+def summary_index(path, occ_csr, stack):
     """Index the summary binary outputs
     Args:
         path (os.PathLike): Path to the workspace folder containing summary binaries
-        event_id_index (ndarray[uint32]): id_index array for event lookup
-        occ_offsets (ndarray[int64]): CSR offsets into occ_flat, length = n_unique_events + 1
-        occ_flat (ndarray): structured array [(period_no, occ_date_id)] sorted by event_id
+        occ_csr (OccurrenceCSR): id_index-backed CSR occurrence map
         stack (ExitStack): Exit stack
     Returns:
         files_handles (List[np.memmap]): List of memmaps for summary files data
@@ -268,9 +255,7 @@ def summary_index(path, event_id_index, occ_offsets, occ_flat, stack):
     memmaps, max_summary_id = get_summaries_data(
         aal_files_folder,
         files_handles,
-        event_id_index,
-        occ_offsets,
-        occ_flat,
+        occ_csr,
         OASIS_AAL_MEMORY
     )
     return files_handles, sample_size, max_summary_id, memmaps
@@ -283,13 +268,11 @@ def read_input_files(run_dir):
     Returns:
         file_data (Dict[str, Any]): A dict of relevent data extracted from files
     """
-    (event_id_index, occ_offsets, occ_flat), date_algorithm, granular_date, no_of_periods = read_occurrence_id_index_csr(Path(run_dir, "input"))
+    occ_csr, date_algorithm, granular_date, no_of_periods = read_occurrence_id_index_csr(Path(run_dir, "input"))
     period_weights = read_periods(no_of_periods, Path(run_dir, "input"))
 
     file_data = {
-        "event_id_index": event_id_index,
-        "occ_offsets": occ_offsets,
-        "occ_flat": occ_flat,
+        "occ_csr": occ_csr,
         "date_algorithm": date_algorithm,
         "granular_date": granular_date,
         "no_of_periods": no_of_periods,
@@ -867,9 +850,7 @@ def run(
         file_data = read_input_files(run_dir)
         files_handles, sample_size, max_summary_id, memmaps = summary_index(
             workspace_folder,
-            file_data["event_id_index"],
-            file_data["occ_offsets"],
-            file_data["occ_flat"],
+            file_data["occ_csr"],
             stack
         )
         if max_summary_id == 0:

--- a/oasislmf/pytools/common/input_files.py
+++ b/oasislmf/pytools/common/input_files.py
@@ -317,27 +317,6 @@ def read_occurrence_bin(run_dir="", filename=OCCURRENCE_FILE, use_stdin=False):
     return occ_arr, date_algorithm, granular_date, no_of_periods
 
 
-def read_occurrence(run_dir, filename=OCCURRENCE_FILE):
-    """Read the occurrence binary file and returns an occurrence map
-    Args:
-        run_dir (str | os.PathLike): Path to input files dir
-        filename (str | os.PathLike): occurrence binary file name
-    Returns:
-        occ_map (nb.typed.Dict): numpy map of event_id, period_no, occ_date_id from the occurrence file
-    """
-    occ_arr, date_algorithm, granular_date, no_of_periods = read_occurrence_bin(run_dir, filename=filename)
-
-    occ_dtype = occurrence_dtype
-    if granular_date:
-        occ_dtype = occurrence_granular_dtype
-
-    occ_map_valtype = occ_dtype[["period_no", "occ_date_id"]]
-    NB_occ_map_valtype = nb.types.Array(nb.from_dtype(occ_map_valtype), 1, "C")
-
-    occ_map = _read_occ_arr(occ_arr, occ_map_valtype, NB_occ_map_valtype)
-
-    return occ_map, date_algorithm, granular_date, no_of_periods
-
 
 @nb.njit(cache=True, error_model="numpy")
 def _read_occ_arr(occ_arr, occ_map_valtype, NB_occ_map_valtype):
@@ -401,15 +380,11 @@ def _build_occ_id_index_csr(occ_arr, granular_date):
     return OccurrenceCSR(_id_index_build(unique_ids), occ_offsets, occ_flat)
 
 
-def read_occurrence_id_index_csr(run_dir, filename=OCCURRENCE_FILE):
+def read_occurrence(run_dir, filename=OCCURRENCE_FILE):
     """Read the occurrence binary file and return an id_index-backed CSR map.
 
-    Replaces read_occurrence for production use in aal/lec/plt managers.
-    Lookup is 12-50x faster than the nb.typed.Dict returned by read_occurrence,
-    and memory is O(N_unique) regardless of event_id sparsity.
-
     Returns:
-        (event_id_index, occ_offsets, occ_flat): CSR lookup structure
+        occ_csr (OccurrenceCSR): id_index-backed CSR occurrence map
         date_algorithm (int): date algorithm flag
         granular_date (int): granular date flag
         no_of_periods (int): number of periods

--- a/oasislmf/pytools/common/input_files.py
+++ b/oasislmf/pytools/common/input_files.py
@@ -12,6 +12,7 @@ from oasislmf.pytools.common.data import (
     quantile_interval_dtype, returnperiods_dtype
 )
 from oasislmf.pytools.common.event_stream import mv_read, oasis_int, oasis_float
+from oasislmf.pytools.common.id_index import build as _id_index_build
 
 
 logger = logging.getLogger(__name__)
@@ -363,6 +364,55 @@ def _read_occ_arr(occ_arr, occ_map_valtype, NB_occ_map_valtype):
         occ_map[event_id] = occ_map[event_id][:occ_map_sizes[event_id]]
 
     return occ_map
+
+
+def _occ_flat_valtype(granular_date):
+    occ_date_np_type = np.int64 if granular_date else np.int32
+    return np.dtype([("period_no", np.int32), ("occ_date_id", occ_date_np_type)])
+
+
+def _build_occ_id_index_csr(occ_arr, granular_date):
+    """Build an id_index-backed CSR from an occurrence record array.
+
+    Returns (event_id_index, occ_offsets, occ_flat) where:
+      - event_id_index  uint32 array built by id_index.build()
+      - occ_offsets     int64 offsets of length n_unique_events + 1
+      - occ_flat        structured array [(period_no, occ_date_id)] sorted by event_id
+    """
+    valtype = _occ_flat_valtype(granular_date)
+    if len(occ_arr) == 0:
+        return _id_index_build(np.zeros(0, dtype=np.int32)), np.zeros(1, dtype=np.int64), np.zeros(0, dtype=valtype)
+
+    sort_idx = np.argsort(occ_arr["event_id"].astype(np.int64), kind="stable")
+    sorted_event_ids = occ_arr["event_id"][sort_idx].astype(np.int32)
+
+    occ_flat = np.empty(len(occ_arr), dtype=valtype)
+    occ_flat["period_no"] = occ_arr["period_no"][sort_idx]
+    occ_flat["occ_date_id"] = occ_arr["occ_date_id"][sort_idx]
+
+    unique_ids, counts = np.unique(sorted_event_ids, return_counts=True)
+    occ_offsets = np.zeros(len(unique_ids) + 1, dtype=np.int64)
+    np.cumsum(counts, out=occ_offsets[1:])
+
+    return _id_index_build(unique_ids), occ_offsets, occ_flat
+
+
+def read_occurrence_id_index_csr(run_dir, filename=OCCURRENCE_FILE):
+    """Read the occurrence binary file and return an id_index-backed CSR map.
+
+    Replaces read_occurrence for production use in aal/lec/plt managers.
+    Lookup is 12-50x faster than the nb.typed.Dict returned by read_occurrence,
+    and memory is O(N_unique) regardless of event_id sparsity.
+
+    Returns:
+        (event_id_index, occ_offsets, occ_flat): CSR lookup structure
+        date_algorithm (int): date algorithm flag
+        granular_date (int): granular date flag
+        no_of_periods (int): number of periods
+    """
+    occ_arr, date_algorithm, granular_date, no_of_periods = read_occurrence_bin(run_dir, filename=filename)
+    event_id_index, occ_offsets, occ_flat = _build_occ_id_index_csr(occ_arr, granular_date)
+    return (event_id_index, occ_offsets, occ_flat), date_algorithm, granular_date, no_of_periods
 
 
 @nb.njit(cache=True)

--- a/oasislmf/pytools/common/input_files.py
+++ b/oasislmf/pytools/common/input_files.py
@@ -365,7 +365,7 @@ def _build_occ_id_index_csr(occ_arr, granular_date):
     if len(occ_arr) == 0:
         return OccurrenceCSR(_id_index_build(np.zeros(0, dtype=np.int32)), np.zeros(1, dtype=np.int64), np.zeros(0, dtype=valtype))
 
-    sort_idx = np.argsort(occ_arr["event_id"].astype(np.int64), kind="stable")
+    sort_idx = np.argsort(occ_arr["event_id"], kind="stable")
     sorted_event_ids = occ_arr["event_id"][sort_idx].astype(np.int32)
 
     occ_flat = np.empty(len(occ_arr), dtype=valtype)

--- a/oasislmf/pytools/common/input_files.py
+++ b/oasislmf/pytools/common/input_files.py
@@ -317,7 +317,6 @@ def read_occurrence_bin(run_dir="", filename=OCCURRENCE_FILE, use_stdin=False):
     return occ_arr, date_algorithm, granular_date, no_of_periods
 
 
-
 @nb.njit(cache=True, error_model="numpy")
 def _read_occ_arr(occ_arr, occ_map_valtype, NB_occ_map_valtype):
     """Reads occurrence file array and returns an occurrence map of event_id to list of (period_no, occ_date_id)

--- a/oasislmf/pytools/common/input_files.py
+++ b/oasislmf/pytools/common/input_files.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 from contextlib import ExitStack
 import logging
 import sys
@@ -9,13 +10,16 @@ from oasislmf.pytools.common.data import (
     load_as_ndarray, nb_oasis_int,
     correlations_headers, correlations_dtype, coverages_headers,
     occurrence_dtype, occurrence_granular_dtype, periods_dtype, quantile_dtype,
-    quantile_interval_dtype, returnperiods_dtype
+    quantile_interval_dtype, returnperiods_dtype,
 )
 from oasislmf.pytools.common.event_stream import mv_read, oasis_int, oasis_float
-from oasislmf.pytools.common.id_index import build as _id_index_build
+from oasislmf.pytools.common.id_index import build as _id_index_build, get_idx as _id_index_get_idx, NOT_FOUND as _OCC_IDX_NOT_FOUND
 
 
 logger = logging.getLogger(__name__)
+
+
+OccurrenceCSR = namedtuple('OccurrenceCSR', ['event_id_index', 'occ_offsets', 'occ_flat'])
 
 # Input file names (input/<file_name>)
 AMPLIFICATIONS_FILE = "amplifications.bin"
@@ -394,7 +398,7 @@ def _build_occ_id_index_csr(occ_arr, granular_date):
     occ_offsets = np.zeros(len(unique_ids) + 1, dtype=np.int64)
     np.cumsum(counts, out=occ_offsets[1:])
 
-    return _id_index_build(unique_ids), occ_offsets, occ_flat
+    return OccurrenceCSR(_id_index_build(unique_ids), occ_offsets, occ_flat)
 
 
 def read_occurrence_id_index_csr(run_dir, filename=OCCURRENCE_FILE):
@@ -411,8 +415,21 @@ def read_occurrence_id_index_csr(run_dir, filename=OCCURRENCE_FILE):
         no_of_periods (int): number of periods
     """
     occ_arr, date_algorithm, granular_date, no_of_periods = read_occurrence_bin(run_dir, filename=filename)
-    event_id_index, occ_offsets, occ_flat = _build_occ_id_index_csr(occ_arr, granular_date)
-    return (event_id_index, occ_offsets, occ_flat), date_algorithm, granular_date, no_of_periods
+    occ_csr = _build_occ_id_index_csr(occ_arr, granular_date)
+    return occ_csr, date_algorithm, granular_date, no_of_periods
+
+
+@nb.njit(cache=True)
+def occ_get(occ_csr, event_id):
+    """Return the occ_flat slice for event_id, or an empty slice on miss.
+
+    The caller iterates the result directly; the loop body is skipped if the
+    event is not present in the occurrence file.
+    """
+    i = _id_index_get_idx(occ_csr.event_id_index, nb.int32(event_id))
+    if i == _OCC_IDX_NOT_FOUND:
+        return occ_csr.occ_flat[0:0]
+    return occ_csr.occ_flat[occ_csr.occ_offsets[i]:occ_csr.occ_offsets[i + 1]]
 
 
 @nb.njit(cache=True)

--- a/oasislmf/pytools/lec/manager.py
+++ b/oasislmf/pytools/lec/manager.py
@@ -11,7 +11,8 @@ import pyarrow.parquet as pq
 
 from oasislmf.pytools.common.data import (DEFAULT_BUFFER_SIZE, oasis_int, oasis_float, oasis_int_size, oasis_float_size)
 from oasislmf.pytools.common.event_stream import MAX_LOSS_IDX, MEAN_IDX, NUMBER_OF_AFFECTED_RISK_IDX, SUMMARY_STREAM_ID, init_streams_in, mv_read
-from oasislmf.pytools.common.input_files import PERIODS_FILE, read_occurrence, read_periods, read_returnperiods
+from oasislmf.pytools.common.id_index import get_idx as id_index_get_idx, NOT_FOUND as OCC_IDX_NOT_FOUND
+from oasislmf.pytools.common.input_files import PERIODS_FILE, read_occurrence_id_index_csr, read_periods, read_returnperiods
 from oasislmf.pytools.lec.data import (AEP, AEPTVAR, AGG_FULL_UNCERTAINTY, AGG_SAMPLE_MEAN, AGG_WHEATSHEAF, AGG_WHEATSHEAF_MEAN,
                                        OCC_FULL_UNCERTAINTY, OCC_SAMPLE_MEAN, OCC_WHEATSHEAF, OCC_WHEATSHEAF_MEAN, OEP, OEPTVAR,
                                        OUTLOSS_DTYPE, EPT_dtype, EPT_fmt, EPT_headers, PSEPT_dtype, PSEPT_fmt, PSEPT_headers)
@@ -44,7 +45,7 @@ def read_input_files(
         occ_wheatsheaf_mean (bool): Occurrence Wheatsheaf Mean.
     """
     input_dir = Path(run_dir, "input")
-    occ_map, date_algorithm, granular_date, no_of_periods = read_occurrence(input_dir)
+    (event_id_index, occ_offsets, occ_flat), date_algorithm, granular_date, no_of_periods = read_occurrence_id_index_csr(input_dir)
     period_weights = read_periods(no_of_periods, input_dir)
     periods_fp = Path(input_dir, PERIODS_FILE)
     if not periods_fp.exists():
@@ -65,7 +66,9 @@ def read_input_files(
             logger.info("INFO: Tail Value at Risk for Wheatsheaf mean/per sample mean is not supported if you wish to use non-uniform period weights.")
 
     file_data = {
-        "occ_map": occ_map,
+        "event_id_index": event_id_index,
+        "occ_offsets": occ_offsets,
+        "occ_flat": occ_flat,
         "date_algorithm": date_algorithm,
         "granular_date": granular_date,
         "no_of_periods": no_of_periods,
@@ -153,7 +156,9 @@ def process_input_file(
     outloss_sample,
     row_used_sample,
     summary_ids,
-    occ_map,
+    event_id_index,
+    occ_offsets,
+    occ_flat,
     use_return_period,
     num_sidxs,
     max_summary_id,
@@ -166,7 +171,9 @@ def process_input_file(
         outloss_sample (ndarray[OUTLOSS_DTYPE]): ndarray indexed by summary_id, sidx, period_no containing aggregate and max losses
         row_used_sample (ndarray[bool]): bool mask for outloss_sample
         summary_ids (ndarray[bool]): bool array marking which summary_ids are used
-        occ_map (nb.typed.Dict): numpy map of event_id, period_no, occ_date_id from the occurrence file
+        event_id_index (ndarray[uint32]): id_index array for event lookup
+        occ_offsets (ndarray[int64]): CSR offsets into occ_flat, length = n_unique_events + 1
+        occ_flat (ndarray): structured array [(period_no, occ_date_id)] sorted by event_id
         use_return_period (bool): Use Return Period file.
         num_sidxs (int): Number of sidxs to consider for outloss_sample
         max_summary_id (int): Max summary ID
@@ -182,7 +189,8 @@ def process_input_file(
         expval, cursor = mv_read(fin, cursor, oasis_float, oasis_float_size)
 
         # Discard samples if event_id not found
-        if event_id not in occ_map:
+        _occ_i = id_index_get_idx(event_id_index, nb.int32(event_id))
+        if _occ_i == OCC_IDX_NOT_FOUND:
             while cursor < valid_buff:
                 sidx, cursor = mv_read(fin, cursor, oasis_int, oasis_int_size)
                 _, cursor = mv_read(fin, cursor, oasis_float, oasis_float_size)
@@ -190,7 +198,7 @@ def process_input_file(
                     break
             continue
 
-        filtered_occ_map = occ_map[event_id]
+        filtered_occ_map = occ_flat[occ_offsets[_occ_i]:occ_offsets[_occ_i + 1]]
         summary_ids[summary_id - 1] = True
 
         while cursor < valid_buff:
@@ -223,7 +231,9 @@ def run_lec(
     outloss_sample,
     row_used_sample,
     summary_ids,
-    occ_map,
+    event_id_index,
+    occ_offsets,
+    occ_flat,
     use_return_period,
     num_sidxs,
     max_summary_id,
@@ -236,7 +246,9 @@ def run_lec(
         outloss_sample (ndarray[OUTLOSS_DTYPE]): ndarray indexed by summary_id, sidx, period_no containing aggregate and max losses
         row_used_sample (ndarray[bool]): bool mask for outloss_sample
         summary_ids (ndarray[bool]): bool array marking which summary_ids are used
-        occ_map (nb.typed.Dict): numpy map of event_id, period_no, occ_date_id from the occurrence file
+        event_id_index (ndarray[uint32]): id_index array for event lookup
+        occ_offsets (ndarray[int64]): CSR offsets into occ_flat, length = n_unique_events + 1
+        occ_flat (ndarray): structured array [(period_no, occ_date_id)] sorted by event_id
         use_return_period (bool): Use Return Period file.
         num_sidxs (int): Number of sidxs to consider for outloss_sample
         max_summary_id (int): Max summary ID
@@ -249,7 +261,9 @@ def run_lec(
             outloss_sample,
             row_used_sample,
             summary_ids,
-            occ_map,
+            event_id_index,
+            occ_offsets,
+            occ_flat,
             use_return_period,
             num_sidxs,
             max_summary_id,
@@ -419,7 +433,9 @@ def run(
             outloss_sample,
             row_used_sample,
             summary_ids,
-            file_data["occ_map"],
+            file_data["event_id_index"],
+            file_data["occ_offsets"],
+            file_data["occ_flat"],
             use_return_period,
             num_sidxs,
             max_summary_id,

--- a/oasislmf/pytools/lec/manager.py
+++ b/oasislmf/pytools/lec/manager.py
@@ -223,7 +223,6 @@ def process_input_file(
     row_used_mean,
     outloss_sample,
     row_used_sample,
-    summary_ids,
     occ_csr,
     use_return_period,
     num_sidxs,
@@ -236,7 +235,6 @@ def process_input_file(
         row_used_mean (ndarray[bool]): bool mask for outloss_mean
         outloss_sample (ndarray[OUTLOSS_DTYPE]): ndarray indexed by summary_id, sidx, period_no containing aggregate and max losses
         row_used_sample (ndarray[bool]): bool mask for outloss_sample
-        summary_ids (ndarray[bool]): bool array marking which summary_ids are used
         occ_csr (OccurrenceCSR): id_index-backed CSR occurrence map
         use_return_period (bool): Use Return Period file.
         num_sidxs (int): Number of sidxs to consider for outloss_sample
@@ -259,8 +257,6 @@ def process_input_file(
                 if sidx == 0:
                     break
             continue
-        summary_ids[summary_id - 1] = True
-
         while cursor < valid_buff:
             sidx, cursor = mv_read(fin, cursor, oasis_int, oasis_int_size)
             loss, cursor = mv_read(fin, cursor, oasis_float, oasis_float_size)
@@ -290,7 +286,6 @@ def run_lec(
     row_used_mean,
     outloss_sample,
     row_used_sample,
-    summary_ids,
     occ_csr,
     use_return_period,
     num_sidxs,
@@ -303,7 +298,6 @@ def run_lec(
         row_used_mean (ndarray[bool]): bool mask for outloss_mean
         outloss_sample (ndarray[OUTLOSS_DTYPE]): ndarray indexed by summary_id, sidx, period_no containing aggregate and max losses
         row_used_sample (ndarray[bool]): bool mask for outloss_sample
-        summary_ids (ndarray[bool]): bool array marking which summary_ids are used
         occ_csr (OccurrenceCSR): id_index-backed CSR occurrence map
         use_return_period (bool): Use Return Period file.
         num_sidxs (int): Number of sidxs to consider for outloss_sample
@@ -316,7 +310,6 @@ def run_lec(
             row_used_mean,
             outloss_sample,
             row_used_sample,
-            summary_ids,
             occ_csr,
             use_return_period,
             num_sidxs,
@@ -616,14 +609,12 @@ def run(
         row_used_sample = np.memmap(row_used_sample_file, dtype=np.bool_, mode="w+", shape=(len(outloss_sample),))
 
         # Run LEC calculations to populate outloss arrays
-        summary_ids = np.zeros(max_summary_id, dtype=np.bool_)
         run_lec(
             file_handles,
             outloss_mean,
             row_used_mean,
             outloss_sample,
             row_used_sample,
-            summary_ids,
             file_data["occ_csr"],
             use_return_period,
             num_sidxs,

--- a/oasislmf/pytools/lec/manager.py
+++ b/oasislmf/pytools/lec/manager.py
@@ -13,7 +13,7 @@ import pyarrow.parquet as pq
 from oasislmf.pytools.common.data import (DEFAULT_BUFFER_SIZE, oasis_int, oasis_float, oasis_int_size, oasis_float_size,
                                           summary_stream_index_dtype)
 from oasislmf.pytools.common.event_stream import MAX_LOSS_IDX, MEAN_IDX, NUMBER_OF_AFFECTED_RISK_IDX, SUMMARY_STREAM_ID, init_streams_in, mv_read
-from oasislmf.pytools.common.input_files import PERIODS_FILE, occ_get, read_occurrence_id_index_csr, read_periods, read_returnperiods
+from oasislmf.pytools.common.input_files import PERIODS_FILE, occ_get, read_occurrence, read_periods, read_returnperiods
 from oasislmf.pytools.lec.data import (AEP, AEPTVAR, AGG_FULL_UNCERTAINTY, AGG_SAMPLE_MEAN, AGG_WHEATSHEAF, AGG_WHEATSHEAF_MEAN,
                                        OCC_FULL_UNCERTAINTY, OCC_SAMPLE_MEAN, OCC_WHEATSHEAF, OCC_WHEATSHEAF_MEAN, OEP, OEPTVAR,
                                        OUTLOSS_DTYPE, EPT_dtype, EPT_fmt, EPT_headers, PSEPT_dtype, PSEPT_fmt, PSEPT_headers)
@@ -46,7 +46,7 @@ def read_input_files(
         occ_wheatsheaf_mean (bool): Occurrence Wheatsheaf Mean.
     """
     input_dir = Path(run_dir, "input")
-    occ_csr, date_algorithm, granular_date, no_of_periods = read_occurrence_id_index_csr(input_dir)
+    occ_csr, date_algorithm, granular_date, no_of_periods = read_occurrence(input_dir)
     period_weights = read_periods(no_of_periods, input_dir)
     periods_fp = Path(input_dir, PERIODS_FILE)
     if not periods_fp.exists():

--- a/oasislmf/pytools/lec/manager.py
+++ b/oasislmf/pytools/lec/manager.py
@@ -11,8 +11,7 @@ import pyarrow.parquet as pq
 
 from oasislmf.pytools.common.data import (DEFAULT_BUFFER_SIZE, oasis_int, oasis_float, oasis_int_size, oasis_float_size)
 from oasislmf.pytools.common.event_stream import MAX_LOSS_IDX, MEAN_IDX, NUMBER_OF_AFFECTED_RISK_IDX, SUMMARY_STREAM_ID, init_streams_in, mv_read
-from oasislmf.pytools.common.id_index import get_idx as id_index_get_idx, NOT_FOUND as OCC_IDX_NOT_FOUND
-from oasislmf.pytools.common.input_files import PERIODS_FILE, read_occurrence_id_index_csr, read_periods, read_returnperiods
+from oasislmf.pytools.common.input_files import PERIODS_FILE, occ_get, read_occurrence_id_index_csr, read_periods, read_returnperiods
 from oasislmf.pytools.lec.data import (AEP, AEPTVAR, AGG_FULL_UNCERTAINTY, AGG_SAMPLE_MEAN, AGG_WHEATSHEAF, AGG_WHEATSHEAF_MEAN,
                                        OCC_FULL_UNCERTAINTY, OCC_SAMPLE_MEAN, OCC_WHEATSHEAF, OCC_WHEATSHEAF_MEAN, OEP, OEPTVAR,
                                        OUTLOSS_DTYPE, EPT_dtype, EPT_fmt, EPT_headers, PSEPT_dtype, PSEPT_fmt, PSEPT_headers)
@@ -45,7 +44,7 @@ def read_input_files(
         occ_wheatsheaf_mean (bool): Occurrence Wheatsheaf Mean.
     """
     input_dir = Path(run_dir, "input")
-    (event_id_index, occ_offsets, occ_flat), date_algorithm, granular_date, no_of_periods = read_occurrence_id_index_csr(input_dir)
+    occ_csr, date_algorithm, granular_date, no_of_periods = read_occurrence_id_index_csr(input_dir)
     period_weights = read_periods(no_of_periods, input_dir)
     periods_fp = Path(input_dir, PERIODS_FILE)
     if not periods_fp.exists():
@@ -66,9 +65,7 @@ def read_input_files(
             logger.info("INFO: Tail Value at Risk for Wheatsheaf mean/per sample mean is not supported if you wish to use non-uniform period weights.")
 
     file_data = {
-        "event_id_index": event_id_index,
-        "occ_offsets": occ_offsets,
-        "occ_flat": occ_flat,
+        "occ_csr": occ_csr,
         "date_algorithm": date_algorithm,
         "granular_date": granular_date,
         "no_of_periods": no_of_periods,
@@ -156,9 +153,7 @@ def process_input_file(
     outloss_sample,
     row_used_sample,
     summary_ids,
-    event_id_index,
-    occ_offsets,
-    occ_flat,
+    occ_csr,
     use_return_period,
     num_sidxs,
     max_summary_id,
@@ -171,9 +166,7 @@ def process_input_file(
         outloss_sample (ndarray[OUTLOSS_DTYPE]): ndarray indexed by summary_id, sidx, period_no containing aggregate and max losses
         row_used_sample (ndarray[bool]): bool mask for outloss_sample
         summary_ids (ndarray[bool]): bool array marking which summary_ids are used
-        event_id_index (ndarray[uint32]): id_index array for event lookup
-        occ_offsets (ndarray[int64]): CSR offsets into occ_flat, length = n_unique_events + 1
-        occ_flat (ndarray): structured array [(period_no, occ_date_id)] sorted by event_id
+        occ_csr (OccurrenceCSR): id_index-backed CSR occurrence map
         use_return_period (bool): Use Return Period file.
         num_sidxs (int): Number of sidxs to consider for outloss_sample
         max_summary_id (int): Max summary ID
@@ -188,17 +181,14 @@ def process_input_file(
         summary_id, cursor = mv_read(fin, cursor, oasis_int, oasis_int_size)
         expval, cursor = mv_read(fin, cursor, oasis_float, oasis_float_size)
 
-        # Discard samples if event_id not found
-        _occ_i = id_index_get_idx(event_id_index, nb.int32(event_id))
-        if _occ_i == OCC_IDX_NOT_FOUND:
+        filtered_occ_map = occ_get(occ_csr, event_id)
+        if len(filtered_occ_map) == 0:
             while cursor < valid_buff:
                 sidx, cursor = mv_read(fin, cursor, oasis_int, oasis_int_size)
                 _, cursor = mv_read(fin, cursor, oasis_float, oasis_float_size)
                 if sidx == 0:
                     break
             continue
-
-        filtered_occ_map = occ_flat[occ_offsets[_occ_i]:occ_offsets[_occ_i + 1]]
         summary_ids[summary_id - 1] = True
 
         while cursor < valid_buff:
@@ -231,9 +221,7 @@ def run_lec(
     outloss_sample,
     row_used_sample,
     summary_ids,
-    event_id_index,
-    occ_offsets,
-    occ_flat,
+    occ_csr,
     use_return_period,
     num_sidxs,
     max_summary_id,
@@ -246,9 +234,7 @@ def run_lec(
         outloss_sample (ndarray[OUTLOSS_DTYPE]): ndarray indexed by summary_id, sidx, period_no containing aggregate and max losses
         row_used_sample (ndarray[bool]): bool mask for outloss_sample
         summary_ids (ndarray[bool]): bool array marking which summary_ids are used
-        event_id_index (ndarray[uint32]): id_index array for event lookup
-        occ_offsets (ndarray[int64]): CSR offsets into occ_flat, length = n_unique_events + 1
-        occ_flat (ndarray): structured array [(period_no, occ_date_id)] sorted by event_id
+        occ_csr (OccurrenceCSR): id_index-backed CSR occurrence map
         use_return_period (bool): Use Return Period file.
         num_sidxs (int): Number of sidxs to consider for outloss_sample
         max_summary_id (int): Max summary ID
@@ -261,9 +247,7 @@ def run_lec(
             outloss_sample,
             row_used_sample,
             summary_ids,
-            event_id_index,
-            occ_offsets,
-            occ_flat,
+            occ_csr,
             use_return_period,
             num_sidxs,
             max_summary_id,
@@ -433,9 +417,7 @@ def run(
             outloss_sample,
             row_used_sample,
             summary_ids,
-            file_data["event_id_index"],
-            file_data["occ_offsets"],
-            file_data["occ_flat"],
+            file_data["occ_csr"],
             use_return_period,
             num_sidxs,
             max_summary_id,

--- a/oasislmf/pytools/plt/manager.py
+++ b/oasislmf/pytools/plt/manager.py
@@ -13,7 +13,8 @@ from oasislmf.pytools.common.data import (DEFAULT_BUFFER_SIZE, MEAN_TYPE_ANALYTI
                                           oasis_int_size, oasis_float_size, write_ndarray_to_fmt_csv)
 from oasislmf.pytools.common.event_stream import (MAX_LOSS_IDX, MEAN_IDX, NUMBER_OF_AFFECTED_RISK_IDX, EventReader, init_streams_in,
                                                   mv_read, SUMMARY_STREAM_ID)
-from oasislmf.pytools.common.input_files import occ_get_date, read_occurrence, read_periods, read_quantile
+from oasislmf.pytools.common.id_index import get_idx as id_index_get_idx, NOT_FOUND as OCC_IDX_NOT_FOUND
+from oasislmf.pytools.common.input_files import occ_get_date, read_occurrence_id_index_csr, read_periods, read_quantile
 from oasislmf.pytools.plt.data import MPLT_dtype, MPLT_fmt, MPLT_headers, QPLT_dtype, QPLT_fmt, QPLT_headers, SPLT_dtype, SPLT_fmt, SPLT_headers
 from oasislmf.pytools.utils import redirect_logging
 
@@ -27,7 +28,9 @@ class PLTReader(EventReader):
         compute_splt,
         compute_mplt,
         compute_qplt,
-        occ_map,
+        event_id_index,
+        occ_offsets,
+        occ_flat,
         period_weights,
         granular_date,
         intervals,
@@ -71,7 +74,9 @@ class PLTReader(EventReader):
         self.state["compute_mplt"] = compute_mplt
         self.state["compute_qplt"] = compute_qplt
         self.state["hasrec"] = False
-        self.occ_map = occ_map
+        self.event_id_index = event_id_index
+        self.occ_offsets = occ_offsets
+        self.occ_flat = occ_flat
         self.period_weights = period_weights
         self.granular_date = granular_date
         self.intervals = intervals
@@ -114,7 +119,9 @@ class PLTReader(EventReader):
             self.splt_data, self.splt_idx,
             self.mplt_data, self.mplt_idx,
             self.qplt_data, self.qplt_idx,
-            self.occ_map,
+            self.event_id_index,
+            self.occ_offsets,
+            self.occ_flat,
             self.period_weights,
             self.granular_date,
             self.intervals,
@@ -218,7 +225,9 @@ def read_buffer(
         splt_data, splt_idx,
         mplt_data, mplt_idx,
         qplt_data, qplt_idx,
-        occ_map,
+        event_id_index,
+        occ_offsets,
+        occ_flat,
         period_weights,
         granular_date,
         intervals,
@@ -293,8 +302,9 @@ def read_buffer(
 
                 # Update MPLT data (sample mean)
                 if state["compute_mplt"]:
-                    if event_id in occ_map:
-                        for record in occ_map[event_id]:
+                    _occ_i_mplt = id_index_get_idx(event_id_index, nb.int32(event_id))
+                    if _occ_i_mplt != OCC_IDX_NOT_FOUND:
+                        for record in occ_flat[occ_offsets[_occ_i_mplt]:occ_offsets[_occ_i_mplt + 1]]:
                             if state["hasrec"]:
                                 meanloss, sdloss = _get_mean_and_sd_loss()
                                 if meanloss > 0 or sdloss > 0:
@@ -321,8 +331,9 @@ def read_buffer(
                 # Update QPLT data
                 if state["compute_qplt"]:
                     state["vrec"].sort()
-                    if event_id in occ_map:
-                        for record in occ_map[event_id]:
+                    _occ_i_qplt = id_index_get_idx(event_id_index, nb.int32(event_id))
+                    if _occ_i_qplt != OCC_IDX_NOT_FOUND:
+                        for record in occ_flat[occ_offsets[_occ_i_qplt]:occ_offsets[_occ_i_qplt + 1]]:
                             for i in range(len(intervals)):
                                 q = intervals[i]["quantile"]
                                 ipart = intervals[i]["integer_part"]
@@ -360,8 +371,9 @@ def read_buffer(
                 impacted_exposure = state["exposure_value"] * (loss > 0)
                 # Update SPLT data
                 if state["compute_splt"]:
-                    if event_id in occ_map:
-                        for record in occ_map[event_id]:
+                    _occ_i_splt = id_index_get_idx(event_id_index, nb.int32(event_id))
+                    if _occ_i_splt != OCC_IDX_NOT_FOUND:
+                        for record in occ_flat[occ_offsets[_occ_i_splt]:occ_offsets[_occ_i_splt + 1]]:
                             _update_splt_data(
                                 splt_data, si, period_weights, granular_date,
                                 record=record,
@@ -381,8 +393,9 @@ def read_buffer(
             elif sidx == MEAN_IDX:
                 # Update MPLT data (analytical mean)
                 if state["compute_mplt"]:
-                    if event_id in occ_map:
-                        for record in occ_map[event_id]:
+                    _occ_i_analytical = id_index_get_idx(event_id_index, nb.int32(event_id))
+                    if _occ_i_analytical != OCC_IDX_NOT_FOUND:
+                        for record in occ_flat[occ_offsets[_occ_i_analytical]:occ_offsets[_occ_i_analytical + 1]]:
                             if loss <= 0:
                                 continue
                             _update_mplt_data(
@@ -432,12 +445,14 @@ def read_input_files(run_dir, compute_qplt, sample_size):
     Returns:
         file_data (Dict[str, Any]): A dict of relevent data extracted from files
     """
-    occ_map, date_algorithm, granular_date, no_of_periods = read_occurrence(Path(run_dir, "input"))
+    (event_id_index, occ_offsets, occ_flat), date_algorithm, granular_date, no_of_periods = read_occurrence_id_index_csr(Path(run_dir, "input"))
     period_weights = read_periods(no_of_periods, Path(run_dir, "input"))
     intervals = read_quantile(sample_size, Path(run_dir, "input"), return_empty=not compute_qplt)
 
     file_data = {
-        "occ_map": occ_map,
+        "event_id_index": event_id_index,
+        "occ_offsets": occ_offsets,
+        "occ_flat": occ_flat,
         "date_algorithm": date_algorithm,
         "granular_date": granular_date,
         "no_of_periods": no_of_periods,
@@ -527,7 +542,9 @@ def run(
             outmap["splt"]["compute"],
             outmap["mplt"]["compute"],
             outmap["qplt"]["compute"],
-            file_data["occ_map"],
+            file_data["event_id_index"],
+            file_data["occ_offsets"],
+            file_data["occ_flat"],
             file_data["period_weights"],
             file_data["granular_date"],
             file_data["intervals"],

--- a/oasislmf/pytools/plt/manager.py
+++ b/oasislmf/pytools/plt/manager.py
@@ -13,7 +13,7 @@ from oasislmf.pytools.common.data import (DEFAULT_BUFFER_SIZE, MEAN_TYPE_ANALYTI
                                           oasis_int_size, oasis_float_size, write_ndarray_to_fmt_csv)
 from oasislmf.pytools.common.event_stream import (MAX_LOSS_IDX, MEAN_IDX, NUMBER_OF_AFFECTED_RISK_IDX, EventReader, init_streams_in,
                                                   mv_read, SUMMARY_STREAM_ID)
-from oasislmf.pytools.common.input_files import occ_get, occ_get_date, read_occurrence_id_index_csr, read_periods, read_quantile
+from oasislmf.pytools.common.input_files import occ_get, occ_get_date, read_occurrence, read_periods, read_quantile
 from oasislmf.pytools.plt.data import MPLT_dtype, MPLT_fmt, MPLT_headers, QPLT_dtype, QPLT_fmt, QPLT_headers, SPLT_dtype, SPLT_fmt, SPLT_headers
 from oasislmf.pytools.utils import redirect_logging
 
@@ -428,7 +428,7 @@ def read_input_files(run_dir, compute_qplt, sample_size):
     Returns:
         file_data (Dict[str, Any]): A dict of relevent data extracted from files
     """
-    occ_csr, date_algorithm, granular_date, no_of_periods = read_occurrence_id_index_csr(Path(run_dir, "input"))
+    occ_csr, date_algorithm, granular_date, no_of_periods = read_occurrence(Path(run_dir, "input"))
     period_weights = read_periods(no_of_periods, Path(run_dir, "input"))
     intervals = read_quantile(sample_size, Path(run_dir, "input"), return_empty=not compute_qplt)
 

--- a/oasislmf/pytools/plt/manager.py
+++ b/oasislmf/pytools/plt/manager.py
@@ -13,8 +13,7 @@ from oasislmf.pytools.common.data import (DEFAULT_BUFFER_SIZE, MEAN_TYPE_ANALYTI
                                           oasis_int_size, oasis_float_size, write_ndarray_to_fmt_csv)
 from oasislmf.pytools.common.event_stream import (MAX_LOSS_IDX, MEAN_IDX, NUMBER_OF_AFFECTED_RISK_IDX, EventReader, init_streams_in,
                                                   mv_read, SUMMARY_STREAM_ID)
-from oasislmf.pytools.common.id_index import get_idx as id_index_get_idx, NOT_FOUND as OCC_IDX_NOT_FOUND
-from oasislmf.pytools.common.input_files import occ_get_date, read_occurrence_id_index_csr, read_periods, read_quantile
+from oasislmf.pytools.common.input_files import occ_get, occ_get_date, read_occurrence_id_index_csr, read_periods, read_quantile
 from oasislmf.pytools.plt.data import MPLT_dtype, MPLT_fmt, MPLT_headers, QPLT_dtype, QPLT_fmt, QPLT_headers, SPLT_dtype, SPLT_fmt, SPLT_headers
 from oasislmf.pytools.utils import redirect_logging
 
@@ -28,9 +27,7 @@ class PLTReader(EventReader):
         compute_splt,
         compute_mplt,
         compute_qplt,
-        event_id_index,
-        occ_offsets,
-        occ_flat,
+        occ_csr,
         period_weights,
         granular_date,
         intervals,
@@ -74,9 +71,7 @@ class PLTReader(EventReader):
         self.state["compute_mplt"] = compute_mplt
         self.state["compute_qplt"] = compute_qplt
         self.state["hasrec"] = False
-        self.event_id_index = event_id_index
-        self.occ_offsets = occ_offsets
-        self.occ_flat = occ_flat
+        self.occ_csr = occ_csr
         self.period_weights = period_weights
         self.granular_date = granular_date
         self.intervals = intervals
@@ -119,9 +114,7 @@ class PLTReader(EventReader):
             self.splt_data, self.splt_idx,
             self.mplt_data, self.mplt_idx,
             self.qplt_data, self.qplt_idx,
-            self.event_id_index,
-            self.occ_offsets,
-            self.occ_flat,
+            self.occ_csr,
             self.period_weights,
             self.granular_date,
             self.intervals,
@@ -225,9 +218,7 @@ def read_buffer(
         splt_data, splt_idx,
         mplt_data, mplt_idx,
         qplt_data, qplt_idx,
-        event_id_index,
-        occ_offsets,
-        occ_flat,
+        occ_csr,
         period_weights,
         granular_date,
         intervals,
@@ -302,62 +293,58 @@ def read_buffer(
 
                 # Update MPLT data (sample mean)
                 if state["compute_mplt"]:
-                    _occ_i_mplt = id_index_get_idx(event_id_index, nb.int32(event_id))
-                    if _occ_i_mplt != OCC_IDX_NOT_FOUND:
-                        for record in occ_flat[occ_offsets[_occ_i_mplt]:occ_offsets[_occ_i_mplt + 1]]:
-                            if state["hasrec"]:
-                                meanloss, sdloss = _get_mean_and_sd_loss()
-                                if meanloss > 0 or sdloss > 0:
-                                    _update_mplt_data(
-                                        mplt_data, mi, period_weights, granular_date,
-                                        record=record,
-                                        event_id=event_id,
-                                        summary_id=state["summary_id"],
-                                        sample_type=MEAN_TYPE_SAMPLE,
-                                        chance_of_loss=state["chance_of_loss"],
-                                        meanloss=meanloss,
-                                        sdloss=sdloss,
-                                        maxloss=state["max_loss"],
-                                        footprint_exposure=state["exposure_value"],
-                                        mean_impacted_exposure=state["mean_impacted_exposure"],
-                                        max_impacted_exposure=state["max_impacted_exposure"],
-                                    )
-                                    mi += 1
-                                    if mi >= mplt_data.shape[0]:
-                                        # Output array full
-                                        _update_idxs()
-                                        return cursor, event_id, item_id, 1
+                    for record in occ_get(occ_csr, event_id):
+                        if state["hasrec"]:
+                            meanloss, sdloss = _get_mean_and_sd_loss()
+                            if meanloss > 0 or sdloss > 0:
+                                _update_mplt_data(
+                                    mplt_data, mi, period_weights, granular_date,
+                                    record=record,
+                                    event_id=event_id,
+                                    summary_id=state["summary_id"],
+                                    sample_type=MEAN_TYPE_SAMPLE,
+                                    chance_of_loss=state["chance_of_loss"],
+                                    meanloss=meanloss,
+                                    sdloss=sdloss,
+                                    maxloss=state["max_loss"],
+                                    footprint_exposure=state["exposure_value"],
+                                    mean_impacted_exposure=state["mean_impacted_exposure"],
+                                    max_impacted_exposure=state["max_impacted_exposure"],
+                                )
+                                mi += 1
+                                if mi >= mplt_data.shape[0]:
+                                    # Output array full
+                                    _update_idxs()
+                                    return cursor, event_id, item_id, 1
 
                 # Update QPLT data
                 if state["compute_qplt"]:
                     state["vrec"].sort()
-                    _occ_i_qplt = id_index_get_idx(event_id_index, nb.int32(event_id))
-                    if _occ_i_qplt != OCC_IDX_NOT_FOUND:
-                        for record in occ_flat[occ_offsets[_occ_i_qplt]:occ_offsets[_occ_i_qplt + 1]]:
-                            for i in range(len(intervals)):
-                                q = intervals[i]["quantile"]
-                                ipart = intervals[i]["integer_part"]
-                                fpart = intervals[i]["fractional_part"]
-                                if ipart == len(state["vrec"]):
-                                    loss = state["vrec"][ipart - 1]
-                                else:
-                                    loss = (
-                                        (state["vrec"][ipart] - state["vrec"][ipart - 1]) *
-                                        fpart + state["vrec"][ipart - 1]
-                                    )
-                                _update_qplt_data(
-                                    qplt_data, qi, period_weights, granular_date,
-                                    record=record,
-                                    event_id=event_id,
-                                    summary_id=state["summary_id"],
-                                    quantile=q,
-                                    loss=loss
+                    for record in occ_get(occ_csr, event_id):
+                        for i in range(len(intervals)):
+                            q = intervals[i]["quantile"]
+                            ipart = intervals[i]["integer_part"]
+                            fpart = intervals[i]["fractional_part"]
+                            if ipart == len(state["vrec"]):
+                                loss = state["vrec"][ipart - 1]
+                            else:
+                                loss = (
+                                    (state["vrec"][ipart] - state["vrec"][ipart - 1]) *
+                                    fpart + state["vrec"][ipart - 1]
                                 )
-                                qi += 1
-                                if qi >= qplt_data.shape[0]:
-                                    # Output array full
-                                    _update_idxs()
-                                    return cursor, event_id, item_id, 1
+                            _update_qplt_data(
+                                qplt_data, qi, period_weights, granular_date,
+                                record=record,
+                                event_id=event_id,
+                                summary_id=state["summary_id"],
+                                quantile=q,
+                                loss=loss
+                            )
+                            qi += 1
+                            if qi >= qplt_data.shape[0]:
+                                # Output array full
+                                _update_idxs()
+                                return cursor, event_id, item_id, 1
                 _reset_state()
                 continue
 
@@ -371,52 +358,48 @@ def read_buffer(
                 impacted_exposure = state["exposure_value"] * (loss > 0)
                 # Update SPLT data
                 if state["compute_splt"]:
-                    _occ_i_splt = id_index_get_idx(event_id_index, nb.int32(event_id))
-                    if _occ_i_splt != OCC_IDX_NOT_FOUND:
-                        for record in occ_flat[occ_offsets[_occ_i_splt]:occ_offsets[_occ_i_splt + 1]]:
-                            _update_splt_data(
-                                splt_data, si, period_weights, granular_date,
-                                record=record,
-                                event_id=event_id,
-                                summary_id=state["summary_id"],
-                                sidx=sidx,
-                                loss=loss,
-                                impacted_exposure=impacted_exposure,
-                            )
-                            si += 1
-                            if si >= splt_data.shape[0]:
-                                # Output array full
-                                _update_idxs()
-                                return cursor, event_id, item_id, 1
+                    for record in occ_get(occ_csr, event_id):
+                        _update_splt_data(
+                            splt_data, si, period_weights, granular_date,
+                            record=record,
+                            event_id=event_id,
+                            summary_id=state["summary_id"],
+                            sidx=sidx,
+                            loss=loss,
+                            impacted_exposure=impacted_exposure,
+                        )
+                        si += 1
+                        if si >= splt_data.shape[0]:
+                            # Output array full
+                            _update_idxs()
+                            return cursor, event_id, item_id, 1
             if sidx == MAX_LOSS_IDX:
                 state["max_loss"] = loss
             elif sidx == MEAN_IDX:
                 # Update MPLT data (analytical mean)
                 if state["compute_mplt"]:
-                    _occ_i_analytical = id_index_get_idx(event_id_index, nb.int32(event_id))
-                    if _occ_i_analytical != OCC_IDX_NOT_FOUND:
-                        for record in occ_flat[occ_offsets[_occ_i_analytical]:occ_offsets[_occ_i_analytical + 1]]:
-                            if loss <= 0:
-                                continue
-                            _update_mplt_data(
-                                mplt_data, mi, period_weights, granular_date,
-                                record=record,
-                                event_id=event_id,
-                                summary_id=state["summary_id"],
-                                sample_type=MEAN_TYPE_ANALYTICAL,
-                                chance_of_loss=0,
-                                meanloss=loss,
-                                sdloss=0,
-                                maxloss=state["max_loss"],
-                                footprint_exposure=state["exposure_value"],
-                                mean_impacted_exposure=state["exposure_value"],
-                                max_impacted_exposure=state["exposure_value"],
-                            )
-                            mi += 1
-                            if mi >= mplt_data.shape[0]:
-                                # Output array full
-                                _update_idxs()
-                                return cursor, event_id, item_id, 1
+                    for record in occ_get(occ_csr, event_id):
+                        if loss <= 0:
+                            continue
+                        _update_mplt_data(
+                            mplt_data, mi, period_weights, granular_date,
+                            record=record,
+                            event_id=event_id,
+                            summary_id=state["summary_id"],
+                            sample_type=MEAN_TYPE_ANALYTICAL,
+                            chance_of_loss=0,
+                            meanloss=loss,
+                            sdloss=0,
+                            maxloss=state["max_loss"],
+                            footprint_exposure=state["exposure_value"],
+                            mean_impacted_exposure=state["exposure_value"],
+                            max_impacted_exposure=state["exposure_value"],
+                        )
+                        mi += 1
+                        if mi >= mplt_data.shape[0]:
+                            # Output array full
+                            _update_idxs()
+                            return cursor, event_id, item_id, 1
             else:
                 # Update state variables
                 if sidx > 0:
@@ -445,14 +428,12 @@ def read_input_files(run_dir, compute_qplt, sample_size):
     Returns:
         file_data (Dict[str, Any]): A dict of relevent data extracted from files
     """
-    (event_id_index, occ_offsets, occ_flat), date_algorithm, granular_date, no_of_periods = read_occurrence_id_index_csr(Path(run_dir, "input"))
+    occ_csr, date_algorithm, granular_date, no_of_periods = read_occurrence_id_index_csr(Path(run_dir, "input"))
     period_weights = read_periods(no_of_periods, Path(run_dir, "input"))
     intervals = read_quantile(sample_size, Path(run_dir, "input"), return_empty=not compute_qplt)
 
     file_data = {
-        "event_id_index": event_id_index,
-        "occ_offsets": occ_offsets,
-        "occ_flat": occ_flat,
+        "occ_csr": occ_csr,
         "date_algorithm": date_algorithm,
         "granular_date": granular_date,
         "no_of_periods": no_of_periods,
@@ -542,9 +523,7 @@ def run(
             outmap["splt"]["compute"],
             outmap["mplt"]["compute"],
             outmap["qplt"]["compute"],
-            file_data["event_id_index"],
-            file_data["occ_offsets"],
-            file_data["occ_flat"],
+            file_data["occ_csr"],
             file_data["period_weights"],
             file_data["granular_date"],
             file_data["intervals"],

--- a/tests/pytools/common/test_input_files.py
+++ b/tests/pytools/common/test_input_files.py
@@ -7,12 +7,14 @@ from oasislmf.pytools.common.data import (
     oasis_int, oasis_float, coverages_dtype, correlations_dtype, periods_dtype,
     quantile_interval_dtype, returnperiods_dtype
 )
+from oasislmf.pytools.common.id_index import get_idx as id_index_get_idx, NOT_FOUND as OCC_IDX_NOT_FOUND
 from oasislmf.pytools.common.input_files import (
     read_amplifications,
     read_coverages,
     read_correlations,
     read_event_rates,
     read_occurrence,
+    read_occurrence_id_index_csr,
     read_periods,
     read_quantile,
     read_returnperiods,
@@ -204,6 +206,53 @@ def test_read_occurrence_granular():
     assert date_algorithm == True
     assert granular_date == True
     assert no_of_periods == 9
+
+
+def test_read_occurrence_id_index_csr():
+    """Tests read_occurrence_id_index_csr non-granular: metadata matches read_occurrence
+    and every event lookup returns the same period_nos as the dict implementation.
+    """
+    run_dir = Path(TESTS_ASSETS_DIR, "input")
+    filename = "occurrence.bin"
+
+    occ_map, date_algorithm_dict, granular_date_dict, no_of_periods_dict = read_occurrence(run_dir, filename)
+    (event_id_index, occ_offsets, occ_flat), date_algorithm, granular_date, no_of_periods = read_occurrence_id_index_csr(run_dir, filename)
+
+    assert date_algorithm == date_algorithm_dict
+    assert granular_date == granular_date_dict
+    assert no_of_periods == no_of_periods_dict
+
+    for event_id, arr in occ_map.items():
+        i = id_index_get_idx(event_id_index, np.int32(event_id))
+        assert i != OCC_IDX_NOT_FOUND, f"event_id {event_id} not found in id_index"
+        csr_slice = occ_flat[occ_offsets[i]:occ_offsets[i + 1]]
+        np.testing.assert_array_equal(
+            np.sort(arr["period_no"]),
+            np.sort(csr_slice["period_no"]),
+        )
+
+
+def test_read_occurrence_id_index_csr_granular():
+    """Tests read_occurrence_id_index_csr granular: metadata and period_nos agree with dict.
+    """
+    run_dir = Path(TESTS_ASSETS_DIR, "input")
+    filename = "occurrence_gran.bin"
+
+    occ_map, date_algorithm_dict, granular_date_dict, no_of_periods_dict = read_occurrence(run_dir, filename)
+    (event_id_index, occ_offsets, occ_flat), date_algorithm, granular_date, no_of_periods = read_occurrence_id_index_csr(run_dir, filename)
+
+    assert date_algorithm == date_algorithm_dict
+    assert granular_date == granular_date_dict
+    assert no_of_periods == no_of_periods_dict
+
+    for event_id, arr in occ_map.items():
+        i = id_index_get_idx(event_id_index, np.int32(event_id))
+        assert i != OCC_IDX_NOT_FOUND, f"event_id {event_id} not found in id_index"
+        csr_slice = occ_flat[occ_offsets[i]:occ_offsets[i + 1]]
+        np.testing.assert_array_equal(
+            np.sort(arr["period_no"]),
+            np.sort(csr_slice["period_no"]),
+        )
 
 
 def test_read_periods():

--- a/tests/pytools/common/test_input_files.py
+++ b/tests/pytools/common/test_input_files.py
@@ -14,7 +14,7 @@ from oasislmf.pytools.common.input_files import (
     read_correlations,
     read_event_rates,
     read_occurrence,
-    read_occurrence_id_index_csr,
+    read_occurrence_bin,
     read_periods,
     read_quantile,
     read_returnperiods,
@@ -185,74 +185,41 @@ def test_read_quantile_get_intervals():
 
 
 def test_read_occurrence():
-    """Tests read_occurrence non granular
-    """
+    """Tests read_occurrence non-granular: correct metadata and CSR structure."""
     run_dir = Path(TESTS_ASSETS_DIR, "input")
     filename = "occurrence.bin"
 
-    occ_map, date_algorithm, granular_date, no_of_periods = read_occurrence(run_dir, filename)
+    occ_csr, date_algorithm, granular_date, no_of_periods = read_occurrence(run_dir, filename)
     assert date_algorithm == True
     assert granular_date == False
     assert no_of_periods == 9
 
+    occ_arr, _, _, _ = read_occurrence_bin(run_dir, filename)
+    for event_id in np.unique(occ_arr["event_id"]):
+        i = id_index_get_idx(occ_csr.event_id_index, np.int32(event_id))
+        assert i != OCC_IDX_NOT_FOUND, f"event_id {event_id} not found in id_index"
+        csr_slice = occ_csr.occ_flat[occ_csr.occ_offsets[i]:occ_csr.occ_offsets[i + 1]]
+        expected = occ_arr[occ_arr["event_id"] == event_id]["period_no"]
+        np.testing.assert_array_equal(np.sort(csr_slice["period_no"]), np.sort(expected))
+
 
 def test_read_occurrence_granular():
-    """Tests read_occurrence granular
-    """
+    """Tests read_occurrence granular: correct metadata and CSR structure."""
     run_dir = Path(TESTS_ASSETS_DIR, "input")
     filename = "occurrence_gran.bin"
 
-    occ_map, date_algorithm, granular_date, no_of_periods = read_occurrence(run_dir, filename)
+    occ_csr, date_algorithm, granular_date, no_of_periods = read_occurrence(run_dir, filename)
     assert date_algorithm == True
     assert granular_date == True
     assert no_of_periods == 9
 
-
-def test_read_occurrence_id_index_csr():
-    """Tests read_occurrence_id_index_csr non-granular: metadata matches read_occurrence
-    and every event lookup returns the same period_nos as the dict implementation.
-    """
-    run_dir = Path(TESTS_ASSETS_DIR, "input")
-    filename = "occurrence.bin"
-
-    occ_map, date_algorithm_dict, granular_date_dict, no_of_periods_dict = read_occurrence(run_dir, filename)
-    (event_id_index, occ_offsets, occ_flat), date_algorithm, granular_date, no_of_periods = read_occurrence_id_index_csr(run_dir, filename)
-
-    assert date_algorithm == date_algorithm_dict
-    assert granular_date == granular_date_dict
-    assert no_of_periods == no_of_periods_dict
-
-    for event_id, arr in occ_map.items():
-        i = id_index_get_idx(event_id_index, np.int32(event_id))
+    occ_arr, _, _, _ = read_occurrence_bin(run_dir, filename)
+    for event_id in np.unique(occ_arr["event_id"]):
+        i = id_index_get_idx(occ_csr.event_id_index, np.int32(event_id))
         assert i != OCC_IDX_NOT_FOUND, f"event_id {event_id} not found in id_index"
-        csr_slice = occ_flat[occ_offsets[i]:occ_offsets[i + 1]]
-        np.testing.assert_array_equal(
-            np.sort(arr["period_no"]),
-            np.sort(csr_slice["period_no"]),
-        )
-
-
-def test_read_occurrence_id_index_csr_granular():
-    """Tests read_occurrence_id_index_csr granular: metadata and period_nos agree with dict.
-    """
-    run_dir = Path(TESTS_ASSETS_DIR, "input")
-    filename = "occurrence_gran.bin"
-
-    occ_map, date_algorithm_dict, granular_date_dict, no_of_periods_dict = read_occurrence(run_dir, filename)
-    (event_id_index, occ_offsets, occ_flat), date_algorithm, granular_date, no_of_periods = read_occurrence_id_index_csr(run_dir, filename)
-
-    assert date_algorithm == date_algorithm_dict
-    assert granular_date == granular_date_dict
-    assert no_of_periods == no_of_periods_dict
-
-    for event_id, arr in occ_map.items():
-        i = id_index_get_idx(event_id_index, np.int32(event_id))
-        assert i != OCC_IDX_NOT_FOUND, f"event_id {event_id} not found in id_index"
-        csr_slice = occ_flat[occ_offsets[i]:occ_offsets[i + 1]]
-        np.testing.assert_array_equal(
-            np.sort(arr["period_no"]),
-            np.sort(csr_slice["period_no"]),
-        )
+        csr_slice = occ_csr.occ_flat[occ_csr.occ_offsets[i]:occ_csr.occ_offsets[i + 1]]
+        expected = occ_arr[occ_arr["event_id"] == event_id]["period_no"]
+        np.testing.assert_array_equal(np.sort(csr_slice["period_no"]), np.sort(expected))
 
 
 def test_read_periods():


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### enhance/occurrence_structure

Replaces the `nb.typed.Dict`-based occurrence map used across `aal`, `lec`, and `plt` managers with a
Compressed Sparse Row (CSR) structure backed by `id_index`. Also introduces an `OccurrenceCSR`
namedtuple and `occ_get` helper to clean up the three-variable lookup pattern at all call sites,
and collapses the redundant `read_occurrence_id_index_csr` back into `read_occurrence` since no dict
callers remain.

**Changes:**
- `input_files.py`: adds `OccurrenceCSR` namedtuple (`event_id_index`, `occ_offsets`, `occ_flat`),
  `_build_occ_id_index_csr`, and `occ_get(occ_csr, event_id)` njit helper; `read_occurrence` now
  returns an `OccurrenceCSR` directly instead of a `nb.typed.Dict`
- `aal/manager.py`: `process_bin_file`, `process_idx_file`, `get_summaries_data`, `summary_index`
  updated to `occ_csr`; `process_idx_file` (added from main's `.idx` fast-path) uses `occ_get`
  instead of dict lookup
- `lec/manager.py`: `process_input_file`, `process_summary_entries`, `run_lec` updated to `occ_csr`;
  `process_summary_entries` (added from main's `.idx` path) uses `occ_get`
- `plt/manager.py`: four `id_index_get_idx` / `NOT_FOUND` lookup sites collapsed to
  `for record in occ_get(occ_csr, event_id)`
- `tests/pytools/common/test_input_files.py`: updated tests verify CSR output directly against
  raw `read_occurrence_bin` data rather than comparing against the removed dict implementation

**Occurrence map benchmark** (dict vs CSR, in-process):

| Scenario | Build | Random lookup | Sorted lookup |
|---|---|---|---|
| dense-small (50k events × 10 occ) | 3.7× | 10.4× | 41× |
| dense-large (200k events × 20 occ) | 2.7× | 8.8× | 51× |
| sparse-large (200k events × 20 occ, sparse=100) | 2.9× | 2.1× | 38× |

**Occurrence scaling** (sparse=100, 10 occ/event — speedup = dict / CSR):

| Events | Build | Random lookup | Sorted lookup |
|---|---|---|---|
| 10k | 3.6× | 1.0× | 22× |
| 100k | 3.2× | 1.6× | 29× |
| 500k | 2.8× | 2.1× | 48× |
| 1M | 2.6× | 2.3× | 55× |

Memory at 1M events: CSR steady-state 88MB vs dict peak RSS 310MB (3.5× less).

**Pipeline benchmark** (5 paired rounds × 6 runs, median, all outputs byte-identical across branches):

| Size | LEC | AAL | PLT |
|---|---|---|---|
| 1k events | 1.00× | 1.11× | 1.03× |
| 10k events | 1.03× | 1.21× | 1.04× |
| 100k events | 1.02× | 1.20× | 1.05× |
| 500k events | 0.98× | 1.17× | 1.04× |
| 1M events | 1.03× | 1.20× | 1.06× |

LEC speedup is modest (occurrence lookup is a small fraction of LEC's total work); AAL benefits most
at 1.17–1.23× as it does the most occurrence lookups per event.

closes https://github.com/OasisLMF/OasisLMF/issues/2020

<!--end_release_notes-->


