### PR TITLE
enhance/supported_oed_versions

### DIFF
--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -130,6 +130,8 @@ class GenerateFiles(ComputationStep):
          'help': 'The dataframe reading engine to use when loading exposure files'},
         {'name': 'oed_backend_dtype', 'type': str, 'default': 'pd_dtype',
          'help': "define what type dtype the oed column will be (pd_dtype or pa_dtype)"},
+        {'name': 'disable_oed_version_update', 'type': str2bool, 'const': True, 'nargs': '?', 'default': False,
+         'help': 'Flag to disable automatic conversion of exposure data to the latest compatible OED version.'},
     ]
 
     chained_commands = [
@@ -158,6 +160,8 @@ class GenerateFiles(ComputationStep):
             'base_df_engine': self.base_df_engine,
             'exposure_df_engine': self.exposure_df_engine,
             'backend_dtype': self.oed_backend_dtype,
+            'supported_oed_versions': self.settings.get('data_settings', {}).get('supported_oed_versions'),
+            'disable_oed_version_update': self.disable_oed_version_update,
         }
 
     def run(self):

--- a/oasislmf/computation/generate/keys.py
+++ b/oasislmf/computation/generate/keys.py
@@ -166,6 +166,8 @@ class GenerateKeysDeterministic(KeyComputationStep):
          'help': 'List of peril covered by the model'},
         {'name': 'oed_backend_dtype', 'type': str, 'default': 'pd_dtype',
          'help': "define what type dtype the oed column will be (pd_dtype or pa_dtype)"},
+        {'name': 'disable_oed_version_update', 'type': str2bool, 'const': True, 'nargs': '?', 'default': False,
+         'help': 'Flag to disable automatic conversion of exposure data to the latest compatible OED version.'},
     ]
 
     def _get_output_dir(self):

--- a/oasislmf/computation/generate/keys.py
+++ b/oasislmf/computation/generate/keys.py
@@ -4,7 +4,6 @@ __all__ = [
 ]
 
 import os
-from packaging import version
 
 from ..base import ComputationStep
 from ...lookup.factory import KeyServerFactory
@@ -22,6 +21,8 @@ class KeyComputationStep(ComputationStep):
             'check_oed': self.check_oed,
             'use_field': True,
             'backend_dtype': self.oed_backend_dtype,
+            'supported_oed_versions': self.settings.get('data_settings', {}).get('supported_oed_versions'),
+            'disable_oed_version_update': self.disable_oed_version_update,
         }
 
 
@@ -114,25 +115,6 @@ class GenerateKeys(KeyComputationStep):
         output_type = 'csv' if self.keys_format.lower() == 'oasis' else self.keys_format.lower()
 
         exposure_data = get_exposure_data(self, add_internal_col=True)
-
-        if not self.disable_oed_version_update:
-            supported_versions = self.settings.get('data_settings', {}).get('supported_oed_versions', None)
-            if supported_versions:
-                if isinstance(supported_versions, str):
-                    self.logger.info(f"Converting to OED version {supported_versions}")
-                    exposure_data.to_version(supported_versions)
-                elif isinstance(supported_versions, list) and supported_versions:
-                    # If 'supported_oed_versions' is a list and is not empty
-                    # Sort the versions in descending order
-                    supported_versions = sorted(supported_versions, key=version.parse, reverse=True)
-                    self.logger.info(f"Converting to OED version {supported_versions[0]}")
-                    exposure_data.to_version(supported_versions[0])
-                else:
-                    # If 'supported_oed_versions' is neither a string nor a non-empty list
-                    self.logger.warning("Invalid OED version information in model settings.")
-            else:
-                # If 'supported_oed_versions' is missing or empty
-                self.logger.debug("No OED version information in model settings.")
 
         keys_fp = self.keys_data_path or os.path.join(self.oasis_files_dir, f'keys.{output_type}')
         keys_errors_fp = self.keys_errors_path or os.path.join(self.oasis_files_dir, f'keys-errors.{output_type}')

--- a/oasislmf/computation/hooks/post_file_gen.py
+++ b/oasislmf/computation/hooks/post_file_gen.py
@@ -50,6 +50,8 @@ class PostFileGen(ComputationStep):
                     'help': 'Directory containing additional model data files which varies between analysis runs'},
                    {'name': 'oed_backend_dtype', 'type': str, 'default': 'pd_dtype',
                     'help': "define what type dtype the oed column will be (pd_dtype or pa_dtype)"},
+                   {'name': 'disable_oed_version_update', 'type': str2bool, 'const': True, 'nargs': '?', 'default': False,
+                    'help': 'Flag to disable automatic conversion of exposure data to the latest compatible OED version.'},
                    ]
 
     run_dir_key = 'pre-loss'
@@ -69,6 +71,8 @@ class PostFileGen(ComputationStep):
             'base_df_engine': self.base_df_engine,
             'exposure_df_engine': self.exposure_df_engine,
             'backend_dtype': self.oed_backend_dtype,
+            'supported_oed_versions': self.settings.get('data_settings', {}).get('supported_oed_versions'),
+            'disable_oed_version_update': self.disable_oed_version_update,
         }
 
     def run(self):

--- a/oasislmf/computation/hooks/pre_analysis.py
+++ b/oasislmf/computation/hooks/pre_analysis.py
@@ -61,6 +61,8 @@ class ExposurePreAnalysis(ComputationStep):
                     'help': 'Directory containing additional model data files which varies between analysis runs'},
                    {'name': 'oed_backend_dtype', 'type': str, 'default': 'pd_dtype',
                     'help': "define what type dtype the oed column will be (pd_dtype or pa_dtype)"},
+                   {'name': 'disable_oed_version_update', 'type': str2bool, 'const': True, 'nargs': '?', 'default': False,
+                    'help': 'Flag to disable automatic conversion of exposure data to the latest compatible OED version.'},
                    ]
 
     run_dir_key = 'pre-analysis'
@@ -80,6 +82,8 @@ class ExposurePreAnalysis(ComputationStep):
             'base_df_engine': self.base_df_engine,
             'exposure_df_engine': self.exposure_df_engine,
             'backend_dtype': self.oed_backend_dtype,
+            'supported_oed_versions': self.settings.get('data_settings', {}).get('supported_oed_versions'),
+            'disable_oed_version_update': self.disable_oed_version_update,
         }
 
     def run(self):

--- a/oasislmf/computation/hooks/pre_loss.py
+++ b/oasislmf/computation/hooks/pre_loss.py
@@ -50,6 +50,8 @@ class PreLoss(ComputationStep):
                     'help': 'Directory containing additional model data files which varies between analysis runs'},
                    {'name': 'oed_backend_dtype', 'type': str, 'default': 'pd_dtype',
                     'help': "define what type dtype the oed column will be (pd_dtype or pa_dtype)"},
+                   {'name': 'disable_oed_version_update', 'type': str2bool, 'const': True, 'nargs': '?', 'default': False,
+                    'help': 'Flag to disable automatic conversion of exposure data to the latest compatible OED version.'},
                    ]
 
     run_dir_key = 'pre-loss'
@@ -69,6 +71,8 @@ class PreLoss(ComputationStep):
             'base_df_engine': self.base_df_engine,
             'exposure_df_engine': self.exposure_df_engine,
             'backend_dtype': self.oed_backend_dtype,
+            'supported_oed_versions': self.settings.get('data_settings', {}).get('supported_oed_versions'),
+            'disable_oed_version_update': self.disable_oed_version_update,
         }
 
     def run(self):

--- a/oasislmf/computation/run/generate_files.py
+++ b/oasislmf/computation/run/generate_files.py
@@ -49,6 +49,8 @@ class GenerateOasisFiles(ComputationStep):
             'base_df_engine': self.base_df_engine,
             'exposure_df_engine': self.exposure_df_engine or self.base_df_engine,
             'backend_dtype': self.oed_backend_dtype,
+            'supported_oed_versions': self.settings.get('data_settings', {}).get('supported_oed_versions'),
+            'disable_oed_version_update': self.disable_oed_version_update,
         }
 
     def run(self):

--- a/oasislmf/computation/run/model.py
+++ b/oasislmf/computation/run/model.py
@@ -59,6 +59,8 @@ class RunModel(ComputationStep):
             'check_oed': self.check_oed,
             'use_field': True,
             'backend_dtype': self.oed_backend_dtype,
+            'supported_oed_versions': self.settings.get('data_settings', {}).get('supported_oed_versions'),
+            'disable_oed_version_update': self.disable_oed_version_update,
         }
 
     def run(self):

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -908,6 +908,8 @@ def get_exposure_data(computation_step, add_internal_col=False):
                     use_field=True,
                     additional_fields=DEFAULT_ADDITIONAL_FIELDS,
                     backend_dtype=getattr(computation_step, 'oed_backend_dtype', None),
+                    supported_oed_versions=getattr(computation_step, 'settings', {}).get('data_settings', {}).get('supported_oed_versions'),
+                    disable_oed_version_update=getattr(computation_step, 'disable_oed_version_update', False),
                 )
 
             if add_internal_col:

--- a/tests/computation/test_generate_keys.py
+++ b/tests/computation/test_generate_keys.py
@@ -193,8 +193,10 @@ class TestGenKeys(ComputationChecker):
             multiproc_num_partitions=call_args['lookup_num_chunks'],
         )
 
-        # Assertions to ensure `to_version` was called with the correct version
-        mock_get_exposure.return_value.to_version.assert_called_once_with("2.0")
+        # Assert that supported_oed_versions and disable_oed_version_update are forwarded correctly
+        config = mock_get_exposure.call_args[0][0].get_exposure_data_config()
+        assert config['supported_oed_versions'] == ["1.0", "2.0"]
+        assert config['disable_oed_version_update'] is False
 
     @patch('oasislmf.computation.generate.keys.KeyServerFactory.create')
     @patch('oasislmf.computation.generate.keys.get_exposure_data')
@@ -248,8 +250,10 @@ class TestGenKeys(ComputationChecker):
             multiproc_num_partitions=call_args['lookup_num_chunks'],
         )
 
-        # Assert that `to_version` was not called
-        mock_get_exposure.return_value.to_version.assert_not_called()
+        # Assert that disable_oed_version_update is forwarded correctly
+        config = mock_get_exposure.call_args[0][0].get_exposure_data_config()
+        assert config['supported_oed_versions'] == []
+        assert config['disable_oed_version_update'] is True
 
     @patch('oasislmf.computation.generate.keys.KeyServerFactory.create')
     @patch('oasislmf.computation.generate.keys.get_exposure_data')
@@ -302,5 +306,6 @@ class TestGenKeys(ComputationChecker):
             multiproc_num_partitions=call_args['lookup_num_chunks'],
         )
 
-        # Assert that `to_version` was not called
-        mock_get_exposure.return_value.to_version.assert_not_called()
+        # Assert that empty supported_oed_versions is forwarded correctly
+        config = mock_get_exposure.call_args[0][0].get_exposure_data_config()
+        assert config['supported_oed_versions'] == []


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### enhance/supported_oed_versions
Delegate `supported_oed_versions` conversion to `OedExposure`

Removes the `to_version` call from `GenerateKeys.run()` and forwards `supported_oed_versions` (from `model_settings.data_settings`) and `disable_oed_version_update` through `get_exposure_data_config()` on all computation step entry points. Conversion now happens inside `OedExposure.__init__()` (ODS_Tools #286), covering all construction paths uniformly.

Updated 3 tests to assert on config forwarding rather than `to_version` mock calls.

closes https://github.com/OasisLMF/ODS_Tools/issues/230
<!--end_release_notes-->
