### PR TITLE
ci: allow OasisModels CLI workflow to target an external oasislmf fork

### DIFF
--- a/.github/workflows/piwind-mdk.yml
+++ b/.github/workflows/piwind-mdk.yml
@@ -9,6 +9,14 @@ on:
 
   workflow_dispatch:
     inputs:
+      oasislmf_repo:
+        description: 'GitHub owner/repo to test oasislmf from (for external/fork PRs). Leave empty to use this repo at the dispatch ref.'
+        required: false
+        default: ''
+      oasislmf_ref:
+        description: 'Git ref (branch/tag/sha) in that repo to test. Leave empty to use the dispatch ref.'
+        required: false
+        default: ''
       oasis_models_branch:
         description: 'OasisModels branch to test against'
         required: false
@@ -37,6 +45,8 @@ jobs:
       - name: Checkout oasislmf
         uses: actions/checkout@v4
         with:
+          repository: ${{ inputs.oasislmf_repo || github.repository }}
+          ref: ${{ inputs.oasislmf_ref || github.event.pull_request.head.sha || github.ref }}
           path: oasislmf
 
       - name: Clone OasisModels


### PR DESCRIPTION
## Why

The "OasisModels CLI" workflow (`piwind-mdk.yml`) only runs against `oasislmf` from the current repo/ref. Its `workflow_dispatch` "Run workflow from branch" selector in the GitHub UI only lists branches that exist on `OasisLMF/OasisLMF` — there's no way to point it at a contributor's fork branch, which meant testing an external PR (e.g. #2048) required first mirroring the branch into this repo (see draft PR #2066) just to get the model-test suite to run against it.

## What

Adds two optional `workflow_dispatch` inputs:
- `oasislmf_repo` — `owner/repo` to check out oasislmf from (e.g. `richardsmythe/OasisLMF`)
- `oasislmf_ref` — branch/tag/sha in that repo

Both default to empty, falling back to `github.repository` / the triggering ref, so behavior on `pull_request` and `push` events is unchanged.

## Test plan

- [x] YAML validated (`yaml.safe_load`)
- [ ] Manually dispatch this workflow once merged, with `oasislmf_repo: richardsmythe/OasisLMF` and `oasislmf_ref: fix/correlation-lookup-interpolation`, to confirm it checks out the fork branch correctly