### PR TITLE
block piptools 7.6.0 with dependency issue

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yml
+++ b/.github/workflows/build-and-deploy-docs.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Compile package requirements.txt
         run: |
            python -m pip install --upgrade "pip<23.3"
-           pip install pip-tools
+           pip install "pip-tools!=7.6.0"
            pip-compile requirements.in
       - name: Install required packages
         run: |

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Compile package requirements.txt
         run: |
              python -m pip install --upgrade "pip<23.3"
-             pip install pip-tools
+             pip install "pip-tools!=7.6.0"
              pip-compile requirements.in
       - name: Install required packages
         run: |

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -91,7 +91,7 @@ jobs:
       - name: install pip tools
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade pip-tools
+          pip install --upgrade "pip-tools!=7.6.0"
 
       - name: install code quality tools
         run: pip install --upgrade autopep8 flake8

--- a/.github/workflows/piwind-test-v1.yml
+++ b/.github/workflows/piwind-test-v1.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Install test deps
         run: |
           python -m pip install --upgrade "pip<23.3"
-          pip install pip-tools
+          pip install "pip-tools!=7.6.0"
           wget $BASE_URL/$PIWIND_BRANCH/tests/requirements.in
           pip-compile requirements.in -o requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/piwind-test-v2.yml
+++ b/.github/workflows/piwind-test-v2.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Install test deps
         run: |
           python -m pip install --upgrade "pip<23.3"
-          pip install pip-tools
+          pip install "pip-tools!=7.6.0"
           wget $BASE_URL/$PIWIND_BRANCH/tests/requirements.in
           pip-compile requirements.in -o requirements.txt
           pip install -r requirements.txt

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install pip-tools
         run: |
-          python -m pip install --upgrade pip pip-tools
+          python -m pip install --upgrade pip "pip-tools!=7.6.0"
 
       - name: Pip Compile
         run: |


### PR DESCRIPTION
Tests fail to run due to piptools 7.6.0 using typing-extensions without having it as a dependancy