### PR TITLE
Switch CI to using UV, replacement for pip-tools

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yml
+++ b/.github/workflows/build-and-deploy-docs.yml
@@ -33,13 +33,13 @@ jobs:
       - name: Compile package requirements.txt
         run: |
            python -m pip install --upgrade "pip<23.3"
-           pip install pip-tools
-           pip-compile requirements.in
+           pip install uv
+           uv pip compile requirements.in
       - name: Install required packages
         run: |
-            pip install -r requirements.txt
-            pip install .
-            pip install furo
+            uv pip install -r requirements.txt
+            uv pip install .
+            uv pip install furo
       - name: Build
         run: ./docs/build.sh
       - name: Upload artifact

--- a/.github/workflows/build-and-deploy-docs.yml
+++ b/.github/workflows/build-and-deploy-docs.yml
@@ -37,9 +37,9 @@ jobs:
            uv pip compile requirements.in > requirements.txt
       - name: Install required packages
         run: |
-            uv pip install -r requirements.txt
-            uv pip install .
-            uv pip install furo
+            uv pip install --system -r requirements.txt
+            uv pip install --system .
+            uv pip install --system furo
       - name: Build
         run: ./docs/build.sh
       - name: Upload artifact

--- a/.github/workflows/build-and-deploy-docs.yml
+++ b/.github/workflows/build-and-deploy-docs.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
            python -m pip install --upgrade "pip<23.3"
            pip install uv
-           uv pip compile requirements.in
+           uv pip compile requirements.in > requirements.txt
       - name: Install required packages
         run: |
             uv pip install -r requirements.txt

--- a/.github/workflows/build-and-deploy-docs.yml
+++ b/.github/workflows/build-and-deploy-docs.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
            python -m pip install --upgrade "pip<23.3"
            pip install uv
-           uv pip compile requirements.in > requirements.txt
+           uv pip compile requirements.in --output-file requirements.txt
       - name: Install required packages
         run: |
             uv pip install --system -r requirements.txt

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
              python -m pip install --upgrade "pip<23.3"
              pip install uv
-             uv pip compile requirements.in > requirements.txt
+             uv pip compile requirements.in --output-file requirements.txt
       - name: Install required packages
         run: |
             uv pip install --system -r requirements.txt

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -27,9 +27,9 @@ jobs:
              uv pip compile requirements.in > requirements.txt
       - name: Install required packages
         run: |
-            uv pip install -r requirements.txt
-            uv pip install .
-            uv pip install furo
+            uv pip install --system -r requirements.txt
+            uv pip install --system .
+            uv pip install --system furo
       - name: Build
         run: ./docs/build.sh
       - name: Upload artifact

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -23,13 +23,13 @@ jobs:
       - name: Compile package requirements.txt
         run: |
              python -m pip install --upgrade "pip<23.3"
-             pip install pip-tools
-             pip-compile requirements.in
+             pip install uv
+             uv pip compile requirements.in
       - name: Install required packages
         run: |
-            pip install -r requirements.txt
-            pip install .
-            pip install furo
+            uv pip install -r requirements.txt
+            uv pip install .
+            uv pip install furo
       - name: Build
         run: ./docs/build.sh
       - name: Upload artifact

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
              python -m pip install --upgrade "pip<23.3"
              pip install uv
-             uv pip compile requirements.in
+             uv pip compile requirements.in > requirements.txt
       - name: Install required packages
         run: |
             uv pip install -r requirements.txt

--- a/.github/workflows/piwind-test-v1.yml
+++ b/.github/workflows/piwind-test-v1.yml
@@ -150,17 +150,17 @@ jobs:
       - name: Install test deps
         run: |
           python -m pip install --upgrade "pip<23.3"
-          pip install pip-tools
+          pip install uv
           wget $BASE_URL/$PIWIND_BRANCH/tests/requirements.in
-          pip-compile requirements.in -o requirements.txt
-          pip install -r requirements.txt
+          uv pip compile requirements.in -o requirements.txt
+          uv pip install -r requirements.txt
         env:
           BASE_URL: 'https://raw.githubusercontent.com/OasisLMF/OasisPiWind'
 
       - name: Reinstall oasislmf from branch
         run: |
-          pip uninstall oasislmf -y
-          pip install -v "git+https://git@github.com/OasisLMF/OasisLMF.git@${{ github.ref }}#egg=oasislmf[extra]"
+          uv pip uninstall oasislmf -y
+          uv pip install -v "git+https://git@github.com/OasisLMF/OasisLMF.git@${{ github.ref }}#egg=oasislmf[extra]"
 
       - name: Run Checks
         run: pytest -v --use-running-containers --docker-compose=./docker/plat2-v2.docker-compose.yml -k all_outputs

--- a/.github/workflows/piwind-test-v1.yml
+++ b/.github/workflows/piwind-test-v1.yml
@@ -153,14 +153,14 @@ jobs:
           pip install uv
           wget $BASE_URL/$PIWIND_BRANCH/tests/requirements.in
           uv pip compile requirements.in > requirements.txt
-          uv pip install -r requirements.txt
+          uv pip install --system -r requirements.txt
         env:
           BASE_URL: 'https://raw.githubusercontent.com/OasisLMF/OasisPiWind'
 
       - name: Reinstall oasislmf from branch
         run: |
-          uv pip uninstall oasislmf -y
-          uv pip install -v "git+https://git@github.com/OasisLMF/OasisLMF.git@${{ github.ref }}#egg=oasislmf[extra]"
+          pip uninstall oasislmf -y
+          pip install -v "git+https://git@github.com/OasisLMF/OasisLMF.git@${{ github.ref }}#egg=oasislmf[extra]"
 
       - name: Run Checks
         run: pytest -v --use-running-containers --docker-compose=./docker/plat2-v2.docker-compose.yml -k all_outputs

--- a/.github/workflows/piwind-test-v1.yml
+++ b/.github/workflows/piwind-test-v1.yml
@@ -152,7 +152,7 @@ jobs:
           python -m pip install --upgrade "pip<23.3"
           pip install uv
           wget $BASE_URL/$PIWIND_BRANCH/tests/requirements.in
-          uv pip compile requirements.in > requirements.txt
+          uv pip compile requirements.in --output-file requirements.txt
           uv pip install --system -r requirements.txt
         env:
           BASE_URL: 'https://raw.githubusercontent.com/OasisLMF/OasisPiWind'

--- a/.github/workflows/piwind-test-v1.yml
+++ b/.github/workflows/piwind-test-v1.yml
@@ -152,7 +152,7 @@ jobs:
           python -m pip install --upgrade "pip<23.3"
           pip install uv
           wget $BASE_URL/$PIWIND_BRANCH/tests/requirements.in
-          uv pip compile requirements.in -o requirements.txt
+          uv pip compile requirements.in > requirements.txt
           uv pip install -r requirements.txt
         env:
           BASE_URL: 'https://raw.githubusercontent.com/OasisLMF/OasisPiWind'

--- a/.github/workflows/piwind-test-v2.yml
+++ b/.github/workflows/piwind-test-v2.yml
@@ -150,17 +150,17 @@ jobs:
       - name: Install test deps
         run: |
           python -m pip install --upgrade "pip<23.3"
-          pip install pip-tools
+          pip install uv
           wget $BASE_URL/$PIWIND_BRANCH/tests/requirements.in
-          pip-compile requirements.in -o requirements.txt
-          pip install -r requirements.txt
+          uv pip compile requirements.in -o requirements.txt
+          uv pip install -r requirements.txt
         env:
           BASE_URL: 'https://raw.githubusercontent.com/OasisLMF/OasisPiWind'
 
       - name: Reinstall oasislmf from branch
         run: |
-          pip uninstall oasislmf -y
-          pip install -v "git+https://git@github.com/OasisLMF/OasisLMF.git@${{ github.ref }}#egg=oasislmf[extra]"
+          uv pip uninstall oasislmf -y
+          uv pip install -v "git+https://git@github.com/OasisLMF/OasisLMF.git@${{ github.ref }}#egg=oasislmf[extra]"
 
       - name: Run Checks
         run: pytest -v --use-running-containers --docker-compose=./docker/plat2-v2.docker-compose.yml -k all_outputs

--- a/.github/workflows/piwind-test-v2.yml
+++ b/.github/workflows/piwind-test-v2.yml
@@ -153,14 +153,14 @@ jobs:
           pip install uv
           wget $BASE_URL/$PIWIND_BRANCH/tests/requirements.in
           uv pip compile requirements.in > requirements.txt
-          uv pip install -r requirements.txt
+          uv pip install --system -r requirements.txt
         env:
           BASE_URL: 'https://raw.githubusercontent.com/OasisLMF/OasisPiWind'
 
       - name: Reinstall oasislmf from branch
         run: |
-          uv pip uninstall oasislmf -y
-          uv pip install -v "git+https://git@github.com/OasisLMF/OasisLMF.git@${{ github.ref }}#egg=oasislmf[extra]"
+          pip uninstall oasislmf -y
+          pip install -v "git+https://git@github.com/OasisLMF/OasisLMF.git@${{ github.ref }}#egg=oasislmf[extra]"
 
       - name: Run Checks
         run: pytest -v --use-running-containers --docker-compose=./docker/plat2-v2.docker-compose.yml -k all_outputs

--- a/.github/workflows/piwind-test-v2.yml
+++ b/.github/workflows/piwind-test-v2.yml
@@ -152,7 +152,7 @@ jobs:
           python -m pip install --upgrade "pip<23.3"
           pip install uv
           wget $BASE_URL/$PIWIND_BRANCH/tests/requirements.in
-          uv pip compile requirements.in > requirements.txt
+          uv pip compile requirements.in --output-file requirements.txt
           uv pip install --system -r requirements.txt
         env:
           BASE_URL: 'https://raw.githubusercontent.com/OasisLMF/OasisPiWind'

--- a/.github/workflows/piwind-test-v2.yml
+++ b/.github/workflows/piwind-test-v2.yml
@@ -152,7 +152,7 @@ jobs:
           python -m pip install --upgrade "pip<23.3"
           pip install uv
           wget $BASE_URL/$PIWIND_BRANCH/tests/requirements.in
-          uv pip compile requirements.in -o requirements.txt
+          uv pip compile requirements.in > requirements.txt
           uv pip install -r requirements.txt
         env:
           BASE_URL: 'https://raw.githubusercontent.com/OasisLMF/OasisPiWind'

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -50,9 +50,9 @@ jobs:
         run: |
           rm -f requirements.txt
           if [ -z "${{ matrix.cfg.pkg-version }}" ]; then
-            uv pip compile requirements.in -o requirements.txt
+            uv pip compile requirements.in > requirements.txt
           else
-            uv pip compile --upgrade-package "${{ matrix.cfg.pkg-version }}" requirements.in -o requirements.txt
+            uv pip compile --upgrade-package "${{ matrix.cfg.pkg-version }}" requirements.in > requirements.txt
           fi
           uv pip install -r requirements.txt
 

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -44,20 +44,20 @@ jobs:
 
       - name: Install pip-tools
         run: |
-          python -m pip install --upgrade pip pip-tools
+          python -m pip install --upgrade uv
 
       - name: Pip Compile
         run: |
           rm -f requirements.txt
           if [ -z "${{ matrix.cfg.pkg-version }}" ]; then
-            pip-compile requirements.in -o requirements.txt
+            uv pip compile requirements.in -o requirements.txt
           else
-            pip-compile --upgrade-package "${{ matrix.cfg.pkg-version }}" requirements.in -o requirements.txt
+            uv pip compile --upgrade-package "${{ matrix.cfg.pkg-version }}" requirements.in -o requirements.txt
           fi
-          pip install -r requirements.txt
+          uv pip install -r requirements.txt
 
       - name: Install oasislmf
-        run: pip install -e .
+        run: uv pip install -e .
 
       - name: download ods_tools
         if: needs.ods_tools.outputs.whl_filename != ''
@@ -69,8 +69,8 @@ jobs:
       - name: install ods_tools
         if: needs.ods_tools.outputs.whl_filename != ''
         run: |
-          pip uninstall ods_tools -y
-          pip install ${{ needs.ods_tools.outputs.whl_filename }}
+          uv pip uninstall ods_tools -y
+          uv pip install ${{ needs.ods_tools.outputs.whl_filename }}
 
       - name: Warmup Numba JIT cache
         if: matrix.cfg.upload-cov != true

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -54,10 +54,10 @@ jobs:
           else
             uv pip compile --upgrade-package "${{ matrix.cfg.pkg-version }}" requirements.in > requirements.txt
           fi
-          uv pip install -r requirements.txt
+          uv pip install --system -r requirements.txt
 
       - name: Install oasislmf
-        run: uv pip install -e .
+        run: pip install -e .
 
       - name: download ods_tools
         if: needs.ods_tools.outputs.whl_filename != ''
@@ -69,8 +69,8 @@ jobs:
       - name: install ods_tools
         if: needs.ods_tools.outputs.whl_filename != ''
         run: |
-          uv pip uninstall ods_tools -y
-          uv pip install ${{ needs.ods_tools.outputs.whl_filename }}
+          pip uninstall ods_tools -y
+          pip install ${{ needs.ods_tools.outputs.whl_filename }}
 
       - name: Warmup Numba JIT cache
         if: matrix.cfg.upload-cov != true

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           rm -f requirements.txt
           if [ -z "${{ matrix.cfg.pkg-version }}" ]; then
-            uv pip compile requirements.in > requirements.txt
+            uv pip compile requirements.in --output-file requirements.txt
           else
             uv pip compile --upgrade-package "${{ matrix.cfg.pkg-version }}" requirements.in > requirements.txt
           fi


### PR DESCRIPTION


<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Switch CI to using UV, replacement for pip-tools
Swtich to https://github.com/astral-sh/uv instead of `pip-tools` due to https://github.com/OasisLMF/OasisLMF/issues/2070 `uv` seems faster and shouldn't have dependency issues.
<!--end_release_notes-->

> Note: if its unstable, we can go with https://github.com/OasisLMF/OasisLMF/pull/2069 
