### PR TITLE
Fix typo: 'vulnerbaility_id' -> 'vulnerability_id' in gul_inputs.py

### DIFF
--- a/oasislmf/preparation/gul_inputs.py
+++ b/oasislmf/preparation/gul_inputs.py
@@ -329,7 +329,7 @@ def get_gul_input_items(
     # ``modeldata`` column in the keys file, and ignore the area peril
     # and vulnerability ID columns, unless it's the dynamic model generator which
     # uses them
-    if 'model_data' in keys_df and 'areaperil_id' not in keys_df and 'vulnerbaility_id' not in keys_df:
+    if 'model_data' in keys_df and 'areaperil_id' not in keys_df and 'vulnerability_id' not in keys_df:
         keys_df['areaperil_id'] = keys_df['vulnerability_id'] = -1
     gul_inputs_df = merge_dataframes(
         keys_df,


### PR DESCRIPTION
## Summary
- Fixes a typo on line 332 of `oasislmf/preparation/gul_inputs.py` where `'vulnerbaility_id'` should have been `'vulnerability_id'`, which caused the condition to always evaluate as if the column was never present.

Fixes #2086

## Test plan
- [x] Visual confirmation of the one-line fix