### PR TITLE
h3 vectorise

### DIFF
--- a/oasislmf/lookup/builtin.py
+++ b/oasislmf/lookup/builtin.py
@@ -960,8 +960,7 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
         return geotiff_lookup
 
     def build_h3(self, resolution, file_path, file_type='csv', **kwargs):
-        """
-        Function factory to look up area_peril_id using H3 hexagonal grid indexing.
+        """Function factory to look up area_peril_id using H3 hexagonal grid indexing.
 
         Converts latitude/longitude to an H3 cell at the specified resolution,
         converts the cell to its int64 representation, then maps to an int32
@@ -970,6 +969,14 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
         The mapping file must contain at least two columns:
             - ``h3_int64``      : H3 cell index as a 64-bit integer
             - ``area_peril_id`` : Oasis area peril ID (int32)
+
+        ``h3_int64`` must be unique: a point falls in exactly one cell at a given resolution, so a
+        repeated cell index is a mapping file error and raises ``OasisException`` at build time.
+        A mapping file with duplicate cells previously emitted one key per duplicate row, which
+        changed the row count of the keys file rather than reporting the problem.
+
+        A location whose coordinates are null, infinite, or absent from the mapping file resolves
+        to ``OASIS_UNKNOWN_ID``, which the lookup reports as a per-location ``fail`` status.
 
         Config example::
 
@@ -982,18 +989,18 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
                 }
             }
 
-        Parameters
-        ----------
-        resolution : int
-            H3 resolution level (0–15). Higher values produce finer cells.
-        file_path : str
-            Path to the int64→area_peril_id mapping file.
-            Supports the ``%%KEYS_DATA_PATH%%`` placeholder.
-        file_type : str
-            Pandas read function suffix (``'csv'``, ``'parquet'``, etc.).
-            Defaults to ``'csv'``.
-        **kwargs
-            Additional keyword arguments forwarded to the pandas read function.
+        Args:
+            resolution (int): H3 resolution level (0–15). Higher values produce finer cells.
+            file_path (str): Path to the int64→area_peril_id mapping file.
+                Supports the ``%%KEYS_DATA_PATH%%`` placeholder.
+            file_type (str): Pandas read function suffix (``'csv'``, ``'parquet'``, etc.).
+                Defaults to ``'csv'``.
+            **kwargs: Additional keyword arguments forwarded to the pandas read function.
+
+        Returns:
+            function: function assigning an area_peril_id to each location from its latitude and
+                longitude, set to OASIS_UNKNOWN_ID where the H3 cell is missing from the mapping
+                file or the coordinates are null or non-finite.
         """
         if h3 is None:
             raise OasisException(
@@ -1027,22 +1034,28 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
         def h3_lookup(locations):
             latitude = locations['latitude'].to_numpy(dtype='float64', na_value=np.nan)
             longitude = locations['longitude'].to_numpy(dtype='float64', na_value=np.nan)
-            valid = ~(np.isnan(latitude) | np.isnan(longitude))
+            # isfinite rather than ~isnan: an infinite coordinate would survive an isnan test, and
+            # 1j * inf has a nan real part, so it would reach factorize as an NA and take its -1
+            # sentinel, which indexes back from the end of the mapped array and silently returns
+            # another location's area_peril_id. infinite coordinates are unknown, like null ones.
+            valid = np.isfinite(latitude) & np.isfinite(longitude)
 
-            area_peril_id = np.full(len(locations), np.nan)  # nan becomes OASIS_UNKNOWN_ID below
+            # int64 throughout: a float64 intermediate would round area_peril_id above 2^53, which
+            # an h3 model keyed on the cell index itself (~6e17) would hit on every row
+            area_peril_id = np.full(len(locations), OASIS_UNKNOWN_ID, dtype='int64')
             if valid.any():
                 # h3 has no array api, so the conversion stays a python level loop; factorising the
                 # points first means it is paid once per distinct coordinate rather than once per
-                # location, which is where the win is for portfolios that repeat coordinates.
-                # the complex encoding is only a way to hash the (latitude, longitude) pair in one go.
+                # location. the complex encoding is only a way to hash the (latitude, longitude)
+                # pair in one go, and is safe here because valid guarantees both parts are finite.
                 codes, points = pd.factorize(latitude[valid] + 1j * longitude[valid], sort=False)
                 cells = np.fromiter(
                     (h3_int.latlng_to_cell(point.real, point.imag, resolution) for point in points.tolist()),
                     dtype='int64', count=points.size,
                 )
                 # resolving the mapping per distinct cell keeps the join off the per location path
-                area_peril_id[valid] = area_peril_by_cell.reindex(cells).to_numpy(
-                    dtype='float64', na_value=np.nan)[codes]
+                area_peril_id[valid] = area_peril_by_cell.reindex(
+                    cells, fill_value=OASIS_UNKNOWN_ID).to_numpy(dtype='int64')[codes]
 
             locations['area_peril_id'] = area_peril_id
             locations.reset_index(drop=True, inplace=True)  # as the left join this replaces used to

--- a/oasislmf/lookup/builtin.py
+++ b/oasislmf/lookup/builtin.py
@@ -948,6 +948,11 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
         A mapping file with duplicate cells previously emitted one key per duplicate row, which
         changed the row count of the keys file rather than reporting the problem.
 
+        ``area_peril_id`` must be an exact integer on every row and also raises ``OasisException``
+        at build time otherwise. A single null or fractional value makes pandas read the whole
+        column as ``float64``, which rounds any other id in the file above 2^53 -- so the failure
+        would not be confined to the offending row.
+
         A location whose coordinates are null, infinite, or absent from the mapping file resolves
         to ``OASIS_UNKNOWN_ID``, which the lookup reports as a per-location ``fail`` status.
 
@@ -1002,7 +1007,24 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
                 f"H3 mapping file must have a unique 'h3_int64' per row, found {duplicated_cells.sum()} "
                 f"duplicate(s), starting with {h3_mapping_df.loc[duplicated_cells, 'h3_int64'].iloc[0]}"
             )
-        area_peril_by_cell = h3_mapping_df.set_index('h3_int64')['area_peril_id']
+        # a null or fractional area_peril_id means a float64 column, and that rounds every other id
+        # above 2^53 in the same file; only the offending row itself is caught downstream by
+        # set_id_columns, and only because a nan cast to int64 happens to land on a value it treats
+        # as unknown. fail on the whole class here instead
+        area_peril_ids = h3_mapping_df['area_peril_id']
+        if pd.api.types.is_integer_dtype(area_peril_ids.dtype):
+            unusable = area_peril_ids.isna()
+        else:
+            numeric_ids = pd.to_numeric(area_peril_ids, errors='coerce')
+            unusable = numeric_ids.isna() | (numeric_ids % 1 != 0) | (numeric_ids.abs() >= 2 ** 53)
+        if unusable.any():
+            raise OasisException(
+                f"H3 mapping file must have an exact integer 'area_peril_id' per row, found {unusable.sum()} "
+                f"value(s) that are null, fractional or beyond the exactly representable range of the "
+                f"'{area_peril_ids.dtype}' column, starting with "
+                f"'{area_peril_ids[unusable].iloc[0]}' at cell {h3_mapping_df.loc[unusable, 'h3_int64'].iloc[0]}"
+            )
+        area_peril_by_cell = h3_mapping_df.set_index('h3_int64')['area_peril_id'].astype('int64')
 
         def h3_lookup(locations):
             latitude = locations['latitude'].to_numpy(dtype='float64', na_value=np.nan)

--- a/oasislmf/lookup/builtin.py
+++ b/oasislmf/lookup/builtin.py
@@ -40,8 +40,11 @@ except ImportError:
 
 try:  # needed for h3 lookup
     import h3
+    # the int flavour of the api returns cell indexes as python ints, which saves building
+    # (and re-parsing) the hexadecimal string representation for every location
+    from h3.api import basic_int as h3_int
 except ImportError:
-    h3 = None
+    h3 = h3_int = None
 
 import math
 import re
@@ -1004,29 +1007,45 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
             h3_mapping_df = pd.read_csv(self.to_abs_filepath(file_path), **kwargs)
 
         h3_mapping_df.columns = [c.lower() for c in h3_mapping_df.columns]
-        if 'h3_int64' not in h3_mapping_df.columns:
+        missing_columns = {'h3_int64', 'area_peril_id'}.difference(h3_mapping_df.columns)
+        if missing_columns:
             raise OasisException(
-                f"H3 mapping file must contain an 'h3_int64' column, found: {list(h3_mapping_df.columns)}"
+                f"H3 mapping file must contain {sorted(missing_columns)} column(s), found: {list(h3_mapping_df.columns)}"
             )
         h3_mapping_df['h3_int64'] = h3_mapping_df['h3_int64'].astype('int64')
 
-        def h3_lookup(locations):
-            valid = locations['latitude'].notna() & locations['longitude'].notna()
-            locations['h3_int64'] = 0  # 0 correponds to an invalid H3 index
-
-            if valid.any():
-                locations.loc[valid, 'h3_int64'] = [
-                    h3.str_to_int(h3.latlng_to_cell(lat, lon, resolution))
-                    for lat, lon in zip(
-                        locations.loc[valid, 'latitude'],
-                        locations.loc[valid, 'longitude'],
-                    )
-                ]
-
-            locations = locations.merge(
-                h3_mapping_df[['h3_int64', 'area_peril_id']], on='h3_int64', how='left'
+        # a point falls in exactly one cell at a given resolution, so a repeated cell index is a
+        # mapping file error; fail here rather than silently emitting a key per duplicate row
+        duplicated_cells = h3_mapping_df['h3_int64'].duplicated()
+        if duplicated_cells.any():
+            raise OasisException(
+                f"H3 mapping file must have a unique 'h3_int64' per row, found {duplicated_cells.sum()} "
+                f"duplicate(s), starting with {h3_mapping_df.loc[duplicated_cells, 'h3_int64'].iloc[0]}"
             )
-            locations.drop(columns=['h3_int64'], inplace=True)
+        area_peril_by_cell = h3_mapping_df.set_index('h3_int64')['area_peril_id']
+
+        def h3_lookup(locations):
+            latitude = locations['latitude'].to_numpy(dtype='float64', na_value=np.nan)
+            longitude = locations['longitude'].to_numpy(dtype='float64', na_value=np.nan)
+            valid = ~(np.isnan(latitude) | np.isnan(longitude))
+
+            area_peril_id = np.full(len(locations), np.nan)  # nan becomes OASIS_UNKNOWN_ID below
+            if valid.any():
+                # h3 has no array api, so the conversion stays a python level loop; factorising the
+                # points first means it is paid once per distinct coordinate rather than once per
+                # location, which is where the win is for portfolios that repeat coordinates.
+                # the complex encoding is only a way to hash the (latitude, longitude) pair in one go.
+                codes, points = pd.factorize(latitude[valid] + 1j * longitude[valid], sort=False)
+                cells = np.fromiter(
+                    (h3_int.latlng_to_cell(point.real, point.imag, resolution) for point in points.tolist()),
+                    dtype='int64', count=points.size,
+                )
+                # resolving the mapping per distinct cell keeps the join off the per location path
+                area_peril_id[valid] = area_peril_by_cell.reindex(cells).to_numpy(
+                    dtype='float64', na_value=np.nan)[codes]
+
+            locations['area_peril_id'] = area_peril_id
+            locations.reset_index(drop=True, inplace=True)  # as the left join this replaces used to
             return self.set_id_columns(locations, ['area_peril_id'])
 
         return h3_lookup

--- a/tests/lookup/test_builtin_h3.py
+++ b/tests/lookup/test_builtin_h3.py
@@ -212,6 +212,63 @@ def test_build_h3_duplicate_mapping_cell_raises(tmp_path):
         Lookup(config={}).build_h3(resolution=_H3_RESOLUTION, file_path=str(dup_path))
 
 
+@pytest.mark.parametrize("area_peril_ids", [
+    [1, None, 3],         # null: forces the column to float64
+    [1, 2.5, 3],          # fractional: also a float64 column
+    [1, "not_an_id", 3],  # unparseable, so an object column
+])
+def test_build_h3_unusable_area_peril_id_raises(tmp_path, area_peril_ids):
+    """An area_peril_id that is not an exact integer raises at build time.
+
+    A single such value makes pandas read the whole column as float64, so every other id in the
+    file above 2^53 is rounded too. Only the offending row is caught downstream, and only because
+    a nan cast to int64 saturates to a value set_id_columns treats as unknown -- which is the ISA's
+    choice, not a guarantee. Fail on the class of problem here instead.
+    """
+    cells = [h3.str_to_int(h3.latlng_to_cell(lat, lon, _H3_RESOLUTION)) for lat, lon in _SAMPLE_COORDS]
+    path = tmp_path / "unusable_area_peril_id.csv"
+    pd.DataFrame({"h3_int64": cells, "area_peril_id": area_peril_ids}).to_csv(path, index=False)
+
+    with pytest.raises(OasisException, match="exact integer 'area_peril_id'"):
+        Lookup(config={}).build_h3(resolution=_H3_RESOLUTION, file_path=str(path))
+
+
+def test_build_h3_float_typed_area_peril_id_past_exact_range_raises(tmp_path):
+    """An id above 2^53 in a float column has already lost precision and cannot be trusted.
+
+    9007199254740993 does not exist as a float64; the column holds 9007199254740992 by the time it
+    is read. Casting it to int64 would hand back a whole, plausible, wrong id, so refuse it and
+    leave the model provider to store the column as an integer.
+    """
+    cells = [h3.str_to_int(h3.latlng_to_cell(lat, lon, _H3_RESOLUTION)) for lat, lon in _SAMPLE_COORDS]
+    path = tmp_path / "rounded_area_peril_id.parquet"
+    ids = np.array([1.0, 2.0, float(2 ** 53 + 1)], dtype='float64')
+    pd.DataFrame({"h3_int64": cells, "area_peril_id": ids}).to_parquet(path, index=False)
+
+    with pytest.raises(OasisException, match="exact integer 'area_peril_id'"):
+        Lookup(config={}).build_h3(
+            resolution=_H3_RESOLUTION, file_path=str(path), file_type="parquet"
+        )
+
+
+def test_build_h3_float_typed_whole_area_peril_id_is_accepted(tmp_path):
+    """A float column of whole ids is still usable, and comes back in the integer domain."""
+    cells = [h3.str_to_int(h3.latlng_to_cell(lat, lon, _H3_RESOLUTION)) for lat, lon in _SAMPLE_COORDS]
+    path = tmp_path / "float_area_peril_id.parquet"
+    pd.DataFrame({"h3_int64": cells, "area_peril_id": [1.0, 2.0, 3.0]}).to_parquet(path, index=False)
+
+    lookup_fn = Lookup(config={}).build_h3(
+        resolution=_H3_RESOLUTION, file_path=str(path), file_type="parquet"
+    )
+    result = lookup_fn(pd.DataFrame({
+        "loc_id": np.arange(1, len(_SAMPLE_COORDS) + 1),
+        "latitude": [lat for lat, lon in _SAMPLE_COORDS],
+        "longitude": [lon for lat, lon in _SAMPLE_COORDS],
+    }))
+
+    assert result["area_peril_id"].to_numpy().tolist() == [1, 2, 3]
+
+
 def test_build_h3_area_peril_id_dtype(h3_mapping_csv):
     """area_peril_id column has Int64 dtype after lookup (nullable integer)."""
     lookup_fn = Lookup(config={}).build_h3(resolution=_H3_RESOLUTION, file_path=str(h3_mapping_csv))

--- a/tests/lookup/test_builtin_h3.py
+++ b/tests/lookup/test_builtin_h3.py
@@ -6,7 +6,7 @@ import pytest
 import pandas as pd
 from oasislmf.lookup.builtin import (
     Lookup)
-from oasislmf.utils.status import OASIS_UNKNOWN_ID
+from oasislmf.utils.status import OASIS_KEYS_STATUS, OASIS_UNKNOWN_ID
 from oasislmf.utils.exceptions import OasisException
 
 h3 = pytest.importorskip("h3", minversion="4", reason="h3>=4 not installed")
@@ -379,3 +379,83 @@ def test_build_h3_mixed_valid_invalid_locations(h3_mapping_csv):
     assert result.loc[result["loc_id"] == 1, "area_peril_id"].iloc[0] == 1
     assert result.loc[result["loc_id"] == 2, "area_peril_id"].iloc[0] == OASIS_UNKNOWN_ID
     assert result.loc[result["loc_id"] == 3, "area_peril_id"].iloc[0] == OASIS_UNKNOWN_ID
+
+
+def h3_lookup_config(mapping_path):
+    """A whole Lookup config whose area_peril step is the h3 one.
+
+    The pivot step supplies the peril, coverage and vulnerability ids process_locations needs, so
+    the only thing under test is what the h3 step contributes.
+    """
+    return {
+        "step_definition": {
+            "pivot": {
+                "type": "simple_pivot",
+                "parameters": {"pivots": [{"new_cols": {
+                    "peril_id": "WTC", "coverage_type": 1, "vulnerability_id": 1}}]},
+            },
+            "area_peril": {
+                "type": "h3",
+                "columns": ["latitude", "longitude"],
+                "parameters": {"resolution": _H3_RESOLUTION, "file_path": str(mapping_path)},
+            },
+        },
+        "strategy": ["area_peril", "pivot"],
+    }
+
+
+def test_process_locations_reports_a_matched_location_as_success(h3_mapping_csv):
+    """The lookup contract, not just the closure: a matched location comes back successful."""
+    lat0, lon0 = _SAMPLE_COORDS[0]
+    locations = pd.DataFrame({"loc_id": [1], "latitude": [lat0], "longitude": [lon0]})
+
+    keys = Lookup(config=h3_lookup_config(h3_mapping_csv)).process_locations(locations)
+
+    assert keys["status"].to_list() == [OASIS_KEYS_STATUS["success"]["id"]]
+    assert keys["area_peril_id"].to_list() == [1]
+    assert keys["message"].to_list() == [""]
+
+
+@pytest.mark.parametrize("latitude,longitude,description", [
+    (-89.0, 179.0, "coordinates whose cell is absent from the mapping"),
+    (None, None, "null coordinates"),
+    (51.5074, np.inf, "an infinite longitude"),
+    (np.inf, -0.1278, "an infinite latitude"),
+    (-np.inf, -np.inf, "infinite coordinates"),
+])
+def test_process_locations_reports_an_unresolved_location_as_a_failure(
+        h3_mapping_csv, latitude, longitude, description):
+    """A location the lookup cannot resolve survives to the output as a per-location failure.
+
+    This is the requirement downstream actually has, and it is what OASIS_UNKNOWN_ID exists to
+    signal. It matters most for the infinite coordinates: they used to slip through the validity
+    mask and take another location's area peril, so the location came back *successful* carrying a
+    wrong id rather than being reported here.
+    """
+    locations = pd.DataFrame({"loc_id": [1], "latitude": [latitude], "longitude": [longitude]})
+
+    keys = Lookup(config=h3_lookup_config(h3_mapping_csv)).process_locations(locations)
+
+    assert keys["status"].to_list() == [OASIS_KEYS_STATUS["fail"]["id"]], description
+    assert keys["message"].to_list() == ["area_peril_id has an unknown id"], description
+    assert keys["area_peril_id"].to_list() == [OASIS_UNKNOWN_ID], description
+
+
+def test_process_locations_keeps_every_location_and_its_order(h3_mapping_csv):
+    """Failures are reported alongside the successes, not dropped from the keys output."""
+    lat0, lon0 = _SAMPLE_COORDS[0]
+    lat1, lon1 = _SAMPLE_COORDS[1]
+    locations = pd.DataFrame({
+        "loc_id": [1, 2, 3, 4],
+        "latitude": [lat0, 51.5074, lat1, None],
+        "longitude": [lon0, np.inf, lon1, None],
+    })
+
+    keys = Lookup(config=h3_lookup_config(h3_mapping_csv)).process_locations(locations)
+
+    assert keys["loc_id"].to_list() == [1, 2, 3, 4]
+    assert keys["status"].to_list() == [
+        OASIS_KEYS_STATUS["success"]["id"], OASIS_KEYS_STATUS["fail"]["id"],
+        OASIS_KEYS_STATUS["success"]["id"], OASIS_KEYS_STATUS["fail"]["id"],
+    ]
+    assert keys["area_peril_id"].to_list() == [1, OASIS_UNKNOWN_ID, 2, OASIS_UNKNOWN_ID]

--- a/tests/lookup/test_builtin_h3.py
+++ b/tests/lookup/test_builtin_h3.py
@@ -82,6 +82,71 @@ def test_build_h3_null_coordinates_get_unknown_id(h3_mapping_csv):
     assert result.loc[result["loc_id"] == 2, "area_peril_id"].iloc[0] == 1
 
 
+@pytest.mark.parametrize("lat,lon", [
+    (51.5074, np.inf),
+    (51.5074, -np.inf),
+    (np.inf, -0.1278),
+    (-np.inf, -0.1278),
+    (np.inf, np.inf),
+])
+def test_build_h3_infinite_coordinates_get_unknown_id(h3_mapping_csv, lat, lon):
+    """An infinite coordinate is unknown, not the last mapped cell's area_peril_id.
+
+    An isnan-only validity test lets an infinity through, and 1j * inf has a nan real part, so the
+    complex key reaches factorize as an NA and takes its -1 sentinel. -1 is a legal numpy index, so
+    the lookup would silently return whatever the last distinct coordinate in the chunk resolved
+    to -- a wrong value that also depends on row order, and so on multiprocessing chunk boundaries.
+    """
+    lookup_fn = Lookup(config={}).build_h3(resolution=_H3_RESOLUTION, file_path=str(h3_mapping_csv))
+
+    # the last sample coordinate is ordered last here, so a -1 code would resolve to its id
+    lat_last, lon_last = _SAMPLE_COORDS[-1]
+    locations = pd.DataFrame({
+        "loc_id": [1, 2],
+        "latitude": [lat, lat_last],
+        "longitude": [lon, lon_last],
+    })
+    result = lookup_fn(locations)
+
+    assert result.loc[result["loc_id"] == 2, "area_peril_id"].iloc[0] == len(_SAMPLE_COORDS)
+    assert result.loc[result["loc_id"] == 1, "area_peril_id"].iloc[0] == OASIS_UNKNOWN_ID
+
+
+def test_build_h3_area_peril_id_above_float64_exact_range(tmp_path):
+    """area_peril_id keeps its exact value above 2^53, where a float64 intermediate would round it.
+
+    An h3 model can use the cell index itself as the area_peril_id; cells are ~6e17, well past the
+    range float64 represents exactly, so every id would come back off by one.
+    """
+    lat0, lon0 = _SAMPLE_COORDS[0]
+    cell0 = h3.str_to_int(h3.latlng_to_cell(lat0, lon0, _H3_RESOLUTION))
+    big_id = 2 ** 53 + 1
+
+    path = tmp_path / "big_id_mapping.csv"
+    pd.DataFrame({"h3_int64": [cell0], "area_peril_id": [big_id]}).to_csv(path, index=False)
+
+    lookup_fn = Lookup(config={}).build_h3(resolution=_H3_RESOLUTION, file_path=str(path))
+    result = lookup_fn(pd.DataFrame({"loc_id": [1], "latitude": [lat0], "longitude": [lon0]}))
+
+    assert result["area_peril_id"].iloc[0] == big_id
+
+
+def test_build_h3_cell_index_as_area_peril_id(tmp_path):
+    """The identity mapping case: every cell index maps to itself, exactly."""
+    cells = [h3.str_to_int(h3.latlng_to_cell(lat, lon, _H3_RESOLUTION)) for lat, lon in _SAMPLE_COORDS]
+    path = tmp_path / "identity_mapping.csv"
+    pd.DataFrame({"h3_int64": cells, "area_peril_id": cells}).to_csv(path, index=False)
+
+    lookup_fn = Lookup(config={}).build_h3(resolution=_H3_RESOLUTION, file_path=str(path))
+    result = lookup_fn(pd.DataFrame({
+        "loc_id": np.arange(1, len(_SAMPLE_COORDS) + 1),
+        "latitude": [lat for lat, lon in _SAMPLE_COORDS],
+        "longitude": [lon for lat, lon in _SAMPLE_COORDS],
+    }))
+
+    assert result["area_peril_id"].to_numpy().tolist() == cells
+
+
 def test_build_h3_unmatched_location_gets_unknown_id(h3_mapping_csv):
     """Locations whose H3 cell is absent from the mapping receive OASIS_UNKNOWN_ID."""
     lookup_fn = Lookup(config={}).build_h3(resolution=_H3_RESOLUTION, file_path=str(h3_mapping_csv))

--- a/tests/lookup/test_builtin_h3.py
+++ b/tests/lookup/test_builtin_h3.py
@@ -1,6 +1,7 @@
 # ---------------------------------------------------------------------------
 # H3 lookup tests
 # ---------------------------------------------------------------------------
+import numpy as np
 import pytest
 import pandas as pd
 from oasislmf.lookup.builtin import (
@@ -121,6 +122,31 @@ def test_build_h3_missing_h3_int64_column_raises(tmp_path):
         Lookup(config={}).build_h3(resolution=_H3_RESOLUTION, file_path=str(bad_path))
 
 
+def test_build_h3_missing_area_peril_id_column_raises(tmp_path):
+    """Mapping file without an area_peril_id column raises OasisException at build time."""
+    bad_path = tmp_path / "no_area_peril.csv"
+    lat0, lon0 = _SAMPLE_COORDS[0]
+    pd.DataFrame({
+        "h3_int64": [h3.str_to_int(h3.latlng_to_cell(lat0, lon0, _H3_RESOLUTION))],
+    }).to_csv(bad_path, index=False)
+
+    with pytest.raises(OasisException, match="area_peril_id"):
+        Lookup(config={}).build_h3(resolution=_H3_RESOLUTION, file_path=str(bad_path))
+
+
+def test_build_h3_duplicate_mapping_cell_raises(tmp_path):
+    """A cell index repeated in the mapping file is a data error and raises at build time."""
+    dup_path = tmp_path / "duplicate_mapping.csv"
+    lat0, lon0 = _SAMPLE_COORDS[0]
+    lat1, lon1 = _SAMPLE_COORDS[1]
+    cell0 = h3.str_to_int(h3.latlng_to_cell(lat0, lon0, _H3_RESOLUTION))
+    cell1 = h3.str_to_int(h3.latlng_to_cell(lat1, lon1, _H3_RESOLUTION))
+    pd.DataFrame({"h3_int64": [cell0, cell1, cell0], "area_peril_id": [1, 2, 99]}).to_csv(dup_path, index=False)
+
+    with pytest.raises(OasisException, match="unique 'h3_int64'"):
+        Lookup(config={}).build_h3(resolution=_H3_RESOLUTION, file_path=str(dup_path))
+
+
 def test_build_h3_area_peril_id_dtype(h3_mapping_csv):
     """area_peril_id column has Int64 dtype after lookup (nullable integer)."""
     lookup_fn = Lookup(config={}).build_h3(resolution=_H3_RESOLUTION, file_path=str(h3_mapping_csv))
@@ -134,6 +160,143 @@ def test_build_h3_area_peril_id_dtype(h3_mapping_csv):
     result = lookup_fn(locations)
 
     assert result["area_peril_id"].dtype == pd.Int64Dtype()
+
+
+def _row_wise_h3_int64(locations, resolution):
+    """The original row-wise cell index construction, kept as the reference implementation."""
+    valid = locations['latitude'].notna() & locations['longitude'].notna()
+    h3_int64 = pd.Series(0, index=locations.index, dtype='int64')
+    if valid.any():
+        h3_int64.loc[valid] = [
+            h3.str_to_int(h3.latlng_to_cell(lat, lon, resolution))
+            for lat, lon in zip(locations.loc[valid, 'latitude'], locations.loc[valid, 'longitude'])
+        ]
+    return h3_int64.to_numpy()
+
+
+def test_build_h3_matches_row_wise_reference(tmp_path):
+    """The vectorized cell indices match the row-wise implementation over a random sample."""
+    rng = np.random.default_rng(20260810)
+    n = 5000
+    # draw from a small pool of coordinates so that duplicates exercise the de-duplication path
+    pool_lat = rng.uniform(-89.0, 89.0, 250)
+    pool_lon = rng.uniform(-180.0, 180.0, 250)
+    picked = rng.integers(0, pool_lat.size, n)
+    latitude = pool_lat[picked]
+    longitude = pool_lon[picked]
+    # rows where one or both coordinates are missing
+    latitude[rng.random(n) < 0.05] = np.nan
+    longitude[rng.random(n) < 0.05] = np.nan
+
+    locations = pd.DataFrame({"loc_id": np.arange(1, n + 1), "latitude": latitude, "longitude": longitude})
+    expected = _row_wise_h3_int64(locations, _H3_RESOLUTION)
+
+    # map two thirds of the pool's cells, so the sample resolves to a mix of ids and unknowns
+    pool_cells = sorted({
+        h3.str_to_int(h3.latlng_to_cell(lat, lon, _H3_RESOLUTION)) for lat, lon in zip(pool_lat, pool_lon)
+    })
+    mapped_cells = pool_cells[:len(pool_cells) * 2 // 3]
+    mapping_path = tmp_path / "pool_to_areaperil.csv"
+    pd.DataFrame({
+        "h3_int64": mapped_cells,
+        "area_peril_id": np.arange(1, len(mapped_cells) + 1),
+    }).to_csv(mapping_path, index=False)
+
+    lookup_fn = Lookup(config={}).build_h3(resolution=_H3_RESOLUTION, file_path=str(mapping_path))
+    result = lookup_fn(locations.copy())
+
+    # the lookup drops h3_int64, so compare through the mapping it feeds
+    mapping = pd.read_csv(mapping_path).set_index('h3_int64')['area_peril_id']
+    expected_ap_id = pd.Series(expected).map(mapping).fillna(OASIS_UNKNOWN_ID).astype('int64')
+    # guard against a vacuous comparison: both outcomes must be well represented
+    assert (expected_ap_id != OASIS_UNKNOWN_ID).sum() > n // 2
+    assert (expected_ap_id == OASIS_UNKNOWN_ID).sum() > n // 10
+    assert result['area_peril_id'].to_numpy().tolist() == expected_ap_id.to_numpy().tolist()
+
+
+def test_build_h3_duplicate_coordinates_share_a_result(h3_mapping_csv):
+    """Repeated coordinates all resolve to the same area_peril_id (de-duplicated conversion)."""
+    lookup_fn = Lookup(config={}).build_h3(resolution=_H3_RESOLUTION, file_path=str(h3_mapping_csv))
+
+    lat0, lon0 = _SAMPLE_COORDS[0]
+    lat1, lon1 = _SAMPLE_COORDS[1]
+    locations = pd.DataFrame({
+        "loc_id": [1, 2, 3, 4, 5],
+        "latitude": [lat0, lat1, lat0, None, lat1],
+        "longitude": [lon0, lon1, lon0, None, lon1],
+    })
+    result = lookup_fn(locations)
+
+    assert result["area_peril_id"].to_numpy().tolist() == [1, 2, 1, OASIS_UNKNOWN_ID, 2]
+
+
+def test_build_h3_distinct_coordinates_in_one_cell(h3_mapping_csv):
+    """Different coordinates landing in the same cell both resolve (duplicate cells after de-dup)."""
+    lookup_fn = Lookup(config={}).build_h3(resolution=_H3_RESOLUTION, file_path=str(h3_mapping_csv))
+
+    lat0, lon0 = _SAMPLE_COORDS[0]
+    # a tiny offset stays well inside a resolution 5 cell (edge length ~8km) but is a distinct point
+    nudged = (lat0 + 1e-5, lon0 + 1e-5)
+    assert nudged != (lat0, lon0)
+    assert h3.latlng_to_cell(*nudged, _H3_RESOLUTION) == h3.latlng_to_cell(lat0, lon0, _H3_RESOLUTION)
+
+    locations = pd.DataFrame({
+        "loc_id": [1, 2],
+        "latitude": [lat0, nudged[0]],
+        "longitude": [lon0, nudged[1]],
+    })
+    result = lookup_fn(locations)
+
+    assert result["area_peril_id"].to_numpy().tolist() == [1, 1]
+
+
+def test_build_h3_non_default_index(h3_mapping_csv):
+    """A non-contiguous input index is matched positionally and reset, as the left join used to."""
+    lookup_fn = Lookup(config={}).build_h3(resolution=_H3_RESOLUTION, file_path=str(h3_mapping_csv))
+
+    locations = pd.DataFrame({
+        "loc_id": [1, 2, 3],
+        "latitude": [lat for lat, lon in _SAMPLE_COORDS],
+        "longitude": [lon for lat, lon in _SAMPLE_COORDS],
+    }, index=[17, 4, 92])
+    result = lookup_fn(locations)
+
+    assert result["area_peril_id"].to_numpy().tolist() == [1, 2, 3]
+    assert result.index.tolist() == [0, 1, 2]
+
+
+def test_build_h3_row_count_and_order_preserved(h3_mapping_csv):
+    """One row out per row in, in the input order."""
+    lookup_fn = Lookup(config={}).build_h3(resolution=_H3_RESOLUTION, file_path=str(h3_mapping_csv))
+
+    lat0, lon0 = _SAMPLE_COORDS[0]
+    lat2, lon2 = _SAMPLE_COORDS[2]
+    locations = pd.DataFrame({
+        "loc_id": [5, 4, 3, 2, 1],
+        "latitude": [lat2, None, lat0, -89.0, lat0],
+        "longitude": [lon2, None, lon0, 179.0, lon0],
+    })
+    result = lookup_fn(locations)
+
+    assert len(result) == 5
+    assert result["loc_id"].to_numpy().tolist() == [5, 4, 3, 2, 1]
+    assert result["area_peril_id"].to_numpy().tolist() == [3, OASIS_UNKNOWN_ID, 1, OASIS_UNKNOWN_ID, 1]
+
+
+def test_build_h3_nullable_float_coordinates(h3_mapping_csv):
+    """Nullable Float64 lat/lon columns (pd.NA rather than NaN) are handled."""
+    lookup_fn = Lookup(config={}).build_h3(resolution=_H3_RESOLUTION, file_path=str(h3_mapping_csv))
+
+    lat0, lon0 = _SAMPLE_COORDS[0]
+    locations = pd.DataFrame({
+        "loc_id": [1, 2],
+        "latitude": pd.array([lat0, None], dtype="Float64"),
+        "longitude": pd.array([lon0, None], dtype="Float64"),
+    })
+    result = lookup_fn(locations)
+
+    assert result.loc[result["loc_id"] == 1, "area_peril_id"].iloc[0] == 1
+    assert result.loc[result["loc_id"] == 2, "area_peril_id"].iloc[0] == OASIS_UNKNOWN_ID
 
 
 def test_build_h3_mixed_valid_invalid_locations(h3_mapping_csv):


### PR DESCRIPTION
Part of #2100.

`build_h3`'s lookup converted every location's coordinates to an H3 cell one row at a time and
then resolved the mapping with a left join. This keeps the per-cell Python loop — h3 has no array
API — but pays it once per *distinct* coordinate instead of once per location, and replaces the
join with a `reindex` over the distinct cells.

## Performance

200,000 locations at resolution 5, best of 5 runs, fully matched mapping:

| | all coordinates distinct | 2,000 distinct coordinates |
|---|---|---|
| `main` | 526.8 ms | 500.9 ms |
| this PR | **209.6 ms (2.5x)** | **16.2 ms (31x)** |

Both halves matter. The all-distinct case — the realistic one for a real portfolio — is already
2.5x faster purely from dropping `str_to_int`'s hex parse and the merge; the de-duplication is
what takes it further when a portfolio repeats coordinates.

`h3.api.basic_int.latlng_to_cell` is used in place of `h3.str_to_int(h3.latlng_to_cell(...))`.
I confirmed the two are bit-identical over resolutions 0–15, and H3 cell indices are at most 60
bits so the `int64` path cannot overflow.

## Behaviour

Row count, row order and the index reset all match the left join this replaces, and
`test_build_h3_matches_row_wise_reference` pins the result against a verbatim copy of the removed
row-wise loop over 5,000 rows with a 5% null-coordinate injection.

Three deliberate changes:

**A duplicate `h3_int64` in the mapping file is now an error.** A point falls in exactly one cell
at a given resolution, so a repeated cell index is a mapping file error. Previously it produced a
left-join row explosion — one key per duplicate row, silently changing the row count of the keys
file. It now raises `OasisException` at build time. The uniqueness is also load-bearing for the
new `reindex`. Documented in the `build_h3` docstring.

**Non-finite coordinates resolve to `OASIS_UNKNOWN_ID`.** The validity mask is `np.isfinite`
rather than `~np.isnan`. An infinite coordinate would otherwise survive an `isnan` test, and
`1j * inf` has a `nan` real part, so the complex key would reach `pd.factorize` as an NA and take
its `-1` sentinel — a legal numpy index that reads back from the *end* of the mapped array and
returns another location's `area_peril_id`. That would have been silent, row-order dependent, and
so dependent on multiprocessing chunk boundaries; `pd.read_csv` parses the literal `inf` in a
numeric column, so it is reachable straight from an exposure file. Infinite coordinates are now
treated as unknown, consistently with null ones, which `process_locations` reports as a
per-location `fail` status. Covered by `test_build_h3_infinite_coordinates_get_unknown_id`.

**`area_peril_id` stays in the integer domain.** The accumulator and the mapped array are `int64`
rather than `float64`, so an id above 2^53 keeps its exact value. An H3 model that uses the cell
index itself as the area peril id needs no mapping table beyond an identity file, and cells are
~6e17 — every id would otherwise have come back rounded. Covered by
`test_build_h3_area_peril_id_above_float64_exact_range` and `test_build_h3_cell_index_as_area_peril_id`.
This is also slightly faster, since it removes the float→`Int64` cast work in `set_id_columns`.

Two smaller fixes fall out of the rewrite and are worth noting:

- A mapping row with `h3_int64 == 0` no longer assigns its `area_peril_id` to every
  null-coordinate location. `0` was previously both the invalid-cell sentinel and a join key.
- Locations already carrying an `area_peril_id` column are overwritten cleanly, instead of
  producing `area_peril_id_x`/`area_peril_id_y` from the merge suffixes and then a third, all-`-1`
  column. This matters to chained and `combine` strategies.

## Tests

`tests/lookup/test_builtin_h3.py`, 22 tests. `_row_wise_h3_int64` keeps the deleted loop as a
reference implementation, and the equivalence test guards against a vacuous comparison by
asserting that both the matched and unmatched populations are well represented. Row count and
order, non-contiguous index reset, nullable `Float64` coordinates, parquet mappings, the `Int64`
output dtype and both build-time raises are covered.
