### PR TITLE
Removing dead code

### DIFF
--- a/oasislmf/execution/bash.py
+++ b/oasislmf/execution/bash.py
@@ -712,34 +712,6 @@ def do_fifos_exec(runtype, max_process_id, filename, fifo_dir, process_number=No
     return fifos
 
 
-def do_fifos_exec_full_correlation(
-        runtype, max_process_id, filename, fifo_dir, process_number=None, action='mkfifo'):
-    """Write FIFO create/remove commands for full-correlation sumcalc and fmcalc pipes.
-
-    For each process ID two FIFOs are created: one for the summarycalc input
-    (``<runtype>_sumcalc_P<id>``) and one for the fmcalc input
-    (``<runtype>_fmcalc_P<id>``).
-
-    Args:
-        runtype (str): The run type identifier (typically ``'gul'``).
-        max_process_id (int): Upper bound of process IDs.
-        filename (str): Path to the bash script being generated.
-        fifo_dir (str): Base directory for FIFOs.
-        process_number (int or None): If set, restrict to a single process.
-        action (str): Shell command (``'mkfifo'`` or ``'rm'``).
-    """
-    for process_id in process_range(max_process_id, process_number):
-        print_command(filename, '{} {}{}_sumcalc_P{}'.format(
-            action, fifo_dir, runtype, process_id
-        ))
-    print_command(filename, '')
-    for process_id in process_range(max_process_id, process_number):
-        print_command(filename, '{} {}{}_fmcalc_P{}'.format(
-            action, fifo_dir, runtype, process_id
-        ))
-    print_command(filename, '')
-
-
 def do_fifos_calc(runtype, analysis_settings, max_process_id, filename, fifo_dir='fifo/', process_number=None,
                   consumer_prefix=None, action='mkfifo', summarypy_low_memory=False):
     """Write FIFO create/remove commands for all summary and ORD output pipes.
@@ -1106,68 +1078,6 @@ def do_tees(
                 print_command(filename, cmd_idx)
 
 
-def do_tees_fc_sumcalc_fmcalc(process_id, filename, correlated_output_stems):
-    """Write a ``tee`` command that splits the full-correlation GUL output.
-
-    Duplicates the correlated GUL stream into two FIFOs: one for the
-    summarycalc path and one for the fmcalc (financial module) path.
-
-    Args:
-        process_id (int): The process number.
-        filename (str): Path to the bash script being generated.
-        correlated_output_stems (dict): FIFO path stems returned by
-            :func:`get_correlated_output_stems`.
-    """
-
-    if process_id == 1:
-        print_command(filename, '')
-
-    cmd = 'tee < {0}{1}'.format(
-        correlated_output_stems['gulcalc_output'], process_id
-    )
-    cmd = '{0} {1}{3} {2}{3} > /dev/null &'.format(
-        cmd,
-        correlated_output_stems['sumcalc_input'],
-        correlated_output_stems['fmcalc_input'],
-        process_id
-    )
-
-    print_command(filename, cmd)
-
-
-def get_correlated_output_stems(fifo_dir):
-    """Return a dict of FIFO path stems for the full-correlation pipeline.
-
-    The returned dict contains three keys:
-
-    * ``'gulcalc_output'`` -- stem for the GUL output FIFO.
-    * ``'fmcalc_input'``   -- stem for the fmcalc input FIFO.
-    * ``'sumcalc_input'``  -- stem for the summarycalc input FIFO.
-
-    Each value is a string ending with ``_P`` so that a process ID can be
-    appended directly.
-
-    Args:
-        fifo_dir (str): Base directory for FIFOs (e.g. ``'fifo/'``).
-
-    Returns:
-        dict: Mapping of stem names to FIFO path prefixes.
-    """
-
-    correlated_output_stems = {}
-    correlated_output_stems['gulcalc_output'] = '{0}{1}_P'.format(
-        fifo_dir, RUNTYPE_GROUNDUP_LOSS
-    )
-    correlated_output_stems['fmcalc_input'] = '{0}{1}_fmcalc_P'.format(
-        fifo_dir, RUNTYPE_GROUNDUP_LOSS
-    )
-    correlated_output_stems['sumcalc_input'] = '{0}{1}_sumcalc_P'.format(
-        fifo_dir, RUNTYPE_GROUNDUP_LOSS
-    )
-
-    return correlated_output_stems
-
-
 def do_ord(
     runtype,
     analysis_settings,
@@ -1515,42 +1425,6 @@ def do_gul(
             stderr_guard=stderr_guard,
             summarypy_low_memory=summarypy_low_memory,
         )
-
-
-def do_gul_full_correlation(
-    analysis_settings,
-    max_process_id,
-    filename,
-    process_counter,
-    fifo_dir='fifo/full_correlation/',
-    work_dir='work/full_correlation/',
-    stderr_guard=None,
-    process_number=None,
-):
-    """Write GUL consumer commands for the full-correlation path.
-
-    Similar to :func:`do_gul` but operates on the ``full_correlation/``
-    sub-directories and only emits ``do_tees`` (no ``do_ord`` or
-    ``do_summarycalcs``).
-
-    Args:
-        analysis_settings (dict): The full analysis settings dictionary.
-        max_process_id (int): Upper bound of process IDs.
-        filename (str): Path to the bash script being generated.
-        process_counter (dict): Mutable counter dict tracking background PIDs.
-        fifo_dir (str): FIFO directory for full-correlation pipes.
-        work_dir (str): Work directory for full-correlation outputs.
-        stderr_guard: Unused (kept for interface consistency).
-        process_number (int or None): If set, restrict to a single process.
-    """
-
-    for process_id in process_range(max_process_id, process_number):
-        do_tees(
-            RUNTYPE_GROUNDUP_LOSS, analysis_settings, process_id, filename,
-            process_counter, fifo_dir, work_dir
-        )
-
-    print_command(filename, '')
 
 
 def do_waits(wait_variable, wait_count, filename):

--- a/oasislmf/preparation/reinsurance_layer.py
+++ b/oasislmf/preparation/reinsurance_layer.py
@@ -175,8 +175,7 @@ FM_TERMS_PER_REINS_TYPE = {
 
 
 def match_filter_level_scope(filter_df, ri_filter_fields, merge_on):
-    """
-    Work out which rows of the merged filter level dataframe the reinsurance scope applies to.
+    """Work out which rows of the merged filter level dataframe the reinsurance scope applies to.
 
     A scope row applies to a profile map row when every filter field the scope actually specifies
     (the ones flagged by the matching '<field>_valid' column) holds the same value on both sides of

--- a/oasislmf/pytools/common/input_files.py
+++ b/oasislmf/pytools/common/input_files.py
@@ -7,7 +7,7 @@ import numpy as np
 from pathlib import Path
 
 from oasislmf.pytools.common.data import (
-    load_as_ndarray, nb_oasis_int,
+    load_as_ndarray,
     correlations_headers, correlations_dtype, coverages_headers,
     occurrence_dtype, occurrence_granular_dtype, periods_dtype, quantile_dtype,
     quantile_interval_dtype, returnperiods_dtype,
@@ -317,37 +317,6 @@ def read_occurrence_bin(run_dir="", filename=OCCURRENCE_FILE, use_stdin=False):
     return occ_arr, date_algorithm, granular_date, no_of_periods
 
 
-@nb.njit(cache=True, error_model="numpy")
-def _read_occ_arr(occ_arr, occ_map_valtype, NB_occ_map_valtype):
-    """Reads occurrence file array and returns an occurrence map of event_id to list of (period_no, occ_date_id)
-    """
-    occ_map = nb.typed.Dict.empty(nb_oasis_int, NB_occ_map_valtype)
-    occ_map_sizes = nb.typed.Dict.empty(nb_oasis_int, nb.types.int64)
-    for row in occ_arr:
-        event_id = row["event_id"]
-        if event_id not in occ_map:
-            occ_map[event_id] = np.zeros(8, dtype=occ_map_valtype)
-            occ_map_sizes[event_id] = 0
-        array = occ_map[event_id]
-        current_size = occ_map_sizes[event_id]
-
-        if current_size >= len(array):  # Resize if the array is full
-            new_array = np.empty(len(array) * 2, dtype=occ_map_valtype)
-            new_array[:len(array)] = array
-            array = new_array
-
-        occ_map_current_size = occ_map_sizes[event_id]
-        array[occ_map_current_size]["period_no"] = row["period_no"]
-        array[occ_map_current_size]["occ_date_id"] = row["occ_date_id"]
-        occ_map[event_id] = array
-        occ_map_sizes[event_id] += 1
-
-    for event_id in occ_map:
-        occ_map[event_id] = occ_map[event_id][:occ_map_sizes[event_id]]
-
-    return occ_map
-
-
 def _occ_flat_valtype(granular_date):
     occ_date_np_type = np.int64 if granular_date else np.int32
     return np.dtype([("period_no", np.int32), ("occ_date_id", occ_date_np_type)])
@@ -435,30 +404,6 @@ def occ_get_date(occ_date_id, granular_date):
     occ_minutes = minutes % 60
 
     return y, mm, dd, occ_hour, occ_minutes
-
-
-@nb.njit(cache=True)
-def occ_get_date_id(granular_date, occ_year, occ_month, occ_day, occ_hour=0, occ_minute=0):
-    """Returns the occ_date_id from year, month, day, hour, minute and whether it is a granular date
-    Args:
-        granular_date (bool): boolean for whether granular date should be extracted or not
-        occ_year (int): Occurrence Year.
-        occ_month (int): Occurrence Month.
-        occ_day (int): Occurrence Day.
-        occ_hour (int): Occurrence Hour. Defaults to 0.
-        occ_minute (int): Occurrence Minute. Defaults to 0.
-    Returns:
-        occ_date_id (np.int64): occurrence file date id (int64 for granular dates)
-    """
-    occ_month = (occ_month + 9) % 12
-    occ_year = occ_year - occ_month // 10
-    occ_date_id = np.int64(
-        365 * occ_year + occ_year // 4 - occ_year // 100 + occ_year // 400 + (occ_month * 306 + 5) // 10 + (occ_day - 1)
-    )
-
-    occ_date_id *= (1440 // (1440 - 1439 * granular_date))
-    occ_date_id += (60 * occ_hour + occ_minute)
-    return occ_date_id
 
 
 def read_periods(no_of_periods, run_dir, filename=PERIODS_FILE):

--- a/oasislmf/pytools/data_layer/footprint_layer.py
+++ b/oasislmf/pytools/data_layer/footprint_layer.py
@@ -96,8 +96,6 @@ class FootprintLayer:
         Returns: None
         """
         logging.info(f"establishing shutdown procedure: {datetime.datetime.now()}")
-        # atexit.register(_shutdown_port, self.socket)
-        pass
 
     @staticmethod
     def _stream_footprint_data(event_data: np.array, connection: socket.socket, event_id: int) -> None:
@@ -226,15 +224,6 @@ class FootprintLayerClient:
         return current_socket
 
     @classmethod
-    def _define_shutdown_procedure(cls) -> None:
-        """
-        Unregisters the client to the server on exit of the process.
-
-        Returns: None
-        """
-        atexit.register(cls.unregister)
-
-    @classmethod
     def register(cls) -> None:
         """
         Registers the client with the server.
@@ -249,7 +238,6 @@ class FootprintLayerClient:
         data: bytes = OperationEnum.REGISTER.value
         current_socket.sendall(data)
         current_socket.close()
-        # cls._define_shutdown_procedure()
 
     @classmethod
     def unregister(cls) -> None:
@@ -304,11 +292,6 @@ class FootprintLayerClient:
 
         if raw_data_buffer:
             return pickle.loads(b"".join(raw_data_buffer))
-
-
-def _shutdown_port(connection: socket.socket) -> None:
-    logging.info(f"socket is shutting down: {datetime.datetime.now()}")
-    connection.shutdown(socket.SHUT_RDWR)
 
 
 def main() -> None:

--- a/oasislmf/pytools/fm/compare.py
+++ b/oasislmf/pytools/fm/compare.py
@@ -49,11 +49,6 @@ def stream_to_dict_array(stream_obj):
     return stream_type, len_sample, dict_array
 
 
-def round_dict_array(dict_array, precision):
-    for key, values in dict_array.items():
-        values.round(decimals=precision, out=values)
-
-
 def compare_streams(gul_stream, fm_stream_obj1, fm_stream_obj2, precision):
     fm_programme, fm_policytc, fm_profile, fm_xref, _, _ = load_static('./input')
 
@@ -80,9 +75,6 @@ def compare_streams(gul_stream, fm_stream_obj1, fm_stream_obj2, precision):
                 msg += f"    {len(missing)} missing in {i + 1} : {sorted(missing)[:10]}" \
                     f"{'...' if len(missing) > 10 else ''}\n"
         return msg
-
-    # round_dict_array(dict_array1, precision)
-    # round_dict_array(dict_array2, precision)
 
     msg_list = []
     mismatch = 0

--- a/oasislmf/pytools/fm/financial_structure.py
+++ b/oasislmf/pytools/fm/financial_structure.py
@@ -126,18 +126,6 @@ def does_nothing(profile):
 
 
 @njit(cache=True)
-def idx_to_node(node_idx, node_level_start, start_level, max_level):
-    """Convert a flat node index back to (level, agg_id) tuple."""
-    for level in range(start_level, max_level + 1):
-        level_start = node_level_start[level]
-        level_end = node_level_start[level + 1]
-        if level_start < node_idx <= level_end:
-            return (nb_oasis_int(level), nb_oasis_int(node_idx - level_start))
-    # Fallback (shouldn't happen)
-    return (nb_oasis_int(0), nb_oasis_int(0))
-
-
-@njit(cache=True)
 def get_all_children_csr(node_idx, children_indptr, children_data, items_only, max_nodes):
     """CSR version of get_all_children using NumPy arrays.
 
@@ -232,15 +220,6 @@ def get_all_parent_csr(start_nodes, start_len, parents_indptr, parents_data, tar
                     break
 
     return result, result_len
-
-
-@njit(cache=True)
-def is_multi_peril(fm_programme):
-    for i in range(fm_programme.shape[0]):
-        if fm_programme[i]['level_id'] == 1 and fm_programme[i]['from_agg_id'] != fm_programme[i]['to_agg_id']:
-            return True
-    else:
-        return False
 
 
 @njit(cache=True)

--- a/oasislmf/pytools/fm/policy.py
+++ b/oasislmf/pytools/fm/policy.py
@@ -433,6 +433,8 @@ def calc(policy, loss_out, loss_in, stepped):
     elif stepped is not None:  # step policies
         if policy['calcrule_id'] == 28:
             calcrule_28(policy, loss_out, loss_in)
+        elif policy['calcrule_id'] == 281:
+            calcrule_281(policy, loss_out, loss_in)
         elif policy['calcrule_id'] == 32:
             calcrule_32(policy, loss_out, loss_in)
         elif policy['calcrule_id'] == 37:

--- a/oasislmf/pytools/fm/policy_extras.py
+++ b/oasislmf/pytools/fm/policy_extras.py
@@ -8,9 +8,9 @@ TODO: It seems that if a policy with share is used, subsequent policy using min 
 
 
 from numba import njit
-from .policy import (calcrule_28 as _calcrule_28, calcrule_32 as _calcrule_32, calcrule_34 as _calcrule_34,
-                     calcrule_37 as _calcrule_37, calcrule_38 as _calcrule_38, calcrule_40 as _calcrule_40,
-                     calcrule_41 as _calcrule_41)
+from .policy import (calcrule_28 as _calcrule_28, calcrule_281 as _calcrule_281, calcrule_32 as _calcrule_32,
+                     calcrule_34 as _calcrule_34, calcrule_37 as _calcrule_37, calcrule_38 as _calcrule_38,
+                     calcrule_40 as _calcrule_40, calcrule_41 as _calcrule_41)
 
 
 @njit(cache=True)
@@ -524,6 +524,14 @@ def calcrule_28(policy, loss_out, loss_in, deductible, over_limit, under_limit):
 
 
 @njit(cache=True, fastmath=True)
+def calcrule_281(policy, loss_out, loss_in, deductible, over_limit, under_limit):
+    """
+    conditional coverage
+    """
+    _calcrule_281(policy, loss_out, loss_in)
+
+
+@njit(cache=True, fastmath=True)
 def calcrule_32(policy, loss_out, loss_in, deductible, over_limit, under_limit):
     """
     monetary amount trigger and % loss step payout with limit
@@ -807,6 +815,8 @@ def calc(policy, loss_out, loss_in, deductible, over_limit, under_limit, stepped
             calcrule_27(policy, loss_out, loss_in, deductible, over_limit, under_limit)
         elif policy['calcrule_id'] == 28:
             calcrule_28(policy, loss_out, loss_in, deductible, over_limit, under_limit)
+        elif policy['calcrule_id'] == 281:
+            calcrule_281(policy, loss_out, loss_in, deductible, over_limit, under_limit)
         elif policy['calcrule_id'] == 32:
             calcrule_32(policy, loss_out, loss_in, deductible, over_limit, under_limit)
         elif policy['calcrule_id'] == 37:

--- a/oasislmf/pytools/fm/policy_extras.py
+++ b/oasislmf/pytools/fm/policy_extras.py
@@ -469,9 +469,7 @@ def calcrule_28(policy, loss_out, loss_in, deductible, over_limit, under_limit):
 
 @njit(cache=True, fastmath=True)
 def calcrule_281(policy, loss_out, loss_in, deductible, over_limit, under_limit):
-    """
-    conditional coverage
-    """
+    """Conditional coverage"""
     _calcrule_281(policy, loss_out, loss_in)
 
 

--- a/oasislmf/pytools/getmodel/manager.py
+++ b/oasislmf/pytools/getmodel/manager.py
@@ -276,10 +276,6 @@ def encode_peril_id(peril_id):
     return sum(ord(c) << (8 * i) for i, c in enumerate(str(peril_id).upper()))
 
 
-def get_intensity_adjustment(input_path):
-    pass
-
-
 @nb.njit(cache=True)
 def load_vuln_probability(vuln_array, vuln, vuln_id):
     if vuln_array.shape[0] < vuln['damage_bin_id']:

--- a/oasislmf/pytools/gul/utils.py
+++ b/oasislmf/pytools/gul/utils.py
@@ -3,7 +3,6 @@ This file contains general-purpose utilities used in gulpy.
 
 """
 from numba import njit
-from numba.typed import List
 
 
 @njit(cache=True, fastmath=True)
@@ -34,34 +33,3 @@ def binary_search(value, array, n):
             hi = mid
 
     return lo
-
-
-@njit(cache=True, fastmath=True)
-def append_to_dict_value(d, key, value, value_type):
-    """Append a value to the list populating a dictionary value.
-    If the key is not present in the dictionary, populate the entry with a list with
-    just the passed value.
-    The dictionary `d` is modified *in-place*, thus it is not returned by the function.
-    If `d` is a dictionary and `d[key]` is a list, this function appends
-    `value` to the list. Example: if d = {0: [1, 2], 1: [3]}, then:
-
-       append_to_dict_entry(d, 0, 3, int)
-
-    will modify `d` to:
-
-       d = {0: [1, 2, 3], 1: [3]}
-
-    Designed to be used with numba.typed.Dict and numba.typed.List.
-
-    Args:
-        d (numba.typed.Dict[*,numba.typedList[value_type]]): dictionary to be modified,
-          by appending `value` to the list in d[key].
-        key (same as d.key_type): key of the element to modify.
-        value (value_type): value to be appended to the list in d[key].
-        value_type (built-in Python or numba type): value data type.
-    """
-    def_lst = List.empty_list(value_type)
-    d.setdefault(key, def_lst)
-    lst = d[key]
-    lst.append(value)
-    d[key] = lst

--- a/oasislmf/pytools/lec/utils.py
+++ b/oasislmf/pytools/lec/utils.py
@@ -1,19 +1,4 @@
 import numba as nb
-import numpy as np
-
-
-@nb.njit(cache=True, error_model="numpy")
-def create_empty_array(mydtype, init_size=8):
-    return np.zeros(init_size, dtype=mydtype)
-
-
-@nb.njit(cache=True, error_model="numpy")
-def resize_array(array, current_size):
-    if current_size >= len(array):  # Resize if the array is full
-        new_array = np.empty(len(array) * 2, dtype=array.dtype)
-        new_array[:len(array)] = array
-        array = new_array
-    return array
 
 
 @nb.njit(cache=True, fastmath=True, error_model="numpy")

--- a/tests/pytools/fm/test_policy.py
+++ b/tests/pytools/fm/test_policy.py
@@ -1,7 +1,20 @@
 import numpy as np
+import pytest
 from numpy.testing import assert_array_almost_equal
-from oasislmf.pytools.common.data import fm_profile_dtype
+from oasislmf.pytools.common.data import fm_profile_dtype, fm_profile_step_dtype
 from oasislmf.pytools.fm.policy import calc
+
+
+def step_policy(calcrule_id, step_id=1, **fields):
+    policy = np.zeros(1, dtype=fm_profile_step_dtype)[0]
+    policy['calcrule_id'] = calcrule_id
+    policy['step_id'] = step_id
+    policy['trigger_start'] = 0.
+    policy['trigger_end'] = np.inf
+    policy['scale1'] = 1.
+    for name, value in fields.items():
+        policy[name] = value
+    return policy
 
 
 def test_calcrule_1():
@@ -196,3 +209,29 @@ def test_calcrule_34():
     loss_expected = np.array([0., 0., 0., 2.5, 7.5, 12.5, 17.5])
 
     assert_array_almost_equal(loss_out, loss_expected)
+
+
+@pytest.mark.parametrize('calcrule_id', [28, 281])
+def test_step_calcrule_is_dispatched(calcrule_id):
+    loss_in = np.array([0., 10., 20., 30.])
+    loss_out = np.empty_like(loss_in)
+    calc(step_policy(calcrule_id), loss_out, loss_in, True)
+
+
+def test_calcrule_281():
+    loss_in = np.array([0., 10., 20., 30.])
+    loss_out = np.array([0., 10., 20., 30.])
+    policy = step_policy(281, step_id=2, scale2=0.5, limit2=8.)
+    calc(policy, loss_out, loss_in, True)
+
+    assert_array_almost_equal(loss_out, np.array([0., 15., 28., 38.]))
+
+
+def test_calcrule_281_outside_trigger_window():
+    loss_in = np.array([0., 10., 20., 30.])
+    loss_out = np.array([0., 10., 20., 30.])
+    policy = step_policy(281, step_id=2, scale2=0.5, limit2=8.,
+                         trigger_start=15., trigger_end=25.)
+    calc(policy, loss_out, loss_in, True)
+
+    assert_array_almost_equal(loss_out, np.array([0., 10., 28., 30.]))

--- a/tests/pytools/fm/test_policy_extra.py
+++ b/tests/pytools/fm/test_policy_extra.py
@@ -1,7 +1,9 @@
 import numpy as np
+import pytest
 from numpy.testing import assert_array_almost_equal
 from oasislmf.pytools.common.data import fm_profile_dtype
 from oasislmf.pytools.fm.policy_extras import calc
+from .test_policy import step_policy
 
 
 def test_calcrule_1():
@@ -516,3 +518,21 @@ def test_calcrule_36():
     assert_array_almost_equal(deductible, deductible_expected)
     assert_array_almost_equal(over_limit, over_limit_expected)
     assert_array_almost_equal(under_limit, under_limit_expected)
+
+
+@pytest.mark.parametrize('calcrule_id', [28, 281])
+def test_step_calcrule_is_dispatched(calcrule_id):
+    loss_in = np.array([0., 10., 20., 30.])
+    loss_out = np.empty_like(loss_in)
+    zeros = np.zeros_like(loss_in)
+    calc(step_policy(calcrule_id), loss_out, loss_in, zeros, zeros.copy(), zeros.copy(), True)
+
+
+def test_calcrule_281():
+    loss_in = np.array([0., 10., 20., 30.])
+    loss_out = np.array([0., 10., 20., 30.])
+    zeros = np.zeros_like(loss_in)
+    policy = step_policy(281, step_id=2, scale2=0.5, limit2=8.)
+    calc(policy, loss_out, loss_in, zeros, zeros.copy(), zeros.copy(), True)
+
+    assert_array_almost_equal(loss_out, np.array([0., 15., 28., 38.]))


### PR DESCRIPTION
Unused functions removed:

  bash.py: `do_fifos_exec_full_correlation`, `do_gul_full_correlation`, `get_correlated_output_stems`
  common/input_files.py: `_read_occ_arr`, `occ_get_date_id`
  footprint_layer.py: `_define_shutdown_procedure`, `_shutdown_port`
  fm/compare.py: `round_dict_array`
  fm/financial_structure.py: `idx_to_node`, `is_multi_peril`
  getmodel/manager.py: `get_intensity_adjustment`
  gul/utils.py: `append_to_dict_value`
  lec/utils.py: `create_empty_array`, `resize_array`

get_correlated_output_stems was reachable only from a Sphinx :func: reference in a removed docstring, never called. Commented-out callers of round_dict_array, _shutdown_port and _define_shutdown_procedure went with them, along with the four imports the removals orphaned.

Financial calcrule 281 never actually called so added call site