### PR TITLE
Feature/decouple websocket

### DIFF
--- a/docs/prepare-docs.py
+++ b/docs/prepare-docs.py
@@ -21,7 +21,7 @@ for cli_module_name in cli_module_names:
 
             tmpl = f"""
             ``{cli_module_name}``
-            {'-'*len(cli_module_name)}
+            {'-' * len(cli_module_name)}
             .. automodule:: oasislmf.cli.{cli_module_name}.{class_name}
             :noindex:
             """

--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -682,7 +682,7 @@ class GenerateLosses(GenerateLossesDir):
             has_http = 'OASIS_ANALYSIS_STATUS_URL' in os.environ
             if 'analysis_pk' in self.kwargs and not (has_websocket or has_http):
                 self.logger.info("Set `OASIS_WEBSOCKET_URL`/`OASIS_WEBSOCKET_PORT` or `OASIS_ANALYSIS_STATUS_URL` "
-                                  "environment variables for run progress updates")
+                                 "environment variables for run progress updates")
             elif 'analysis_pk' in self.kwargs:
                 oasis_ping({"analysis_pk": self.kwargs["analysis_pk"], 'events_total': str(os.path.getsize("input/events.bin") // oasis_int_size)})
             else:

--- a/oasislmf/computation/generate/losses.py
+++ b/oasislmf/computation/generate/losses.py
@@ -693,8 +693,11 @@ class GenerateLosses(GenerateLossesDir):
         with setcwd(model_run_fp):
             socket_server_size = None
             socket_server_port = None
-            if 'analysis_pk' in self.kwargs and not all(item in os.environ for item in ['OASIS_WEBSOCKET_URL', 'OASIS_WEBSOCKET_PORT']):
-                self.logger.info("Set `OASIS_WEBSOCKET_URL` and `OASIS_WEBSOCKET_URL` environment variables for run progress updates")
+            has_websocket = all(item in os.environ for item in ['OASIS_WEBSOCKET_URL', 'OASIS_WEBSOCKET_PORT'])
+            has_http = 'OASIS_ANALYSIS_STATUS_URL' in os.environ
+            if 'analysis_pk' in self.kwargs and not (has_websocket or has_http):
+                self.logger.info("Set `OASIS_WEBSOCKET_URL`/`OASIS_WEBSOCKET_PORT` or `OASIS_ANALYSIS_STATUS_URL` "
+                                  "environment variables for run progress updates")
             elif 'analysis_pk' in self.kwargs:
                 oasis_ping({"analysis_pk": self.kwargs["analysis_pk"], 'events_total': str(os.path.getsize("input/events.bin") // oasis_int_size)})
             else:

--- a/oasislmf/execution/bash.py
+++ b/oasislmf/execution/bash.py
@@ -3232,13 +3232,14 @@ def genbash(
 
 
 def add_server_call(call, analysis_pk=None, socket_server_port=None):
-    """Inject WebSocket or socket-server flags into a GUL command string.
+    """Inject WebSocket/HTTP or socket-server flags into a GUL command string.
 
-    If the environment variables ``OASIS_WEBSOCKET_URL`` and
-    ``OASIS_WEBSOCKET_PORT`` are set and ``analysis_pk`` is provided, the
-    ``gulmc``/``gulpy`` invocation within *call* is augmented with
-    ``--socket-server`` and ``--analysis-pk`` flags.  Otherwise, the
-    ``--socket-server`` flag is set to ``IP:port`` when a port is known.
+    If ``analysis_pk`` is provided and either the environment variables
+    ``OASIS_WEBSOCKET_URL``/``OASIS_WEBSOCKET_PORT`` (websocket mode) or
+    ``OASIS_ANALYSIS_STATUS_URL`` (HTTP mode) are set, the ``gulmc``/``gulpy``
+    invocation within *call* is augmented with ``--socket-server`` and
+    ``--analysis-pk`` flags.  Otherwise, the ``--socket-server`` flag is set
+    to ``IP:port`` when a port is known.
 
     Args:
         call (str): The full pipeline command string.
@@ -3250,7 +3251,9 @@ def add_server_call(call, analysis_pk=None, socket_server_port=None):
     """
     if '| gul' not in call:
         return call
-    if all(item in os.environ for item in ['OASIS_WEBSOCKET_URL', 'OASIS_WEBSOCKET_PORT']) and analysis_pk is not None:
+    has_websocket = all(item in os.environ for item in ['OASIS_WEBSOCKET_URL', 'OASIS_WEBSOCKET_PORT'])
+    has_http = 'OASIS_ANALYSIS_STATUS_URL' in os.environ
+    if (has_websocket or has_http) and analysis_pk is not None:
         return re.sub(r'(\bgulmc\b|\bgulpy\b)', rf"\1 --socket-server='True' --analysis-pk='{analysis_pk}'", call)
     if socket_server_port is not None:
         return re.sub(r'(\bgulmc\b|\bgulpy\b)', rf"\1 --socket-server='{socket_server_port}'", call)

--- a/oasislmf/pytools/gul/manager.py
+++ b/oasislmf/pytools/gul/manager.py
@@ -328,6 +328,7 @@ def run(run_dir, ignore_file_type, sample_size, loss_threshold, alloc_rule, debu
                     ping_data['port_override'] = ping_port
                 oasis_ping(ping_data)
                 counter = 0
+                timer = time.time()
 
         if ping:
             ping_data = {"events_complete": counter, "analysis_pk": kwargs.get("analysis_pk", None)}

--- a/oasislmf/pytools/gul/manager.py
+++ b/oasislmf/pytools/gul/manager.py
@@ -317,11 +317,11 @@ def run(run_dir, ignore_file_type, sample_size, loss_threshold, alloc_rule, debu
                 while write_start < cursor:
                     select([], select_stream_list, select_stream_list)
                     write_start += stream_out.write(byte_mv[write_start:cursor].tobytes())
-                    counter += 1
 
                 cursor = 0
 
             logger.info(f"event {event_id} DONE")
+            counter += 1
 
             if ping and time.time() - timer > SERVER_UPDATE_TIME:
                 ping_data = {"events_complete": counter, "analysis_pk": kwargs.get("analysis_pk", None)}

--- a/oasislmf/pytools/gul/manager.py
+++ b/oasislmf/pytools/gul/manager.py
@@ -8,7 +8,7 @@ from select import select
 import numpy as np
 from numba import njit
 import time
-from oasislmf.utils.ping import oasis_ping
+from oasislmf.utils.ping import oasis_ping, oasis_ping_async
 
 from oasislmf.pytools.common.data import correlations_dtype, items_dtype
 from oasislmf.pytools.common.event_stream import (PIPE_CAPACITY, mv_write_item_header, mv_write_sidx_loss, mv_write_delimiter,
@@ -327,7 +327,7 @@ def run(run_dir, ignore_file_type, sample_size, loss_threshold, alloc_rule, debu
                 ping_data = {"events_complete": counter, "analysis_pk": kwargs.get("analysis_pk", None)}
                 if ping_port is not None:
                     ping_data['port_override'] = ping_port
-                oasis_ping(ping_data)
+                oasis_ping_async(ping_data)
                 counter = 0
                 timer = time.time()
 

--- a/oasislmf/pytools/gulmc/manager.py
+++ b/oasislmf/pytools/gulmc/manager.py
@@ -47,7 +47,7 @@ from oasislmf.pytools.gulmc.common import (DAMAGE_TYPE_ABSOLUTE,
                                            gulmc_compute_info_type)
 from oasislmf.pytools.common.id_index import get_idx as id_index_get_idx, NOT_FOUND as ID_INDEX_NOT_FOUND
 from oasislmf.pytools.utils import redirect_logging
-from oasislmf.utils.ping import oasis_ping
+from oasislmf.utils.ping import oasis_ping, oasis_ping_async
 from oasislmf.utils.defaults import SERVER_UPDATE_TIME
 
 logger = logging.getLogger(__name__)
@@ -465,7 +465,7 @@ def run(run_dir,
                 ping_data = {"events_complete": counter, "analysis_pk": kwargs.get("analysis_pk", None)}
                 if ping_port is not None:
                     ping_data['port_override'] = ping_port
-                oasis_ping(ping_data)
+                oasis_ping_async(ping_data)
                 counter = 0
 
     return 0

--- a/oasislmf/utils/ping.py
+++ b/oasislmf/utils/ping.py
@@ -47,7 +47,7 @@ def oasis_ping(data):
                 return True
         if not attempted:
             logger.error("Missing environment variables `OASIS_ANALYSIS_STATUS_URL` or "
-                          "`OASIS_WEBSOCKET_URL`/`OASIS_WEBSOCKET_PORT`.")
+                         "`OASIS_WEBSOCKET_URL`/`OASIS_WEBSOCKET_PORT`.")
         return False
     port_override = data.pop('port_override', None)
     msg = json.dumps(data)

--- a/oasislmf/utils/ping.py
+++ b/oasislmf/utils/ping.py
@@ -88,7 +88,7 @@ def oasis_ping_http(url, data):
         Boolean: whether attempted call gets through
     """
     try:
-        response = requests.post(url, json=data, timeout=5)
+        response = requests.post(url, json=data, timeout=1)
         response.raise_for_status()
         return True
     except requests.exceptions.RequestException as e:
@@ -108,7 +108,7 @@ def oasis_ping_websocket(ws_url, data):
     """
     ws = websocket.WebSocket()
     try:
-        ws.connect(ws_url, timeout=5)
+        ws.connect(ws_url, timeout=1)
         ws.send(data)
         return True
     except Exception as e:

--- a/oasislmf/utils/ping.py
+++ b/oasislmf/utils/ping.py
@@ -6,6 +6,8 @@ import logging
 import requests
 from oasislmf.utils.defaults import SERVER_DEFAULT_PORT, SERVER_DEFAULT_IP
 
+logger = logging.getLogger(__name__)
+
 
 def oasis_ping(data):
     """
@@ -32,21 +34,26 @@ def oasis_ping(data):
         attempted = False
         if 'OASIS_ANALYSIS_STATUS_URL' in os.environ:
             attempted = True
-            if oasis_ping_http(os.environ['OASIS_ANALYSIS_STATUS_URL'], data):
+            url = os.environ['OASIS_ANALYSIS_STATUS_URL']
+            logger.debug(f"Sending ping to {url}: {data}")
+            if oasis_ping_http(url, data):
                 return True
         if all(item in os.environ for item in ['OASIS_WEBSOCKET_URL', 'OASIS_WEBSOCKET_PORT']):
             attempted = True
             msg = json.dumps(data)
-            if oasis_ping_websocket(f"{os.environ['OASIS_WEBSOCKET_URL']}:{os.environ['OASIS_WEBSOCKET_PORT']}/ws/analysis-status/", msg):
+            ws_url = f"{os.environ['OASIS_WEBSOCKET_URL']}:{os.environ['OASIS_WEBSOCKET_PORT']}/ws/analysis-status/"
+            logger.debug(f"Sending ping to {ws_url}: {msg}")
+            if oasis_ping_websocket(ws_url, msg):
                 return True
         if not attempted:
-            logging.error("Missing environment variables `OASIS_ANALYSIS_STATUS_URL` or "
-                           "`OASIS_WEBSOCKET_URL`/`OASIS_WEBSOCKET_PORT`.")
+            logger.error("Missing environment variables `OASIS_ANALYSIS_STATUS_URL` or "
+                          "`OASIS_WEBSOCKET_URL`/`OASIS_WEBSOCKET_PORT`.")
         return False
     port_override = data.pop('port_override', None)
     msg = json.dumps(data)
     target_port = int(port_override) if port_override is not None else int(os.environ.get("OASIS_SOCKET_SERVER_PORT", SERVER_DEFAULT_PORT))
     target = (os.environ.get("OASIS_SOCKET_SERVER_IP", SERVER_DEFAULT_IP), target_port)
+    logger.debug(f"Sending ping to {target}: {msg}")
     return oasis_ping_socket(target, msg)
 
 
@@ -67,7 +74,7 @@ def oasis_ping_socket(target, data):
             oasis_socket.sendall(data.encode('utf-8'))
         return True
     except (ConnectionError, TimeoutError, socket.gaierror) as e:
-        logging.error(f"oasis_ping_socket could not connect: {e}")
+        logger.error(f"oasis_ping_socket could not connect: {e}")
         return False
 
 
@@ -87,7 +94,7 @@ def oasis_ping_http(url, data):
         response.raise_for_status()
         return True
     except requests.exceptions.RequestException as e:
-        logging.error(f"oasis_ping_http could not connect: {e}")
+        logger.error(f"oasis_ping_http could not connect: {e}")
         return False
 
 
@@ -108,7 +115,7 @@ def oasis_ping_websocket(ws_url, data):
         ws.send(data)
         return True
     except Exception as e:
-        logging.error(f"oasis_ping_websocket could not connect: {e}")
+        logger.error(f"oasis_ping_websocket could not connect: {e}")
         return False
     finally:
         ws.close()

--- a/oasislmf/utils/ping.py
+++ b/oasislmf/utils/ping.py
@@ -43,8 +43,8 @@ def oasis_ping(data):
             logging.error("Missing environment variables `OASIS_ANALYSIS_STATUS_URL` or "
                            "`OASIS_WEBSOCKET_URL`/`OASIS_WEBSOCKET_PORT`.")
         return False
-    msg = json.dumps(data)
     port_override = data.pop('port_override', None)
+    msg = json.dumps(data)
     target_port = int(port_override) if port_override is not None else int(os.environ.get("OASIS_SOCKET_SERVER_PORT", SERVER_DEFAULT_PORT))
     target = (os.environ.get("OASIS_SOCKET_SERVER_IP", SERVER_DEFAULT_IP), target_port)
     return oasis_ping_socket(target, msg)
@@ -66,7 +66,7 @@ def oasis_ping_socket(target, data):
             oasis_socket.connect(target)
             oasis_socket.sendall(data.encode('utf-8'))
         return True
-    except ConnectionRefusedError as e:
+    except OSError as e:
         logging.error(f"oasis_ping_socket could not connect: {e}")
         return False
 

--- a/oasislmf/utils/ping.py
+++ b/oasislmf/utils/ping.py
@@ -66,7 +66,7 @@ def oasis_ping_socket(target, data):
             oasis_socket.connect(target)
             oasis_socket.sendall(data.encode('utf-8'))
         return True
-    except OSError as e:
+    except (ConnectionError, TimeoutError, socket.gaierror) as e:
         logging.error(f"oasis_ping_socket could not connect: {e}")
         return False
 

--- a/oasislmf/utils/ping.py
+++ b/oasislmf/utils/ping.py
@@ -4,9 +4,14 @@ import socket
 import os
 import logging
 import requests
+import threading
 from oasislmf.utils.defaults import SERVER_DEFAULT_PORT, SERVER_DEFAULT_IP
 
 logger = logging.getLogger(__name__)
+
+# Guards `oasis_ping_async` so a stuck ping target can never pile up more than
+# one in-flight ping thread within this process.
+_ping_lock = threading.Lock()
 
 
 def oasis_ping(data):
@@ -55,6 +60,38 @@ def oasis_ping(data):
     target = (os.environ.get("OASIS_SOCKET_SERVER_IP", SERVER_DEFAULT_IP), target_port)
     logger.debug(f"Sending ping to {target}: {msg}")
     return oasis_ping_socket(target, msg)
+
+
+def oasis_ping_async(data):
+    """Sends a ping without blocking the caller.
+
+    `oasis_ping` makes a network call (HTTP POST or websocket connect) that can
+    block for up to the configured timeout when the target is unreachable but
+    not actively refusing the connection (wrong hostname, dropped packets, a
+    NetworkPolicy). Calling it directly from a per-event progress ping inside a
+    compute loop means a broken ping target stalls the calculation itself. This
+    runs `oasis_ping` on a background daemon thread instead, so a stuck ping
+    can never block the caller.
+
+    Only one ping is ever in flight at a time per process: if a previous call
+    is still pending when this is invoked, the new update is dropped (a
+    subsequent ping will carry a more up to date `events_complete`) rather than
+    letting a persistently broken target pile up threads.
+
+    Args:
+        data (dict): dictionary of data: JSON serialisable
+    """
+    if not _ping_lock.acquire(blocking=False):
+        logger.debug(f"Skipping ping, previous ping still in flight: {data}")
+        return
+
+    def _send():
+        try:
+            oasis_ping(data)
+        finally:
+            _ping_lock.release()
+
+    threading.Thread(target=_send, daemon=True).start()
 
 
 def oasis_ping_socket(target, data):

--- a/oasislmf/utils/ping.py
+++ b/oasislmf/utils/ping.py
@@ -11,10 +11,10 @@ def oasis_ping(data):
     """
     Sends a JSON message to either an HTTP endpoint, a websocket server, or a socket server.
 
-    If `analysis_pk` is in the data:
+    If `analysis_pk` is in the data, targets are tried in order until one succeeds:
         - if `OASIS_ANALYSIS_STATUS_URL` is in environment, POSTs the message to that URL.
-        - elif `OASIS_WEBSOCKET_URL` and `OASIS_WEBSOCKET_PORT` are in environment, sends a websocket message.
-        - else, no message sent.
+        - if `OASIS_WEBSOCKET_URL` and `OASIS_WEBSOCKET_PORT` are in environment, sends a websocket message.
+        - if neither is configured, or all configured targets fail, no message gets through.
     Else, a message sent to `OASIS_SOCKET_SERVER_IP` `OASIS_SOCKET_SERVER_PORT` defaulted to 127.0.0.1 8888.
 
     If ``data`` contains a ``port_override`` key, that port is used in place of the default/env-var port
@@ -29,13 +29,19 @@ def oasis_ping(data):
         Boolean: whether attempted call gets through
     """
     if data.get('analysis_pk', None) is not None:
+        attempted = False
         if 'OASIS_ANALYSIS_STATUS_URL' in os.environ:
-            return oasis_ping_http(os.environ['OASIS_ANALYSIS_STATUS_URL'], data)
+            attempted = True
+            if oasis_ping_http(os.environ['OASIS_ANALYSIS_STATUS_URL'], data):
+                return True
         if all(item in os.environ for item in ['OASIS_WEBSOCKET_URL', 'OASIS_WEBSOCKET_PORT']):
+            attempted = True
             msg = json.dumps(data)
-            return oasis_ping_websocket(f"{os.environ['OASIS_WEBSOCKET_URL']}:{os.environ['OASIS_WEBSOCKET_PORT']}/ws/analysis-status/", msg)
-        logging.error("Missing environment variables `OASIS_ANALYSIS_STATUS_URL` or "
-                       "`OASIS_WEBSOCKET_URL`/`OASIS_WEBSOCKET_PORT`.")
+            if oasis_ping_websocket(f"{os.environ['OASIS_WEBSOCKET_URL']}:{os.environ['OASIS_WEBSOCKET_PORT']}/ws/analysis-status/", msg):
+                return True
+        if not attempted:
+            logging.error("Missing environment variables `OASIS_ANALYSIS_STATUS_URL` or "
+                           "`OASIS_WEBSOCKET_URL`/`OASIS_WEBSOCKET_PORT`.")
         return False
     msg = json.dumps(data)
     port_override = data.pop('port_override', None)
@@ -70,7 +76,7 @@ def oasis_ping_http(url, data):
     Sends a JSON message to a target HTTP endpoint via POST.
 
     Args:
-        url (str): URL to hit (e.g. "http://oasis-server:8000/v2/analysis-status/")
+        url (str): URL to hit (e.g. "http://oasis-server:8000/analysis-status/")
         data (dict): dictionary of data: JSON serialisable
 
     Returns:
@@ -98,7 +104,7 @@ def oasis_ping_websocket(ws_url, data):
     """
     ws = websocket.WebSocket()
     try:
-        ws.connect(ws_url)
+        ws.connect(ws_url, timeout=5)
         ws.send(data)
         return True
     except Exception as e:

--- a/oasislmf/utils/ping.py
+++ b/oasislmf/utils/ping.py
@@ -3,21 +3,24 @@ import websocket
 import socket
 import os
 import logging
+import requests
 from oasislmf.utils.defaults import SERVER_DEFAULT_PORT, SERVER_DEFAULT_IP
 
 
 def oasis_ping(data):
     """
-    Sends a JSON message to either a websocket server or a socket server.
+    Sends a JSON message to either an HTTP endpoint, a websocket server, or a socket server.
 
-    If `analysis_pk` is in the data, `OASIS_WEBSOCKET_URL` and `OASIS_WEBSOCKET_URL` are in environment, sends a websocket message.
-    If `analysis_pk` but missing variables, no message sent.
-    Else, websocket sent to `OASIS_SOCKET_SERVER_IP` `OASIS_SOCKET_SERVER_PORT` defaulted to 127.0.0.1 8888.
+    If `analysis_pk` is in the data:
+        - if `OASIS_ANALYSIS_STATUS_URL` is in environment, POSTs the message to that URL.
+        - elif `OASIS_WEBSOCKET_URL` and `OASIS_WEBSOCKET_PORT` are in environment, sends a websocket message.
+        - else, no message sent.
+    Else, a message sent to `OASIS_SOCKET_SERVER_IP` `OASIS_SOCKET_SERVER_PORT` defaulted to 127.0.0.1 8888.
 
     If ``data`` contains a ``port_override`` key, that port is used in place of the default/env-var port
     when connecting to the socket server. The key is stripped before the message is sent.
 
-    For a specific socket or websocket, use `oasis_ping_socket` or `oasis_ping_websocket` with the target location.
+    For a specific target, use `oasis_ping_http`, `oasis_ping_socket` or `oasis_ping_websocket` directly.
 
     Args:
         data (dict): dictionary of data: JSON serialisable
@@ -25,12 +28,16 @@ def oasis_ping(data):
     Returns:
         Boolean: whether attempted call gets through
     """
-    msg = json.dumps(data)
     if data.get('analysis_pk', None) is not None:
+        if 'OASIS_ANALYSIS_STATUS_URL' in os.environ:
+            return oasis_ping_http(os.environ['OASIS_ANALYSIS_STATUS_URL'], data)
         if all(item in os.environ for item in ['OASIS_WEBSOCKET_URL', 'OASIS_WEBSOCKET_PORT']):
+            msg = json.dumps(data)
             return oasis_ping_websocket(f"{os.environ['OASIS_WEBSOCKET_URL']}:{os.environ['OASIS_WEBSOCKET_PORT']}/ws/analysis-status/", msg)
-        logging.error("Missing environment variables `OASIS_WEBSOCKET_URL` and `OASIS_WEBSOCKET_PORT`.")
+        logging.error("Missing environment variables `OASIS_ANALYSIS_STATUS_URL` or "
+                       "`OASIS_WEBSOCKET_URL`/`OASIS_WEBSOCKET_PORT`.")
         return False
+    msg = json.dumps(data)
     port_override = data.pop('port_override', None)
     target_port = int(port_override) if port_override is not None else int(os.environ.get("OASIS_SOCKET_SERVER_PORT", SERVER_DEFAULT_PORT))
     target = (os.environ.get("OASIS_SOCKET_SERVER_IP", SERVER_DEFAULT_IP), target_port)
@@ -55,6 +62,26 @@ def oasis_ping_socket(target, data):
         return True
     except ConnectionRefusedError as e:
         logging.error(f"oasis_ping_socket could not connect: {e}")
+        return False
+
+
+def oasis_ping_http(url, data):
+    """
+    Sends a JSON message to a target HTTP endpoint via POST.
+
+    Args:
+        url (str): URL to hit (e.g. "http://oasis-server:8000/v2/analysis-status/")
+        data (dict): dictionary of data: JSON serialisable
+
+    Returns:
+        Boolean: whether attempted call gets through
+    """
+    try:
+        response = requests.post(url, json=data, timeout=5)
+        response.raise_for_status()
+        return True
+    except requests.exceptions.RequestException as e:
+        logging.error(f"oasis_ping_http could not connect: {e}")
         return False
 
 

--- a/tests/pytools/gul/test_gulpy.py
+++ b/tests/pytools/gul/test_gulpy.py
@@ -142,8 +142,9 @@ def test_gulpy_periodic_ping():
     """The in-loop periodic ping fires once more than SERVER_UPDATE_TIME elapses between events.
 
     Feeds gulpy a real getmodel stream (so the event loop runs) and forces the threshold
-    negative, so the periodic ping fires per event -> oasis_ping is called more than once
-    (periodic pings + the end-of-run ping).
+    negative, so the periodic ping fires per event. The periodic ping is dispatched through
+    `oasis_ping_async` (fire-and-forget, so a stuck ping target can't stall the compute loop)
+    while the end-of-run ping still calls `oasis_ping` directly.
     """
     test_model_dir = Path(test_models_dirs[0][1])
     with TemporaryDirectory() as tmp_result_dir_str:
@@ -156,12 +157,14 @@ def test_gulpy_periodic_ping():
             with open(stream, 'wb') as fout:
                 subprocess.run("evepy 1 1 | modelpy", cwd=test_model_dir, shell=True, check=True, stdout=fout)
             with (patch('oasislmf.pytools.gul.manager.oasis_ping') as mock_ping,
+                  patch('oasislmf.pytools.gul.manager.oasis_ping_async') as mock_ping_async,
                   patch('oasislmf.pytools.gul.manager.SERVER_UPDATE_TIME', -1)):
                 gulpy_run(run_dir=tmp_result_dir, ignore_file_type=set(), sample_size=10, loss_threshold=0.,
                           alloc_rule=1, debug=False, random_generator=1,
                           file_in=str(stream), file_out=str(out_bin),
                           socket_server='True')
-            assert mock_ping.call_count > 1
+            assert mock_ping_async.call_count > 1
+            mock_ping.assert_called_once()
         finally:
             for scratch in (stream, out_bin):
                 if scratch.exists():

--- a/tests/pytools/gulmc/test_gulmc.py
+++ b/tests/pytools/gulmc/test_gulmc.py
@@ -392,11 +392,14 @@ def test_gulmc_socket_server_periodic_ping():
     """The in-loop periodic ping fires once more than SERVER_UPDATE_TIME elapses between events.
 
     Forcing the threshold below zero makes the periodic ping (distinct from the
-    end-of-run ping) fire on every event, so oasis_ping is called more than once.
+    end-of-run ping) fire on every event. The periodic ping is dispatched through
+    `oasis_ping_async` (fire-and-forget, so a stuck ping target can't stall the compute
+    loop), while the end-of-run ping still calls `oasis_ping` directly.
     """
     test_model_dir = TESTS_ASSETS_DIR.joinpath("test_model_1")
     with (TemporaryDirectory() as tmp_result_dir_str,
           patch('oasislmf.pytools.gulmc.manager.oasis_ping') as mock_ping,
+          patch('oasislmf.pytools.gulmc.manager.oasis_ping_async') as mock_ping_async,
           patch('oasislmf.pytools.gulmc.manager.SERVER_UPDATE_TIME', -1)):
         tmp_result_dir = Path(tmp_result_dir_str).joinpath("assets")
         os.symlink(test_model_dir, tmp_result_dir, target_is_directory=True)
@@ -416,8 +419,9 @@ def test_gulmc_socket_server_periodic_ping():
                 effective_damageability=False,
                 socket_server='True',
             )
-            # periodic ping (per event, threshold forced negative) + end-of-run ping -> >1 call
-            assert mock_ping.call_count > 1
+            # periodic ping (per event, threshold forced negative) fires more than once
+            assert mock_ping_async.call_count > 1
+            mock_ping.assert_called_once()
         finally:
             if file_out.exists():
                 file_out.unlink()

--- a/tests/utils/test_ping.py
+++ b/tests/utils/test_ping.py
@@ -77,7 +77,7 @@ def test_oasis_ping_websocket_success():
     with patch("websocket.WebSocket", return_value=fake_ws):
         result = oasis_ping_websocket("ws://fakehost:1234/ws", '{"hello": "world"}')
     assert result is True
-    fake_ws.connect.assert_called_once_with("ws://fakehost:1234/ws")
+    fake_ws.connect.assert_called_once_with("ws://fakehost:1234/ws", timeout=5)
     fake_ws.send.assert_called_once_with('{"hello": "world"}')
     fake_ws.close.assert_called_once()
 

--- a/tests/utils/test_ping.py
+++ b/tests/utils/test_ping.py
@@ -38,13 +38,13 @@ def test_oasis_ping_http_path():
 def test_oasis_ping_http_path_falls_back_to_websocket():
     data = {"analysis_pk": 123}
     with (patch.dict(os.environ, {
-              "OASIS_ANALYSIS_STATUS_URL": "http://fakehost/analysis-status/",
-              "OASIS_WEBSOCKET_URL": "ws://fakehost",
-              "OASIS_WEBSOCKET_PORT": "9999",
-          }, clear=True),
-          patch("oasislmf.utils.ping.oasis_ping_http", return_value=False) as mock_http,
-          patch("oasislmf.utils.ping.oasis_ping_websocket", return_value=True) as mock_ws,
-          patch("oasislmf.utils.ping.oasis_ping_socket") as mock_sock):
+        "OASIS_ANALYSIS_STATUS_URL": "http://fakehost/analysis-status/",
+        "OASIS_WEBSOCKET_URL": "ws://fakehost",
+        "OASIS_WEBSOCKET_PORT": "9999",
+    }, clear=True),
+            patch("oasislmf.utils.ping.oasis_ping_http", return_value=False) as mock_http,
+            patch("oasislmf.utils.ping.oasis_ping_websocket", return_value=True) as mock_ws,
+            patch("oasislmf.utils.ping.oasis_ping_socket") as mock_sock):
         result = oasis_ping(data)
 
     mock_http.assert_called_once()

--- a/tests/utils/test_ping.py
+++ b/tests/utils/test_ping.py
@@ -1,8 +1,11 @@
 import json
 import os
+import threading
+import time
 from unittest.mock import patch, MagicMock
 import requests
-from oasislmf.utils.ping import oasis_ping, oasis_ping_socket, oasis_ping_websocket, oasis_ping_http
+import oasislmf.utils.ping as ping_module
+from oasislmf.utils.ping import oasis_ping, oasis_ping_socket, oasis_ping_websocket, oasis_ping_http, oasis_ping_async
 
 
 def test_oasis_ping_websocket_path():
@@ -110,7 +113,7 @@ def test_oasis_ping_websocket_success():
     with patch("websocket.WebSocket", return_value=fake_ws):
         result = oasis_ping_websocket("ws://fakehost:1234/ws", '{"hello": "world"}')
     assert result is True
-    fake_ws.connect.assert_called_once_with("ws://fakehost:1234/ws", timeout=5)
+    fake_ws.connect.assert_called_once_with("ws://fakehost:1234/ws", timeout=1)
     fake_ws.send.assert_called_once_with('{"hello": "world"}')
     fake_ws.close.assert_called_once()
 
@@ -130,7 +133,7 @@ def test_oasis_ping_http_success():
         result = oasis_ping_http("http://fakehost/analysis-status/", {"hello": "world"})
 
     assert result is True
-    mock_post.assert_called_once_with("http://fakehost/analysis-status/", json={"hello": "world"}, timeout=5)
+    mock_post.assert_called_once_with("http://fakehost/analysis-status/", json={"hello": "world"}, timeout=1)
     fake_response.raise_for_status.assert_called_once()
 
 
@@ -170,3 +173,46 @@ def test_oasis_ping_no_port_override_uses_env():
 
     called_target, _ = mock_sock.call_args[0]
     assert called_target == ("1.2.3.4", 4321)
+
+
+def test_oasis_ping_async_calls_oasis_ping_off_caller_thread():
+    data = {"hello": "world"}
+    caller_thread = threading.current_thread()
+    done = threading.Event()
+    calls = []
+
+    def fake_oasis_ping(d):
+        calls.append((d, threading.current_thread()))
+        done.set()
+
+    with patch("oasislmf.utils.ping.oasis_ping", side_effect=fake_oasis_ping):
+        oasis_ping_async(data)
+        assert done.wait(timeout=2), "oasis_ping_async did not call oasis_ping in time"
+
+    assert calls == [(data, calls[0][1])]
+    assert calls[0][1] is not caller_thread
+
+
+def test_oasis_ping_async_drops_update_when_previous_still_in_flight():
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_oasis_ping(d):
+        started.set()
+        release.wait(timeout=2)
+
+    with patch("oasislmf.utils.ping.oasis_ping", side_effect=slow_oasis_ping) as mock_ping:
+        oasis_ping_async({"events_complete": 1})
+        assert started.wait(timeout=2), "first ping never started"
+
+        # A second update arriving while the first is still in flight is dropped,
+        # not queued behind it.
+        oasis_ping_async({"events_complete": 2})
+
+        release.set()
+        for _ in range(200):
+            if not ping_module._ping_lock.locked():
+                break
+            time.sleep(0.01)
+
+    mock_ping.assert_called_once_with({"events_complete": 1})

--- a/tests/utils/test_ping.py
+++ b/tests/utils/test_ping.py
@@ -1,7 +1,8 @@
 import json
 import os
 from unittest.mock import patch, MagicMock
-from oasislmf.utils.ping import oasis_ping, oasis_ping_socket, oasis_ping_websocket
+import requests
+from oasislmf.utils.ping import oasis_ping, oasis_ping_socket, oasis_ping_websocket, oasis_ping_http
 
 
 def test_oasis_ping_websocket_path():
@@ -18,6 +19,38 @@ def test_oasis_ping_websocket_path():
     called_url, called_msg = mock_ws.call_args[0]
     assert called_url == "ws://fakehost:9999/ws/analysis-status/"
     assert json.loads(called_msg) == data
+
+
+def test_oasis_ping_http_path():
+    data = {"analysis_pk": 123}
+    with (patch.dict(os.environ, {"OASIS_ANALYSIS_STATUS_URL": "http://fakehost/analysis-status/"}, clear=True),
+          patch("oasislmf.utils.ping.oasis_ping_http", return_value=True) as mock_http,
+          patch("oasislmf.utils.ping.oasis_ping_websocket") as mock_ws,
+          patch("oasislmf.utils.ping.oasis_ping_socket") as mock_sock):
+        result = oasis_ping(data)
+
+    mock_http.assert_called_once_with("http://fakehost/analysis-status/", data)
+    mock_ws.assert_not_called()
+    mock_sock.assert_not_called()
+    assert result is True
+
+
+def test_oasis_ping_http_path_falls_back_to_websocket():
+    data = {"analysis_pk": 123}
+    with (patch.dict(os.environ, {
+              "OASIS_ANALYSIS_STATUS_URL": "http://fakehost/analysis-status/",
+              "OASIS_WEBSOCKET_URL": "ws://fakehost",
+              "OASIS_WEBSOCKET_PORT": "9999",
+          }, clear=True),
+          patch("oasislmf.utils.ping.oasis_ping_http", return_value=False) as mock_http,
+          patch("oasislmf.utils.ping.oasis_ping_websocket", return_value=True) as mock_ws,
+          patch("oasislmf.utils.ping.oasis_ping_socket") as mock_sock):
+        result = oasis_ping(data)
+
+    mock_http.assert_called_once()
+    mock_ws.assert_called_once()
+    mock_sock.assert_not_called()
+    assert result is True
 
 
 def test_oasis_ping_analysis_pk_missing_env():
@@ -89,6 +122,32 @@ def test_oasis_ping_websocket_failure():
         result = oasis_ping_websocket("ws://fakehost:1234/ws", '{"hello": "world"}')
     assert result is False
     fake_ws.send.assert_not_called()
+
+
+def test_oasis_ping_http_success():
+    fake_response = MagicMock()
+    with patch("requests.post", return_value=fake_response) as mock_post:
+        result = oasis_ping_http("http://fakehost/analysis-status/", {"hello": "world"})
+
+    assert result is True
+    mock_post.assert_called_once_with("http://fakehost/analysis-status/", json={"hello": "world"}, timeout=5)
+    fake_response.raise_for_status.assert_called_once()
+
+
+def test_oasis_ping_http_failure():
+    with patch("requests.post", side_effect=requests.exceptions.ConnectionError("boom")):
+        result = oasis_ping_http("http://fakehost/analysis-status/", {"hello": "world"})
+
+    assert result is False
+
+
+def test_oasis_ping_http_bad_status():
+    fake_response = MagicMock()
+    fake_response.raise_for_status.side_effect = requests.exceptions.HTTPError("500")
+    with patch("requests.post", return_value=fake_response):
+        result = oasis_ping_http("http://fakehost/analysis-status/", {"hello": "world"})
+
+    assert result is False
 
 
 def test_oasis_ping_port_override():


### PR DESCRIPTION
<!--start_release_notes-->
### Fixes to run platform without redis websocket

Works with https://github.com/OasisLMF/OasisPlatform/pull/1427 add an option to send event processing updates via a HTTP instead of websocket 

#### Bug: periodic ping timer never reset in `gul/manager.py`
- **`oasislmf/pytools/gul/manager.py`** — the periodic-ping loop reset `counter = 0` after each ping but never reset `timer`. Once `SERVER_UPDATE_TIME` first elapsed, the stale `timer` meant every subsequent event satisfied the "time elapsed" check, so pings fired on every event for the rest of the run instead of being throttled to the interval. `gulmc/manager.py` already did this correctly (`timer = time.time()`); `gul/manager.py` now matches.

#### `oasislmf/utils/ping.py` updates
- **`port_override` ordering bug**: `json.dumps(data)` was called *before*
  `data.pop('port_override', None)`, so the key leaked into the outgoing socket message despite
  the docstring claiming it's stripped first. Fixed by popping before serializing.
- **Narrow exception handling**: `oasis_ping_socket` only caught `ConnectionRefusedError`. Other
  realistic failures (`TimeoutError`, DNS resolution failures) were left uncaught and would
  crash the calling worker process just because a progress ping failed. Now catches
  `(ConnectionError, TimeoutError, socket.gaierror)`.
- **Logging routed to the wrong logger**: all `logging.error(...)` calls used the bare
  module-level shortcut, which logs on the **root** logger — a different, disconnected object
  from the `oasislmf.*` logger hierarchy that `gulmc`/`gulpy`/`modelpy` actually configure
  handlers on via `redirect_logging`/`OASIS_PYTOOLS_LOG_LEVEL`. Ping errors were reaching stderr
  only via Python's unformatted "handler of last resort", untagged and inconsistent with the
  rest of each pytool's log output. Fixed by using `logger = logging.getLogger(__name__)`
  throughout.
- **Added debug visibility**: a `logger.debug(...)` line before each send attempt (HTTP,
  websocket, and plain socket), logging the target and payload. Naturally gated by
  `OASIS_PYTOOLS_LOG_LEVEL` — silent unless that's set to `DEBUG`, no separate flag needed.


<!--end_release_notes-->
