### PR TITLE
Dummy model vectorise

### DIFF
--- a/oasislmf/computation/data/dummy_model/generate.py
+++ b/oasislmf/computation/data/dummy_model/generate.py
@@ -26,6 +26,14 @@ from math import erf
 import numpy as np
 
 
+# the file layouts are declared as struct format characters, which the arrays written to
+# the files have to match exactly, so the two are kept in step through this mapping
+STRUCT_TO_NUMPY_FORMAT = {'i': 'i4', 'f': 'f4', 'q': 'i8'}
+
+# rows generated before being written, keeping the memory used by a chunk in the tens of MBs
+CHUNK_ROWS = 10 ** 6
+
+
 class ModelFile:
     """Base class for all dummy model files.
 
@@ -33,20 +41,30 @@ class ModelFile:
     typical order of execution is as follows:
         1. Initialise class attributes and methods (__init__).
         2. Set random seed (seed_rng).
-        3. Generate random data (generate_data).
-        4. Convert random data to binary format and write to file. This step is
-        done as each line of data is generated to minimise memory use
-        (write_file).
+        3. Generate random data (generate_arrays, or generate_data for the
+        classes that generate their data a row at a time).
+        4. Write the generated data to file in binary format, in chunks to
+        minimise memory use (write_file).
 
     Attributes:
         seed_rng: Seed random number generator.
         write_file: Write data to output file in binary format.
         debug_write_file: Write data to screen in csv format.
-        generate_data: Generate dummy model data.
+        generate_data: Generate dummy model data row by row.
+        generate_arrays: Generate dummy model data in chunks.
     """
 
     def __init__(self):
         pass
+
+    @property
+    def array_dtype(self):
+        """Get the numpy dtype of the rows written to the file.
+
+        Returns:
+            numpy.dtype: packed dtype matching the file's struct format
+        """
+        return np.dtype([(name, STRUCT_TO_NUMPY_FORMAT[fmt]) for name, fmt in self.dtypes.items()])
 
     def seed_rng(self):
         """Seed random number generator.
@@ -69,16 +87,15 @@ class ModelFile:
     def write_file(self):
         """Write data to output file in binary format.
 
-        General method to convert generated data to binary format and write to
-        file. Calls chlid class-specific generate_data method.
+        General method to write the generated data to file. Calls child
+        class-specific generate_arrays method.
         """
         with open(self.file_name, 'wb') as f:
             if self.start_stats:
                 for stat in self.start_stats:
                     f.write(struct.pack(stat['dtype'], stat['value']))
-            dtypes_list = ''.join(self.dtypes.values())
-            for line in self.generate_data():
-                f.write(struct.pack('=' + dtypes_list, *(line)))
+            for chunk in self.generate_arrays():
+                chunk.tofile(f)
 
     def debug_write_file(self):
         """Write data to screen in csv format.
@@ -96,10 +113,22 @@ class ModelFile:
     def generate_data(self):
         """Generate dummy model data.
 
-        Class specific method to generate randomised data. Is called by
-        write_file method.
+        Class specific method to generate randomised data a row at a time. Is
+        called by debug_write_file, and by generate_arrays for the classes that
+        do not generate their data with numpy.
         """
         pass
+
+    def generate_arrays(self):
+        """Generate dummy model data as arrays of the file's rows.
+
+        Class specific method, defaulting to packing the rows from
+        generate_data. Is called by write_file.
+
+        Yields:
+            numpy.ndarray: rows of dummy model data, in the file's dtype
+        """
+        yield np.fromiter(self.generate_data(), dtype=self.array_dtype)
 
 
 class VulnerabilityFile(ModelFile):
@@ -176,6 +205,39 @@ class VulnerabilityFile(ModelFile):
                 for damage_bin, probability in enumerate(probabilities):
                     yield vulnerability + 1, intensity_bin + 1, damage_bin + 1, probability
 
+    def generate_arrays(self):
+        """Generate Vulnerability dummy model file data.
+
+        The probabilities are drawn per (vulnerability, intensity bin) pair, two blocks of
+        num_damage_bins at a time, so drawing them for several pairs at once takes the same
+        numbers from the generator as drawing them pair by pair does.
+
+        Yields:
+            numpy.ndarray: rows of vulnerability data, in the file's dtype
+        """
+        super().seed_rng()
+        pairs = self.num_vulnerabilities * self.num_intensity_bins
+        pairs_per_chunk = max(1, CHUNK_ROWS // self.num_damage_bins)
+        damage_bins = np.arange(1, self.num_damage_bins + 1)
+
+        for start in range(0, pairs, pairs_per_chunk):
+            chunk_pairs = min(pairs_per_chunk, pairs - start)
+            draws = np.random.uniform(size=(chunk_pairs, 2, self.num_damage_bins))
+            probabilities = np.where(draws[:, 0, :] < self.vulnerability_sparseness, draws[:, 1, :], 0.0)
+
+            total_probability = probabilities.sum(axis=1)
+            impacted = total_probability != 0
+            probabilities[~impacted, 0] = 1.0   # First damage bin is always zero-loss
+            probabilities[impacted] /= total_probability[impacted, np.newaxis]
+
+            pair_index = np.arange(start, start + chunk_pairs)
+            chunk = np.empty(chunk_pairs * self.num_damage_bins, dtype=self.array_dtype)
+            chunk['vulnerability_id'] = np.repeat(pair_index // self.num_intensity_bins + 1, self.num_damage_bins)
+            chunk['intensity_bin_index'] = np.repeat(pair_index % self.num_intensity_bins + 1, self.num_damage_bins)
+            chunk['damage_bin_index'] = np.tile(damage_bins, chunk_pairs)
+            chunk['prob'] = probabilities.reshape(-1)
+            yield chunk
+
 
 class EventsFile(ModelFile):
     """Generate random data for Events dummy model file.
@@ -206,6 +268,16 @@ class EventsFile(ModelFile):
             event (int): event ID.
         """
         return (tuple([event]) for event in range(1, self.num_events + 1))
+
+    def generate_arrays(self):
+        """Generate Events dummy model file data.
+
+        Yields:
+            numpy.ndarray: rows of event data, in the file's dtype
+        """
+        events = np.empty(self.num_events, dtype=self.array_dtype)
+        events['event_id'] = np.arange(1, self.num_events + 1)
+        yield events
 
 
 class LossFactorsFile(ModelFile):
@@ -268,6 +340,33 @@ class LossFactorsFile(ModelFile):
                     continue   # Default loss factor = 1.0
                 yield event + 1, amplification + 1, factor
 
+    def generate_arrays(self):
+        """Generate Loss Factors dummy model file data.
+
+        One factor is drawn per event and amplification pair, so drawing them for several events
+        at once takes the same numbers from the generator as drawing them event by event does.
+
+        Yields:
+            numpy.ndarray: rows of loss factor data, in the file's dtype
+        """
+        super().seed_rng()
+        events_per_chunk = max(1, CHUNK_ROWS // self.num_amplifications)
+        amplification_id = np.arange(1, self.num_amplifications + 1)
+
+        for start in range(0, self.num_events, events_per_chunk):
+            chunk_events = min(events_per_chunk, self.num_events - start)
+            factor = np.round(
+                np.random.random(size=chunk_events * self.num_amplifications) * self.delta_pla_factor
+                + self.min_pla_factor, decimals=2
+            )
+            amplified = factor != 1.0   # Default loss factor = 1.0
+
+            chunk = np.empty(int(amplified.sum()), dtype=self.array_dtype)
+            chunk['event_id'] = np.repeat(np.arange(start + 1, start + chunk_events + 1), self.num_amplifications)[amplified]
+            chunk['amplification_id'] = np.tile(amplification_id, chunk_events)[amplified]
+            chunk['factor'] = factor[amplified]
+            yield chunk
+
     def write_file(self):
         """Write data to output Loss Factors file in binary format.
 
@@ -287,6 +386,7 @@ class FootprintIdxFile(ModelFile):
 
     Attributes:
         write_file: Write data to Footprint index file in binary format.
+        write_array: Write the whole index to the Footprint index file in binary format.
     """
 
     def __init__(self, directory):
@@ -300,6 +400,18 @@ class FootprintIdxFile(ModelFile):
         ])
         self.dtypes_list = ''.join(self.dtypes.values())
         self.file_name = os.path.join(directory, 'footprint.idx')
+
+    def write_array(self, index):
+        """Write the whole footprint index to file in binary format.
+
+        Called by FootprintBinFile.write_file() with the index of every event, in place of the
+        per-event appends the row by row path makes.
+
+        Args:
+            index (numpy.ndarray): the event id, offset and size of every event
+        """
+        with open(self.file_name, 'wb') as f:
+            index.tofile(f)
 
     def write_file(self, event_id, offset, event_size):
         """Write data to output Footprint index file in binary format.
@@ -386,6 +498,7 @@ class FootprintBinFile(ModelFile):
         self.offset = 0
         for stat in self.start_stats:
             self.offset += struct.calcsize(stat['dtype'])
+        self.initial_offset = self.offset
 
     def generate_data(self):
         """Generate Footprint binary dummy model file data.
@@ -438,6 +551,74 @@ class FootprintBinFile(ModelFile):
 
             self.idx_file.write_file(event + 1, self.offset, event_size)
             self.offset += event_size
+
+    def generate_arrays(self):
+        """Generate Footprint binary dummy model file data.
+
+        The areaperils of an event are drawn together, and the intensities of each of those
+        areaperils in blocks of num_intensity_bins, so an event's intensities can be drawn in
+        one go without changing which numbers come from the generator. The event index is
+        collected as the events are generated, for write_file to write afterwards.
+
+        Yields:
+            numpy.ndarray: rows of footprint data for one event, in the file's dtype
+        """
+        super().seed_rng()
+        self.offset = self.initial_offset
+        self.index = np.empty(self.num_events, dtype=self.idx_file.array_dtype)
+        intensity_bins = np.arange(1, self.num_intensity_bins + 1)
+
+        for event in range(self.num_events):
+            if self.areaperils_per_event == self.num_areaperils:
+                selected_areaperils = np.arange(1, self.num_areaperils + 1)
+            else:
+                selected_areaperils = np.random.choice(
+                    self.num_areaperils, self.areaperils_per_event,
+                    replace=False
+                )
+                selected_areaperils += 1
+                selected_areaperils = np.sort(selected_areaperils)
+
+            if self.no_intensity_uncertainty:
+                impacted_areaperils = self.areaperils_per_event
+                areaperil_id = selected_areaperils
+                intensity_bin_id = np.random.randint(
+                    1, self.num_intensity_bins + 1, size=self.areaperils_per_event
+                )
+                probability = np.ones(self.areaperils_per_event)
+            else:
+                # Generate probabalities according to intensity sparseness
+                # and normalise
+                draws = np.random.uniform(size=(self.areaperils_per_event, 2, self.num_intensity_bins))
+                probabilities = np.where(draws[:, 0, :] < self.intensity_sparseness, draws[:, 1, :], 0.0)
+
+                total_probability = probabilities.sum(axis=1)
+                impacted = total_probability != 0   # areaperils with no impacted intensity bin
+                probabilities = probabilities[impacted] / total_probability[impacted, np.newaxis]
+
+                impacted_areaperils = probabilities.shape[0]
+                areaperil_id = np.repeat(selected_areaperils[impacted], self.num_intensity_bins)
+                intensity_bin_id = np.tile(intensity_bins, impacted_areaperils)
+                probability = probabilities.reshape(-1)
+
+            event_data = np.empty(len(areaperil_id), dtype=self.array_dtype)
+            event_data['areaperil_id'] = areaperil_id
+            event_data['intensity_bin_id'] = intensity_bin_id
+            event_data['probability'] = probability
+
+            event_size = self.size * impacted_areaperils
+            self.index[event] = (event + 1, self.offset, event_size)
+            self.offset += event_size
+            yield event_data
+
+    def write_file(self):
+        """Write data to output Footprint binary file, and its index file, in binary format.
+
+        The index is only known once the events have been generated, so it is written after the
+        binary file rather than as each event is generated.
+        """
+        super().write_file()
+        self.idx_file.write_array(self.index)
 
 
 class DamageBinDictFile(ModelFile):
@@ -676,6 +857,19 @@ class RandomFile(ModelFile):
         # First random number is 0
         return (tuple([np.random.uniform()]) if i != 0 else (0,) for i in range(self.num_randoms))
 
+    def generate_arrays(self):
+        """Generate Random Numbers dummy model file data.
+
+        Yields:
+            numpy.ndarray: rows of random numbers, in the file's dtype
+        """
+        super().seed_rng()
+        randoms = np.empty(self.num_randoms, dtype=self.array_dtype)
+        # First random number is 0
+        randoms['random_no'][:1] = 0
+        randoms['random_no'][1:] = np.random.uniform(size=max(0, self.num_randoms - 1))
+        yield randoms
+
 
 class CoveragesFile(ModelFile):
     """Generate data for Coverages dummy model Oasis file.
@@ -718,6 +912,17 @@ class CoveragesFile(ModelFile):
                 self.num_locations * self.coverages_per_location
             )
         )
+
+    def generate_arrays(self):
+        """Generate Coverages dummy model file data.
+
+        Yields:
+            numpy.ndarray: rows of coverage data, in the file's dtype
+        """
+        super().seed_rng()
+        coverages = np.empty(self.num_locations * self.coverages_per_location, dtype=self.array_dtype)
+        coverages['tiv'] = np.random.uniform(1, 1000000, size=len(coverages))
+        yield coverages
 
 
 class ItemsFile(ModelFile):
@@ -782,6 +987,39 @@ class ItemsFile(ModelFile):
                 # Assume group ID mapped to location
                 yield item, item, areaperils[coverage], vulnerabilities[coverage], location + 1
 
+    def generate_arrays(self):
+        """Generate Items dummy model file data.
+
+        The areaperils and vulnerabilities of a location are drawn from different ranges, and the
+        two draws alternate per location, so they have to stay in that order to take the same
+        numbers from the generator. Only the ids and the packing are built with numpy.
+
+        Yields:
+            numpy.ndarray: rows of item data, in the file's dtype
+        """
+        super().seed_rng()
+        shape = (self.num_locations, self.coverages_per_location)
+        areaperils = np.empty(shape, dtype='int64')
+        vulnerabilities = np.empty(shape, dtype='int64')
+
+        for location in range(self.num_locations):
+            areaperils[location] = np.random.randint(
+                1, self.num_areaperils + 1, size=self.coverages_per_location
+            )
+            vulnerabilities[location] = np.random.randint(
+                1, self.num_vulnerabilities + 1, size=self.coverages_per_location
+            )
+
+        items = np.empty(self.num_locations * self.coverages_per_location, dtype=self.array_dtype)
+        # Assume 1-1 mapping between item and coverage IDs
+        items['item_id'] = np.arange(1, len(items) + 1)
+        items['coverage_id'] = items['item_id']
+        items['areaperil_id'] = areaperils.reshape(-1)
+        items['vulnerability_id'] = vulnerabilities.reshape(-1)
+        # Assume group ID mapped to location
+        items['group_id'] = np.repeat(np.arange(1, self.num_locations + 1), self.coverages_per_location)
+        yield items
+
 
 class AmplificationsFile(ModelFile):
     """Generate data for Amplifications dummy model Oasis file.
@@ -829,6 +1067,20 @@ class AmplificationsFile(ModelFile):
         for item in range(self.num_items):
             amplification = np.random.randint(1, self.num_amplifications + 1)
             yield item + 1, amplification
+
+    def generate_arrays(self):
+        """Generate Amplifications dummy model Oasis file data.
+
+        Yields:
+            numpy.ndarray: rows of amplification data, in the file's dtype
+        """
+        super().seed_rng()
+        amplifications = np.empty(self.num_items, dtype=self.array_dtype)
+        amplifications['item_id'] = np.arange(1, self.num_items + 1)
+        amplifications['amplification_id'] = np.random.randint(
+            1, self.num_amplifications + 1, size=self.num_items
+        )
+        yield amplifications
 
     def write_file(self):
         """Write data to output Amplifications file in binary format.
@@ -902,6 +1154,22 @@ class FMProgrammeFile(FMFile):
                 elif level == len(levels):
                     yield agg_id, level, 1
 
+    def generate_arrays(self):
+        """Generate Financial Model Programme dummy model file data.
+
+        Yields:
+            numpy.ndarray: rows of programme data, in the file's dtype
+        """
+        num_aggs = self.num_locations * self.coverages_per_location
+        agg_id = np.arange(1, num_aggs + 1)
+
+        programme = np.empty(num_aggs * 2, dtype=self.array_dtype)   # 2 from number of levels
+        programme['from_agg_id'] = np.tile(agg_id, 2)
+        programme['level_id'] = np.repeat([1, 2], num_aggs)
+        # Site coverage FM level aggregates to itself, policy layer FM level to the programme
+        programme['to_agg_id'] = np.concatenate([agg_id, np.ones(num_aggs, dtype='int64')])
+        yield programme
+
 
 class FMPolicyTCFile(FMFile):
     """Generate data for Financial Model Policy dummy model Oasis file.
@@ -961,6 +1229,27 @@ class FMPolicyTCFile(FMFile):
                 for layer in range(self.num_layers):
                     yield level, 1, layer + 1, profile_id
                     profile_id += 1   # Next profile_id
+
+    def generate_arrays(self):
+        """Generate Financial Model Policy dummy model file data.
+
+        Yields:
+            numpy.ndarray: rows of policy data, in the file's dtype
+        """
+        num_aggs = self.num_locations * self.coverages_per_location
+
+        policytc = np.empty(num_aggs + self.num_layers, dtype=self.array_dtype)
+        # Site coverage FM level, one layer sharing the first profile
+        policytc['level_id'][:num_aggs] = 1
+        policytc['agg_id'][:num_aggs] = np.arange(1, num_aggs + 1)
+        policytc['layer_id'][:num_aggs] = 1
+        policytc['profile_id'][:num_aggs] = 1
+        # Policy layer FM level, a profile per layer
+        policytc['level_id'][num_aggs:] = 2
+        policytc['agg_id'][num_aggs:] = 1
+        policytc['layer_id'][num_aggs:] = np.arange(1, self.num_layers + 1)
+        policytc['profile_id'][num_aggs:] = np.arange(2, self.num_layers + 2)
+        yield policytc
 
 
 class FMProfileFile(ModelFile):
@@ -1078,6 +1367,20 @@ class FMXrefFile(FMFile):
                 yield output_count, agg_id, layer
                 output_count += 1
 
+    def generate_arrays(self):
+        """Generate Financial Model Cross Reference dummy model file data.
+
+        Yields:
+            numpy.ndarray: rows of cross reference data, in the file's dtype
+        """
+        num_aggs = self.num_locations * self.coverages_per_location
+
+        xref = np.empty(num_aggs * self.num_layers, dtype=self.array_dtype)
+        xref['output'] = np.arange(1, len(xref) + 1)
+        xref['agg_id'] = np.repeat(np.arange(1, num_aggs + 1), self.num_layers)
+        xref['layer_id'] = np.tile(np.arange(1, self.num_layers + 1), num_aggs)
+        yield xref
+
 
 class GULSummaryXrefFile(FMFile):
     """Generate data for Ground Up Losses Summary Cross Reference dummy model Oasis
@@ -1118,6 +1421,18 @@ class GULSummaryXrefFile(FMFile):
         summaryset_id = 1
         for item in range(self.num_locations * self.coverages_per_location):
             yield item + 1, summary_id, summaryset_id
+
+    def generate_arrays(self):
+        """Generate Ground Up Losses Summary Cross Reference dummy model file data.
+
+        Yields:
+            numpy.ndarray: rows of summary cross reference data, in the file's dtype
+        """
+        summary_xref = np.empty(self.num_locations * self.coverages_per_location, dtype=self.array_dtype)
+        summary_xref['item_id'] = np.arange(1, len(summary_xref) + 1)
+        summary_xref['summary_id'] = 1
+        summary_xref['summaryset_id'] = 1
+        yield summary_xref
 
 
 class FMSummaryXrefFile(FMFile):
@@ -1165,3 +1480,16 @@ class FMSummaryXrefFile(FMFile):
             self.num_locations * self.coverages_per_location * self.num_layers
         ):
             yield output_id + 1, summary_id, summaryset_id
+
+    def generate_arrays(self):
+        """Generate Financial Model Summary Cross Reference dummy model file data.
+
+        Yields:
+            numpy.ndarray: rows of summary cross reference data, in the file's dtype
+        """
+        summary_xref = np.empty(
+            self.num_locations * self.coverages_per_location * self.num_layers, dtype=self.array_dtype)
+        summary_xref['output_id'] = np.arange(1, len(summary_xref) + 1)
+        summary_xref['summary_id'] = 1
+        summary_xref['summaryset_id'] = 1
+        yield summary_xref

--- a/oasislmf/computation/data/dummy_model/generate.py
+++ b/oasislmf/computation/data/dummy_model/generate.py
@@ -560,13 +560,21 @@ class FootprintBinFile(ModelFile):
         one go without changing which numbers come from the generator. The event index is
         collected as the events are generated, for write_file to write afterwards.
 
+        A whole event is the largest thing this file generates, and it is unbounded in
+        areaperils_per_event x num_intensity_bins, so the areaperils of an event are taken in
+        chunks rather than all at once. The draws stay contiguous per areaperil, so chunking
+        takes the same numbers from the generator as drawing the event in one go, and an event
+        is simply yielded as more than one array.
+
         Yields:
-            numpy.ndarray: rows of footprint data for one event, in the file's dtype
+            numpy.ndarray: rows of footprint data for part of one event, in the file's dtype
         """
         super().seed_rng()
         self.offset = self.initial_offset
         self.index = np.empty(self.num_events, dtype=self.idx_file.array_dtype)
         intensity_bins = np.arange(1, self.num_intensity_bins + 1)
+        rows_per_areaperil = 1 if self.no_intensity_uncertainty else self.num_intensity_bins
+        areaperils_per_chunk = max(1, CHUNK_ROWS // rows_per_areaperil)
 
         for event in range(self.num_events):
             if self.areaperils_per_event == self.num_areaperils:
@@ -579,37 +587,42 @@ class FootprintBinFile(ModelFile):
                 selected_areaperils += 1
                 selected_areaperils = np.sort(selected_areaperils)
 
-            if self.no_intensity_uncertainty:
-                impacted_areaperils = self.areaperils_per_event
-                areaperil_id = selected_areaperils
-                intensity_bin_id = np.random.randint(
-                    1, self.num_intensity_bins + 1, size=self.areaperils_per_event
-                )
-                probability = np.ones(self.areaperils_per_event)
-            else:
-                # Generate probabalities according to intensity sparseness
-                # and normalise
-                draws = np.random.uniform(size=(self.areaperils_per_event, 2, self.num_intensity_bins))
-                probabilities = np.where(draws[:, 0, :] < self.intensity_sparseness, draws[:, 1, :], 0.0)
+            event_size = 0
+            for start in range(0, self.areaperils_per_event, areaperils_per_chunk):
+                chunk_areaperils = selected_areaperils[start:start + areaperils_per_chunk]
 
-                total_probability = probabilities.sum(axis=1)
-                impacted = total_probability != 0   # areaperils with no impacted intensity bin
-                probabilities = probabilities[impacted] / total_probability[impacted, np.newaxis]
+                if self.no_intensity_uncertainty:
+                    impacted_areaperils = len(chunk_areaperils)
+                    areaperil_id = chunk_areaperils
+                    intensity_bin_id = np.random.randint(
+                        1, self.num_intensity_bins + 1, size=impacted_areaperils
+                    )
+                    probability = np.ones(impacted_areaperils)
+                else:
+                    # Generate probabalities according to intensity sparseness
+                    # and normalise
+                    draws = np.random.uniform(size=(len(chunk_areaperils), 2, self.num_intensity_bins))
+                    probabilities = np.where(draws[:, 0, :] < self.intensity_sparseness, draws[:, 1, :], 0.0)
 
-                impacted_areaperils = probabilities.shape[0]
-                areaperil_id = np.repeat(selected_areaperils[impacted], self.num_intensity_bins)
-                intensity_bin_id = np.tile(intensity_bins, impacted_areaperils)
-                probability = probabilities.reshape(-1)
+                    total_probability = probabilities.sum(axis=1)
+                    impacted = total_probability != 0   # areaperils with no impacted intensity bin
+                    probabilities = probabilities[impacted] / total_probability[impacted, np.newaxis]
 
-            event_data = np.empty(len(areaperil_id), dtype=self.array_dtype)
-            event_data['areaperil_id'] = areaperil_id
-            event_data['intensity_bin_id'] = intensity_bin_id
-            event_data['probability'] = probability
+                    impacted_areaperils = probabilities.shape[0]
+                    areaperil_id = np.repeat(chunk_areaperils[impacted], self.num_intensity_bins)
+                    intensity_bin_id = np.tile(intensity_bins, impacted_areaperils)
+                    probability = probabilities.reshape(-1)
 
-            event_size = self.size * impacted_areaperils
+                event_data = np.empty(len(areaperil_id), dtype=self.array_dtype)
+                event_data['areaperil_id'] = areaperil_id
+                event_data['intensity_bin_id'] = intensity_bin_id
+                event_data['probability'] = probability
+
+                event_size += self.size * impacted_areaperils
+                yield event_data
+
             self.index[event] = (event + 1, self.offset, event_size)
             self.offset += event_size
-            yield event_data
 
     def write_file(self):
         """Write data to output Footprint binary file, and its index file, in binary format.

--- a/tests/computation/test_dummy_model_generate.py
+++ b/tests/computation/test_dummy_model_generate.py
@@ -5,6 +5,7 @@ import struct
 import numpy as np
 import pytest
 
+from oasislmf.computation.data.dummy_model import generate
 from oasislmf.computation.data.dummy_model.generate import (AmplificationsFile, CoveragesFile,
                                                             DamageBinDictFile, EventsFile,
                                                             FMPolicyTCFile, FMProfileFile,
@@ -138,6 +139,46 @@ def test_footprint_index_matches_the_rows_written_per_event(tmp_path):
     )
     np.testing.assert_array_equal(
         index['offset'], footprint.initial_offset + np.cumsum([0] + [event.nbytes for event in events[:-1]])
+    )
+
+
+@pytest.mark.parametrize('chunk_rows', [1, 2, 3, 7, 13])
+@pytest.mark.parametrize('no_intensity_uncertainty', [False, True])
+def test_footprint_chunking_does_not_change_the_output(chunk_rows, no_intensity_uncertainty, monkeypatch, tmp_path):
+    """Taking an event's areaperils in chunks takes the same numbers from the generator.
+
+    An event is unbounded in areaperils_per_event x num_intensity_bins, so it is generated in
+    chunks rather than all at once. The draws stay contiguous per areaperil, so the rows must come
+    out identical however the chunk boundaries fall, and the index must still describe whole events.
+    """
+    # more areaperils than the largest chunk size, so every parametrisation really does chunk
+    settings = {'no_intensity_uncertainty': no_intensity_uncertainty, 'num_areaperils': 30,
+                'areaperils_per_event': 30, 'num_intensity_bins': 4}
+    unchunked = model_files(tmp_path, **settings)['footprint']
+    expected = arrays_of(unchunked)
+
+    monkeypatch.setattr(generate, 'CHUNK_ROWS', chunk_rows)
+    chunked = model_files(tmp_path, **settings)['footprint']
+    generated = arrays_of(chunked)
+
+    np.testing.assert_array_equal(generated, expected)
+    np.testing.assert_array_equal(chunked.index, unchunked.index)
+    # the chunking is real: the event is yielded as more than one array
+    assert len(list(model_files(tmp_path, **settings)['footprint'].generate_arrays())) > unchunked.num_events
+
+
+def test_footprint_index_describes_whole_events_when_chunked(monkeypatch, tmp_path):
+    """The index holds one entry per event, sized for the whole event, not per chunk."""
+    monkeypatch.setattr(generate, 'CHUNK_ROWS', 2)
+    footprint = model_files(tmp_path, num_areaperils=12, areaperils_per_event=12)['footprint']
+    chunks = list(footprint.generate_arrays())
+
+    index = footprint.index
+    assert len(index) == footprint.num_events < len(chunks)
+    np.testing.assert_array_equal(index['event_id'], np.arange(1, footprint.num_events + 1))
+    assert index['size'].sum() == sum(chunk.nbytes for chunk in chunks)
+    np.testing.assert_array_equal(
+        index['offset'], footprint.initial_offset + np.cumsum(np.append(0, index['size'][:-1]))
     )
 
 

--- a/tests/computation/test_dummy_model_generate.py
+++ b/tests/computation/test_dummy_model_generate.py
@@ -1,6 +1,8 @@
 """Pin the array generation of the dummy model files against the row by row generation."""
 
+import os
 import struct
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -182,12 +184,67 @@ def test_footprint_index_describes_whole_events_when_chunked(monkeypatch, tmp_pa
     )
 
 
+def test_footprint_with_no_events_writes_a_header_and_an_empty_index(tmp_path):
+    """A footprint with no events still writes both files, the index simply holding no records.
+
+    The row by row version only ever opened footprint.idx from inside the per event loop, so with
+    no events it left no index file at all -- and a footprint with no index is not readable, where
+    an empty one is well formed. This is the single case where the array output is not byte for
+    byte what the row output was, so it is pinned rather than left to be rediscovered.
+    """
+    footprint = model_files(tmp_path, num_events=0)['footprint']
+    footprint.write_file()
+
+    idx_path = Path(footprint.idx_file.file_name)
+    assert idx_path.exists()
+    assert np.fromfile(idx_path, dtype=footprint.idx_file.array_dtype).size == 0
+    assert len(footprint.index) == 0
+
+    # the bin file is the 8 byte header and nothing else
+    start_stats_size = sum(struct.calcsize(stat['dtype']) for stat in footprint.start_stats or [])
+    assert os.path.getsize(footprint.file_name) == start_stats_size
+    assert np.fromfile(footprint.file_name, dtype=footprint.array_dtype,
+                       offset=start_stats_size).size == 0
+
+
 def test_footprint_index_written_to_file(tmp_path):
     footprint = model_files(tmp_path)['footprint']
     footprint.write_file()
 
     written = np.fromfile(footprint.idx_file.file_name, dtype=footprint.idx_file.array_dtype)
     np.testing.assert_array_equal(written, footprint.index)
+
+
+@pytest.mark.parametrize('file_name', FILE_NAMES)
+def test_array_dtype_is_packed_like_the_struct_format(file_name, tmp_path):
+    """Every row written as an array occupies exactly the bytes its struct format declares.
+
+    The files are read back by struct format characters, so the dtype has to stay packed. Building
+    it with align=True, or adding a format character to STRUCT_TO_NUMPY_FORMAT whose numpy width
+    does not match, would insert padding and shift every field after it -- producing a file of
+    plausible size that no assertion on the generated rows would notice.
+    """
+    model_file = model_files(tmp_path)[file_name]
+    array_dtype = model_file.array_dtype
+
+    assert array_dtype.itemsize == struct.calcsize('=' + ''.join(model_file.dtypes.values()))
+    assert array_dtype.names == tuple(model_file.dtypes)
+    # no gaps: each field starts where the previous one ended
+    offsets = [array_dtype.fields[name][1] for name in array_dtype.names]
+    widths = [array_dtype.fields[name][0].itemsize for name in array_dtype.names]
+    assert offsets == list(np.cumsum([0] + widths[:-1]))
+
+
+def test_footprint_index_dtype_is_packed_like_the_struct_format(tmp_path):
+    """The index record is 20 bytes, not the 24 an aligned dtype would give it.
+
+    getmodel reads footprint.idx with EventIndexBin_dtype, so a padded record here would be
+    silently misread rather than rejected.
+    """
+    idx_file = model_files(tmp_path)['footprint'].idx_file
+
+    assert idx_file.array_dtype.itemsize == struct.calcsize('=' + ''.join(idx_file.dtypes.values()))
+    assert idx_file.array_dtype.itemsize == 20
 
 
 @pytest.mark.parametrize('file_name', FILE_NAMES)

--- a/tests/computation/test_dummy_model_generate.py
+++ b/tests/computation/test_dummy_model_generate.py
@@ -1,0 +1,162 @@
+"""Pin the array generation of the dummy model files against the row by row generation."""
+
+import struct
+
+import numpy as np
+import pytest
+
+from oasislmf.computation.data.dummy_model.generate import (AmplificationsFile, CoveragesFile,
+                                                            DamageBinDictFile, EventsFile,
+                                                            FMPolicyTCFile, FMProfileFile,
+                                                            FMProgrammeFile, FMSummaryXrefFile,
+                                                            FMXrefFile, FootprintBinFile,
+                                                            GULSummaryXrefFile, ItemsFile,
+                                                            LossFactorsFile, OccurrenceFile,
+                                                            RandomFile, VulnerabilityFile)
+
+RANDOM_SEED = -1
+
+
+def model_files(directory, **kwargs):
+    """Build every dummy model file class, at a size that exercises more than one chunk."""
+    settings = {
+        'num_vulnerabilities': 5, 'num_intensity_bins': 4, 'num_damage_bins': 6,
+        'vulnerability_sparseness': 0.6, 'num_events': 7, 'num_areaperils': 8,
+        'areaperils_per_event': 8, 'intensity_sparseness': 0.7, 'no_intensity_uncertainty': False,
+        'num_periods': 20, 'num_locations': 9, 'coverages_per_location': 3, 'num_layers': 2,
+        'num_amplifications': 4, 'min_pla_factor': 0.875, 'max_pla_factor': 1.5, 'num_randoms': 11,
+        **kwargs,
+    }
+    seed, out = RANDOM_SEED, str(directory)
+
+    return {
+        'vulnerability': VulnerabilityFile(
+            settings['num_vulnerabilities'], settings['num_intensity_bins'],
+            settings['num_damage_bins'], settings['vulnerability_sparseness'], seed, out),
+        'events': EventsFile(settings['num_events'], out),
+        'footprint': FootprintBinFile(
+            settings['num_events'], settings['num_areaperils'], settings['areaperils_per_event'],
+            settings['num_intensity_bins'], settings['intensity_sparseness'],
+            settings['no_intensity_uncertainty'], seed, out),
+        'damage_bin_dict': DamageBinDictFile(settings['num_damage_bins'], out),
+        'occurrence': OccurrenceFile(
+            settings['num_events'], settings['num_periods'], seed, out, mean=2, stddev=1.0),
+        'loss_factors': LossFactorsFile(
+            settings['num_events'], settings['num_amplifications'], settings['min_pla_factor'],
+            settings['max_pla_factor'], seed, out),
+        'random': RandomFile(settings['num_randoms'], seed, out),
+        'coverages': CoveragesFile(
+            settings['num_locations'], settings['coverages_per_location'], seed, out),
+        'items': ItemsFile(
+            settings['num_locations'], settings['coverages_per_location'],
+            settings['num_areaperils'], settings['num_vulnerabilities'], seed, out),
+        'amplifications': AmplificationsFile(
+            settings['num_locations'], settings['coverages_per_location'],
+            settings['num_amplifications'], seed, out),
+        'gulsummaryxref': GULSummaryXrefFile(
+            settings['num_locations'], settings['coverages_per_location'], out),
+        'fm_programme': FMProgrammeFile(
+            settings['num_locations'], settings['coverages_per_location'], out),
+        'fm_policytc': FMPolicyTCFile(
+            settings['num_locations'], settings['coverages_per_location'], settings['num_layers'], out),
+        'fm_profile': FMProfileFile(settings['num_layers'], out),
+        'fm_xref': FMXrefFile(
+            settings['num_locations'], settings['coverages_per_location'], settings['num_layers'], out),
+        'fmsummaryxref': FMSummaryXrefFile(
+            settings['num_locations'], settings['coverages_per_location'], settings['num_layers'], out),
+    }
+
+
+def rows_of(model_file):
+    """Pack the rows from the row by row generation into the file's dtype."""
+    return np.fromiter(model_file.generate_data(), dtype=model_file.array_dtype)
+
+
+def arrays_of(model_file):
+    return np.concatenate(list(model_file.generate_arrays()))
+
+
+FILE_NAMES = list(model_files('.'))
+
+
+@pytest.mark.parametrize('file_name', FILE_NAMES)
+def test_arrays_match_rows(file_name, tmp_path):
+    # a fresh object per path, as generating the data advances the footprint file's offset
+    expected = rows_of(model_files(tmp_path)[file_name])
+    generated = arrays_of(model_files(tmp_path)[file_name])
+
+    assert generated.dtype == expected.dtype
+    np.testing.assert_array_equal(generated, expected)
+
+
+@pytest.mark.parametrize('file_name', FILE_NAMES)
+def test_arrays_match_rows_over_several_chunks(file_name, tmp_path):
+    # enough vulnerabilities and events that the chunked generators yield more than once
+    sizes = {'num_damage_bins': 400, 'num_events': 300, 'num_amplifications': 5000}
+    expected = rows_of(model_files(tmp_path, **sizes)[file_name])
+    generated = arrays_of(model_files(tmp_path, **sizes)[file_name])
+
+    np.testing.assert_array_equal(generated, expected)
+
+
+@pytest.mark.parametrize('sparseness', [0.0, 0.5, 1.0])
+def test_vulnerability_matches_rows_at_any_sparseness(sparseness, tmp_path):
+    # 0.0 leaves every vulnerability with no impacted bin, taking the zero-loss fallback
+    settings = {'vulnerability_sparseness': sparseness}
+    expected = rows_of(model_files(tmp_path, **settings)['vulnerability'])
+    generated = arrays_of(model_files(tmp_path, **settings)['vulnerability'])
+
+    np.testing.assert_array_equal(generated, expected)
+
+
+@pytest.mark.parametrize('sparseness', [0.0, 0.5, 1.0])
+@pytest.mark.parametrize('no_intensity_uncertainty', [False, True])
+@pytest.mark.parametrize('areaperils_per_event', [4, 8])
+def test_footprint_matches_rows(sparseness, no_intensity_uncertainty, areaperils_per_event, tmp_path):
+    settings = {
+        'intensity_sparseness': sparseness,
+        'no_intensity_uncertainty': no_intensity_uncertainty,
+        'areaperils_per_event': areaperils_per_event,
+    }
+    expected = rows_of(model_files(tmp_path, **settings)['footprint'])
+    generated = arrays_of(model_files(tmp_path, **settings)['footprint'])
+
+    np.testing.assert_array_equal(generated, expected)
+
+
+def test_footprint_index_matches_the_rows_written_per_event(tmp_path):
+    footprint = model_files(tmp_path)['footprint']
+    events = list(footprint.generate_arrays())
+
+    index = footprint.index
+    assert len(index) == footprint.num_events
+    np.testing.assert_array_equal(index['event_id'], np.arange(1, footprint.num_events + 1))
+    # every event's data sits at the offset the index gives, and is as long as it claims
+    assert index['offset'][0] == footprint.initial_offset
+    np.testing.assert_array_equal(
+        index['size'], [event.nbytes for event in events]
+    )
+    np.testing.assert_array_equal(
+        index['offset'], footprint.initial_offset + np.cumsum([0] + [event.nbytes for event in events[:-1]])
+    )
+
+
+def test_footprint_index_written_to_file(tmp_path):
+    footprint = model_files(tmp_path)['footprint']
+    footprint.write_file()
+
+    written = np.fromfile(footprint.idx_file.file_name, dtype=footprint.idx_file.array_dtype)
+    np.testing.assert_array_equal(written, footprint.index)
+
+
+@pytest.mark.parametrize('file_name', FILE_NAMES)
+def test_written_file_holds_the_generated_rows(file_name, tmp_path):
+    model_file = model_files(tmp_path)[file_name]
+    model_file.write_file()
+
+    expected = arrays_of(model_files(tmp_path)[file_name])
+    start_stats_size = sum(struct.calcsize(stat['dtype']) for stat in model_file.start_stats or [])
+    written = np.fromfile(model_file.file_name, dtype=model_file.array_dtype,
+                          offset=start_stats_size)
+
+    np.testing.assert_array_equal(written, expected)


### PR DESCRIPTION
Part of #2100.

The dummy model generators built their files a row at a time, packing each row with
`struct.pack` and writing it. This generates each file as numpy arrays instead, in chunks, and
writes the chunks straight out with `ndarray.tofile`.

## Performance

`FootprintBinFile` at 100 events × 400 areaperils × 25 intensity bins: **15.18 s → 0.07 s (216x)**,
files identical.

## Output is byte-for-byte identical

Every generator keeps its row-by-row `generate_data` as the reference implementation, and
`tests/computation/test_dummy_model_generate.py` pins the array path against it per file class,
including dtype. This is the whole correctness argument, so it is worth being precise about what
holds it up:

- The chunk boundaries never move the RNG stream. Each generator draws in blocks whose shape keeps
  the per-item draws contiguous, so drawing N items at once takes the same numbers from the
  generator as drawing them one at a time.
- `array_dtype` builds a **packed** dtype, matching `struct.pack('=iqq')` and the reader's
  `EventIndexBin_dtype` in `oasislmf/pytools/getmodel/common.py`. `align=True` would silently give
  24-byte index records instead of 20.
- `ItemsFile` and `OccurrenceFile` keep their per-row draw order. `ItemsFile` does get a
  `generate_arrays`, but its areaperil and vulnerability draws alternate per location and are
  bounded differently, so only the assembly is vectorised and the draws themselves stay per
  location. `OccurrenceFile` keeps row-by-row generation entirely — its row count per event is
  itself random — and is assembled whole by the base class `np.fromiter`. They are the residual
  hot spots.

One caveat to "byte for byte identical": with `num_events=0` the footprint now produces an empty
`footprint.idx`, where before no idx file was created at all. A footprint with no index file is not
readable; an empty index is at least well-formed, so this is kept rather than restored.

## Memory

`CHUNK_ROWS` bounds how many rows are built before being written. `FootprintBinFile` is the only
file that gets genuinely large, and its peak memory is unbounded in
`areaperils_per_event × num_intensity_bins` unless the chunking also applies *within* an event —
the draws alone are `(areaperils_per_event, 2, num_intensity_bins)` float64, roughly 68 bytes of
transient RAM per output row against 12 bytes on disk.

So an event is taken in chunks of areaperils rather than all at once, and the index entry is
written once the last chunk of that event is done. Measured peak RSS, one event, sparseness 1.0:

| areaperils | bins | rows | footprint.bin | peak RSS before | peak RSS after |
|---|---|---|---|---|---|
| 50,000 | 20 | 1.0M | 11.4 MB | 83.8 MB | 85.1 MB |
| 200,000 | 20 | 4.0M | 45.8 MB | 236.4 MB | 121.9 MB |
| 500,000 | 20 | 10.0M | 114.4 MB | 544.6 MB | 131.9 MB |

`oasislmf test generate-model-files -a 2000000 -i 50` — 2M areaperils, 50 intensity bins, all
reachable through documented CLI flags — extrapolates to roughly 5.4 GB unchunked, an OOM kill on a
4 GB runner. It now writes its 1.1 GB `footprint.bin` in **152.8 MB** of peak RSS.

I verified the chunking is stream-neutral over 144 configurations (sparseness 0.0/0.3/0.7/1.0 ×
`no_intensity_uncertainty` × `areaperils_per_event` above and below `num_areaperils` × 1/4/9
intensity bins × 0/1/5 events) crossed with `CHUNK_ROWS` forced to 1, 2, 3, 7, 13 and 10⁶ — 864
SHA-256 comparisons of `footprint.bin` and `footprint.idx` against the unchunked generator, zero
mismatches. `test_footprint_chunking_does_not_change_the_output` pins that with a `CHUNK_ROWS`
monkeypatch, and `test_footprint_index_describes_whole_events_when_chunked` pins that the index
still describes whole events rather than chunks.

### What is not bounded

`CHUNK_ROWS` is applied to three classes — `FootprintBinFile`, `VulnerabilityFile` and
`LossFactorsFile`. The other generators build the whole file in a single array, plus full-length
int64 `repeat`/`tile` temporaries, where the row path was constant-memory. On the portfolio side
that is a regression rather than an improvement:

| generator | inputs | file size | peak RSS before | peak RSS after |
|---|---|---|---|---|
| `FMXrefFile` | `-l 2000000 -c 4 --num-layers 3` (24M rows) | 288 MB | 30 MB | 549 MB |
| `ItemsFile` | `-l 2000000 -c 4` (8M rows) | 160 MB | 33 MB | 384 MB |
| `OccurrenceFile` | `-e 2000000` (2M rows) | 24 MB | 33 MB | 56 MB |

`-l 8000000 -c 4 --num-layers 3` extrapolates to roughly 2.7 GB for `fm_xref.bin` alone — an OOM
kill on the same 4 GB runner this section uses as its yardstick for the footprint, on a run that
previously peaked around 30 MB.

These are the easy cases to chunk: the ids are pure `arange`/`repeat`/`tile` with no RNG
involved, so they need no stream-order argument at all, just `CHUNK_ROWS` rows at a time with the
`arange` starts offset, exactly as `LossFactorsFile.generate_arrays` already does. `ItemsFile`
already loops over locations, so it only needs to yield every N locations rather than
accumulate. Follow-up rather than part of this PR — but the section above should not be read as
"peak memory is now bounded generally", because outside those three classes it is not.

## Also fixed

Re-running the generator into the same directory used to append to `footprint.idx` while
truncating `footprint.bin`, leaving a corrupt model — idx sizes went 100 → 200 → 300 bytes over
three runs of a 5-event footprint. `write_array` truncates, so it is now 100 → 100 → 100.

## Tests

`tests/computation/test_dummy_model_generate.py`, 76 tests. It parametrises over every `ModelFile`
subclass asserting `generate_arrays` equals `generate_data` including dtype, repeats over
multi-chunk sizes, sweeps sparseness and `no_intensity_uncertainty`, checks the footprint index
offsets against each event's `nbytes`, and round-trips every file back off disk with
`np.fromfile`. Retaining `generate_data` is what makes this possible — it is the executable
specification, not dead code, and `debug_write_file` still uses it.

