### PR TITLE
Array operations speedup

### DIFF
--- a/oasislmf/computation/run/exposure.py
+++ b/oasislmf/computation/run/exposure.py
@@ -304,8 +304,7 @@ class RunExposure(ComputationStep):
                         total_gul, total_il, total_ri_ceded)
 
             # Convert output cols to strings for formatting
-            for c in group_by_cols:
-                all_losses_df[c] = all_losses_df[c].apply(str)
+            all_losses_df[group_by_cols] = all_losses_df[group_by_cols].astype(str)
 
             if self.print_summary:
                 cols_to_print = all_loss_cols.copy()

--- a/oasislmf/computation/run/exposure.py
+++ b/oasislmf/computation/run/exposure.py
@@ -231,7 +231,7 @@ class RunExposure(ComputationStep):
         elif self.output_level == 'peril_item':
             summary_cols = ['output_id'] + lowest_id_cols + [policy_num, 'coverage_type_id', 'peril_id']
 
-        summary_cols += self.extra_summary_cols
+        summary_cols = list(dict.fromkeys(summary_cols + self.extra_summary_cols))
         for col in self.extra_summary_cols:
             if col in calculated_summary_cols:
                 all_losses_df = calculated_summary_cols[col](all_losses_df)

--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -1023,6 +1023,41 @@ def get_sub_step_trigger_types():
     })
 
 
+def assign_sub_step_trigger_types(level_df, step_filter):
+    """Split each step row's trigger type into its sub-type for that row's coverage type.
+
+    A StepTriggerType can cover several coverage types separately -- type 5 covers buildings and
+    contents apart from one another -- and the calc rule is looked up by the sub-type. A pair with
+    no sub-type keeps the trigger type it already has.
+
+    Args:
+        level_df (pandas.DataFrame): the FM level frame, with `steptriggertype` and
+            `coverage_type_id` columns. Modified in place.
+        step_filter (pandas.Series): boolean mask of the rows that are step rows
+
+    Returns:
+        pandas.DataFrame: `level_df`, with the step rows' `steptriggertype` replaced by its
+        sub-type wherever the (trigger type, coverage type) pair has one
+    """
+    step_rows = level_df.loc[step_filter, ['steptriggertype', 'coverage_type_id']]
+    sub_step_trigger_type = get_sub_step_trigger_types().reindex(pd.MultiIndex.from_frame(step_rows))
+    # positional throughout: level_df's index is not guaranteed unique, and reindexing onto a
+    # duplicated label would raise rather than assign
+    has_sub_type = sub_step_trigger_type.notna().to_numpy()
+    # reindexing onto a MultiIndex introduces NaN and so promotes the lookup to float64. sub-types
+    # are integers, and a float written into an object column would not match the integer key the
+    # calc rules table is merged on, so the integer is restored before the rows are combined
+    sub_types = sub_step_trigger_type.fillna(0).to_numpy().astype('int64')
+    replacement = np.where(has_sub_type, sub_types, step_rows['steptriggertype'].to_numpy())
+    # pd.array rather than ndarray.astype, because the column is a nullable Int32 in the real
+    # pipeline and numpy cannot interpret a pandas extension dtype. assigning an array rather
+    # than a Series keeps the assignment positional.
+    level_df.loc[step_filter, 'steptriggertype'] = pd.array(
+        replacement, dtype=level_df['steptriggertype'].dtype)
+
+    return level_df
+
+
 @oasis_log
 def assign_level_calcrule_and_profile_ids(level_df, level_id, factorize_key, profile_id_offset):
     """Assign calcrule_id and profile_id to a level's terms.
@@ -1052,13 +1087,7 @@ def assign_level_calcrule_and_profile_ids(level_df, level_id, factorize_key, pro
         # coverages are covered separately
         # For example, StepTriggerType = 5 covers buildings and contents separately
 
-        step_rows = level_df.loc[step_filter, ['steptriggertype', 'coverage_type_id']]
-        sub_step_trigger_type = get_sub_step_trigger_types().reindex(pd.MultiIndex.from_frame(step_rows))
-        # a trigger type with no sub-type for the row's coverage type keeps the trigger type it has
-        has_sub_type = sub_step_trigger_type.notna().to_numpy()
-        level_df.loc[step_rows.index[has_sub_type], 'steptriggertype'] = pd.Series(
-            sub_step_trigger_type.to_numpy()[has_sub_type],
-            index=step_rows.index[has_sub_type], dtype=level_df['steptriggertype'].dtype)
+        level_df = assign_sub_step_trigger_types(level_df, step_filter)
         final_step_filter = level_df['steptriggertype'] > 0
         # step part
         level_df.loc[final_step_filter, 'calcrule_id'] = get_calc_rule_ids(level_df[final_step_filter], calc_rule_type='step')

--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -1010,6 +1010,19 @@ def write_level_policytc_and_programme(gul_inputs_df, level_id, fm_policytc_bin,
                                                                header=False, chunksize=chunksize)
 
 
+def get_sub_step_trigger_types():
+    """Get the sub-step trigger type of every (step trigger type, coverage type) pair that has one.
+
+    Returns:
+        pandas.Series: sub-step trigger type, indexed by (steptriggertype, coverage_type_id)
+    """
+    return pd.Series({
+        (step_trigger_type, coverage_type_id): sub_step_trigger_type
+        for step_trigger_type, step_trigger_info in STEP_TRIGGER_TYPES.items()
+        for coverage_type_id, sub_step_trigger_type in step_trigger_info['sub_step_trigger_types'].items()
+    })
+
+
 @oasis_log
 def assign_level_calcrule_and_profile_ids(level_df, level_id, factorize_key, profile_id_offset):
     """Assign calcrule_id and profile_id to a level's terms.
@@ -1039,16 +1052,13 @@ def assign_level_calcrule_and_profile_ids(level_df, level_id, factorize_key, pro
         # coverages are covered separately
         # For example, StepTriggerType = 5 covers buildings and contents separately
 
-        def assign_sub_step_trigger_type(row):
-            try:
-                step_trigger_type = STEP_TRIGGER_TYPES[row['steptriggertype']]['sub_step_trigger_types'][
-                    row['coverage_type_id']]
-                return step_trigger_type
-            except KeyError:
-                return row['steptriggertype']
-        level_df.loc[step_filter, 'steptriggertype'] = level_df[step_filter].apply(
-            lambda row: assign_sub_step_trigger_type(row), axis=1
-        )
+        step_rows = level_df.loc[step_filter, ['steptriggertype', 'coverage_type_id']]
+        sub_step_trigger_type = get_sub_step_trigger_types().reindex(pd.MultiIndex.from_frame(step_rows))
+        # a trigger type with no sub-type for the row's coverage type keeps the trigger type it has
+        has_sub_type = sub_step_trigger_type.notna().to_numpy()
+        level_df.loc[step_rows.index[has_sub_type], 'steptriggertype'] = pd.Series(
+            sub_step_trigger_type.to_numpy()[has_sub_type],
+            index=step_rows.index[has_sub_type], dtype=level_df['steptriggertype'].dtype)
         final_step_filter = level_df['steptriggertype'] > 0
         # step part
         level_df.loc[final_step_filter, 'calcrule_id'] = get_calc_rule_ids(level_df[final_step_filter], calc_rule_type='step')

--- a/oasislmf/pytools/common/input_files.py
+++ b/oasislmf/pytools/common/input_files.py
@@ -7,7 +7,7 @@ import numpy as np
 from pathlib import Path
 
 from oasislmf.pytools.common.data import (
-    load_as_ndarray, nb_oasis_int,
+    areaperil_int, load_as_ndarray, nb_oasis_int,
     correlations_headers, correlations_dtype, coverages_headers,
     occurrence_dtype, occurrence_granular_dtype, periods_dtype, quantile_dtype,
     quantile_interval_dtype, returnperiods_dtype,
@@ -37,6 +37,26 @@ OCCURRENCE_FILE = "occurrence.bin"
 PERIODS_FILE = "periods.bin"
 QUANTILE_FILE = "quantile.bin"
 RETURNPERIODS_FILE = "returnperiods.bin"
+
+
+KEYS_DTYPE = np.dtype([('LocID', np.int32), ('PerilID', 'U3'), ('CoverageTypeID', np.int32),
+                       ('AreaPerilID', areaperil_int), ('VulnerabilityID', np.int32)])
+
+
+def filter_area_peril_id(keys_tb, peril_filter):
+    """Select the area perils a peril specific run covers.
+
+    Args:
+        keys_tb (numpy.ndarray): the keys table, in `KEYS_DTYPE`
+        peril_filter (iterable): the peril ids the run is restricted to
+
+    Returns:
+        numpy.ndarray: the distinct AreaPerilIDs of the keys rows whose PerilID is in
+        `peril_filter`, in ascending order. Empty rather than absent when nothing matches.
+    """
+    # peril_filter is listed because np.isin treats a bare string as a sequence of characters,
+    # and an empty keys table must still give an integer array for the indexing below to work
+    return np.unique(keys_tb['AreaPerilID'][np.isin(keys_tb['PerilID'], list(peril_filter))])
 
 
 @nb.njit(cache=True)

--- a/oasislmf/pytools/getmodel/footprint.py
+++ b/oasislmf/pytools/getmodel/footprint.py
@@ -666,9 +666,7 @@ class FootprintParquetDynamic(Footprint):
             df_footprint = df_footprint.groupby(
                 ['areaperil_id', 'intensity', 'return_period'], as_index=False
             )['probability'].sum()
-            df_footprint['probability'] = df_footprint.groupby('areaperil_id')['probability'].transform(
-                lambda x: x / x.sum()
-            )
+            df_footprint['probability'] /= df_footprint.groupby('areaperil_id')['probability'].transform('sum')
             df_footprint = df_footprint.sort_values(['areaperil_id', 'intensity'], ascending=[True, False])
 
             df_footprint['intensity_bin_id'] = 0

--- a/oasislmf/pytools/gul/structure.py
+++ b/oasislmf/pytools/gul/structure.py
@@ -12,8 +12,8 @@ import os
 
 import numpy as np
 from oasis_data_manager.filestore.config import get_storage_from_config_path
-from oasislmf.pytools.common.data import areaperil_int, correlations_dtype, load_as_ndarray
-from oasislmf.pytools.common.input_files import read_coverages, read_correlations
+from oasislmf.pytools.common.data import correlations_dtype, load_as_ndarray
+from oasislmf.pytools.common.input_files import KEYS_DTYPE, filter_area_peril_id, read_coverages, read_correlations
 from oasislmf.pytools.getmodel.manager import get_damage_bins
 from oasislmf.pytools.gul.common import coverage_type
 from oasislmf.pytools.gul.manager import gul_get_items, generate_item_map
@@ -85,11 +85,8 @@ def build_structures(run_dir, ignore_file_type, peril_filter):
     # --- items + peril filter --------------------------------------------------
     logger.debug('import items')
     if peril_filter:
-        keys_dtype = np.dtype([('LocID', np.int32), ('PerilID', 'U3'), ('CoverageTypeID', np.int32),
-                               ('AreaPerilID', areaperil_int), ('VulnerabilityID', np.int32)])
-        keys_tb = load_as_ndarray(input_path, 'keys', keys_dtype)
-        mask = np.isin(keys_tb['PerilID'], list(peril_filter))
-        valid_area_peril_id = np.unique(keys_tb['AreaPerilID'][mask])
+        keys_tb = load_as_ndarray(input_path, 'keys', KEYS_DTYPE)
+        valid_area_peril_id = filter_area_peril_id(keys_tb, peril_filter)
         logger.debug(
             f'Peril specific run: ({peril_filter}), '
             f'{len(valid_area_peril_id)} AreaPerilID included out of {len(keys_tb)}')

--- a/oasislmf/pytools/gul/structure.py
+++ b/oasislmf/pytools/gul/structure.py
@@ -88,8 +88,7 @@ def build_structures(run_dir, ignore_file_type, peril_filter):
         keys_dtype = np.dtype([('LocID', np.int32), ('PerilID', 'U3'), ('CoverageTypeID', np.int32),
                                ('AreaPerilID', areaperil_int), ('VulnerabilityID', np.int32)])
         keys_tb = load_as_ndarray(input_path, 'keys', keys_dtype)
-        peril_set = set(peril_filter)
-        mask = np.array([p in peril_set for p in keys_tb['PerilID']])
+        mask = np.isin(keys_tb['PerilID'], list(peril_filter))
         valid_area_peril_id = np.unique(keys_tb['AreaPerilID'][mask])
         logger.debug(
             f'Peril specific run: ({peril_filter}), '

--- a/oasislmf/pytools/gulmc/items.py
+++ b/oasislmf/pytools/gulmc/items.py
@@ -299,7 +299,8 @@ def get_dynamic_footprint_adjustments(input_path):
         adjustments_tb = np.loadtxt(adjustments_fn, dtype=ItemAdjustment, delimiter=",", skiprows=1, ndmin=1)
     else:  # Fall back to the items file (items.bin or items.csv) with zero adjustments.
         items_tb = read_items(input_path)
-        adjustments_tb = np.array([(i['item_id'], 0, 0) for i in items_tb], dtype=ItemAdjustment)
+        adjustments_tb = np.zeros(len(items_tb), dtype=ItemAdjustment)
+        adjustments_tb['item_id'] = items_tb['item_id']
 
     return adjustments_tb
 

--- a/oasislmf/pytools/gulmc/structure.py
+++ b/oasislmf/pytools/gulmc/structure.py
@@ -105,8 +105,7 @@ def build_structures(run_dir, ignore_file_type, peril_filter, dynamic_footprint,
                                ('AreaPerilID', areaperil_int), ('VulnerabilityID', np.int32)])
         keys_tb = load_as_ndarray(input_path, 'keys', keys_dtype)
         if peril_filter:
-            peril_set = set(peril_filter)
-            mask = np.array([p in peril_set for p in keys_tb['PerilID']])
+            mask = np.isin(keys_tb['PerilID'], list(peril_filter))
             valid_areaperil_id = np.unique(keys_tb['AreaPerilID'][mask])
             logger.debug(
                 f'Peril specific run: ({peril_filter}), {len(valid_areaperil_id)} AreaPerilID included out of {len(keys_tb)}')

--- a/oasislmf/pytools/gulmc/structure.py
+++ b/oasislmf/pytools/gulmc/structure.py
@@ -14,9 +14,9 @@ import numpy as np
 import numpy.lib.recfunctions as rfn
 import numba as nb
 from oasis_data_manager.filestore.config import get_storage_from_config_path
-from oasislmf.pytools.common.data import areaperil_int, load_as_ndarray, oasis_int
+from oasislmf.pytools.common.data import load_as_ndarray, oasis_int
 from oasislmf.pytools.common.id_index import build as id_index_build
-from oasislmf.pytools.common.input_files import read_coverages, read_correlations
+from oasislmf.pytools.common.input_files import KEYS_DTYPE, filter_area_peril_id, read_coverages, read_correlations
 from oasislmf.pytools.getmodel.footprint import Footprint
 from oasislmf.pytools.getmodel.manager import (
     get_damage_bins, get_vulns, get_intensity_bin_dict,
@@ -101,12 +101,9 @@ def build_structures(run_dir, ignore_file_type, peril_filter, dynamic_footprint,
 
     # --- keys / peril filter ---------------------------------------------------
     if os.path.exists(os.path.join(input_path, 'keys.csv')) or os.path.exists(os.path.join(input_path, 'keys.bin')):
-        keys_dtype = np.dtype([('LocID', np.int32), ('PerilID', 'U3'), ('CoverageTypeID', np.int32),
-                               ('AreaPerilID', areaperil_int), ('VulnerabilityID', np.int32)])
-        keys_tb = load_as_ndarray(input_path, 'keys', keys_dtype)
+        keys_tb = load_as_ndarray(input_path, 'keys', KEYS_DTYPE)
         if peril_filter:
-            mask = np.isin(keys_tb['PerilID'], list(peril_filter))
-            valid_areaperil_id = np.unique(keys_tb['AreaPerilID'][mask])
+            valid_areaperil_id = filter_area_peril_id(keys_tb, peril_filter)
             logger.debug(
                 f'Peril specific run: ({peril_filter}), {len(valid_areaperil_id)} AreaPerilID included out of {len(keys_tb)}')
         else:

--- a/oasislmf/pytools/join_summary_info/manager.py
+++ b/oasislmf/pytools/join_summary_info/manager.py
@@ -132,7 +132,11 @@ def run(
 
             summary_id = df["SummaryId"].to_numpy()
             in_range = summary_id <= max_summary_id
-            joined_summary_data = np.full(len(df), "", dtype=object)
+            # a summary id past the end of the summary info has no summary info, the same as
+            # one that falls in a gap within it, so it joins to the same empty columns. They
+            # have to be spelled out, as a row splitting into fewer columns than the headers
+            # is an error rather than a short row
+            joined_summary_data = np.full(len(df), "," * (len(summary_headers) - 1), dtype=object)
             joined_summary_data[in_range] = summary_data[summary_id[in_range]]
             df[summary_headers] = pd.Series(
                 joined_summary_data, index=df.index).str.split(",", expand=True)

--- a/oasislmf/pytools/join_summary_info/manager.py
+++ b/oasislmf/pytools/join_summary_info/manager.py
@@ -3,6 +3,7 @@
 import logging
 import shutil
 import numpy as np
+import pandas as pd
 from pathlib import Path
 import pyarrow.parquet as pq
 import pyarrow as pa
@@ -53,7 +54,9 @@ def load_summary_info(stack, summaryinfo_file):
             raise ValueError("Missing 'summary_id' column in summary info file.")
 
         summary_ids = df["summary_id"].to_numpy(dtype=np.int64)
-        summary_data = df.drop(columns=["summary_id"]).astype(str).agg(",".join, axis=1).to_numpy(dtype=object)
+        summary_columns = df.drop(columns=["summary_id"]).astype(str)
+        summary_data = summary_columns.iloc[:, 0].str.cat(
+            summary_columns.iloc[:, 1:], sep=",").to_numpy(dtype=object)
         headers = [col for col in df.columns if col != "summary_id"]
     else:
         raise ValueError(f"Unsupported file format {summaryinfo_file.suffix}.")
@@ -63,8 +66,7 @@ def load_summary_info(stack, summaryinfo_file):
 
     max_summary_id = summary_ids.max()
     full_summary_data = np.full((max_summary_id + 1,), "," * (len(headers) - 1), dtype=object)
-    for i in range(len(summary_ids)):
-        full_summary_data[summary_ids[i]] = summary_data[i]
+    full_summary_data[summary_ids] = summary_data
 
     return full_summary_data, headers, max_summary_id
 
@@ -128,9 +130,12 @@ def run(
             if "SummaryId" not in df.columns:
                 raise ValueError("Missing 'SummaryId' column in data file.")
 
-            df[summary_headers] = df["SummaryId"].apply(
-                lambda sid: summary_data[sid] if sid <= max_summary_id else ""
-            ).str.split(",", expand=True)
+            summary_id = df["SummaryId"].to_numpy()
+            in_range = summary_id <= max_summary_id
+            joined_summary_data = np.full(len(df), "", dtype=object)
+            joined_summary_data[in_range] = summary_data[summary_id[in_range]]
+            df[summary_headers] = pd.Series(
+                joined_summary_data, index=df.index).str.split(",", expand=True)
             pq.write_table(pa.Table.from_pandas(df), temp_output_file)
         else:
             raise ValueError(f"Unsupported file format {data_file.suffix}.")

--- a/oasislmf/pytools/join_summary_info/manager.py
+++ b/oasislmf/pytools/join_summary_info/manager.py
@@ -55,8 +55,11 @@ def load_summary_info(stack, summaryinfo_file):
 
         summary_ids = df["summary_id"].to_numpy(dtype=np.int64)
         summary_columns = df.drop(columns=["summary_id"]).astype(str)
-        summary_data = summary_columns.iloc[:, 0].str.cat(
-            summary_columns.iloc[:, 1:], sep=",").to_numpy(dtype=object)
+        if summary_columns.shape[1]:
+            summary_data = summary_columns.iloc[:, 0].str.cat(
+                summary_columns.iloc[:, 1:], sep=",").to_numpy(dtype=object)
+        else:
+            summary_data = np.full(len(df), "", dtype=object)
         headers = [col for col in df.columns if col != "summary_id"]
     else:
         raise ValueError(f"Unsupported file format {summaryinfo_file.suffix}.")
@@ -119,7 +122,7 @@ def run(
                 for line in data_fin:
                     row = line.strip().split(",")
                     summary_id = int(row[summary_id_col_idx])
-                    if summary_id > max_summary_id:
+                    if summary_id < 0 or summary_id > max_summary_id:
                         fout.write(line.strip() + ("," * len(summary_headers)) + "\n")
                     else:
                         fout.write(line.strip() + "," + summary_data[summary_id] + "\n")
@@ -131,15 +134,16 @@ def run(
                 raise ValueError("Missing 'SummaryId' column in data file.")
 
             summary_id = df["SummaryId"].to_numpy()
-            in_range = summary_id <= max_summary_id
+            in_range = (summary_id >= 0) & (summary_id <= max_summary_id)
             # a summary id past the end of the summary info has no summary info, the same as
             # one that falls in a gap within it, so it joins to the same empty columns. They
             # have to be spelled out, as a row splitting into fewer columns than the headers
             # is an error rather than a short row
-            joined_summary_data = np.full(len(df), "," * (len(summary_headers) - 1), dtype=object)
-            joined_summary_data[in_range] = summary_data[summary_id[in_range]]
-            df[summary_headers] = pd.Series(
-                joined_summary_data, index=df.index).str.split(",", expand=True)
+            if summary_headers:
+                joined_summary_data = np.full(len(df), "," * (len(summary_headers) - 1), dtype=object)
+                joined_summary_data[in_range] = summary_data[summary_id[in_range]]
+                df[summary_headers] = pd.Series(
+                    joined_summary_data, index=df.index).str.split(",", expand=True)
             pq.write_table(pa.Table.from_pandas(df), temp_output_file)
         else:
             raise ValueError(f"Unsupported file format {data_file.suffix}.")

--- a/oasislmf/pytools/join_summary_info/manager.py
+++ b/oasislmf/pytools/join_summary_info/manager.py
@@ -119,13 +119,14 @@ def run(
                 fout.write(",".join(data_headers + summary_headers) + "\n")
 
                 summary_id_col_idx = data_headers.index("SummaryId")
+                summary_sep = "," if summary_headers else ""
                 for line in data_fin:
                     row = line.strip().split(",")
                     summary_id = int(row[summary_id_col_idx])
                     if summary_id < 0 or summary_id > max_summary_id:
                         fout.write(line.strip() + ("," * len(summary_headers)) + "\n")
                     else:
-                        fout.write(line.strip() + "," + summary_data[summary_id] + "\n")
+                        fout.write(line.strip() + summary_sep + summary_data[summary_id] + "\n")
         elif data_file.suffix == ".parquet":
             table = pq.read_table(data_file)
             df = table.to_pandas()

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -962,7 +962,7 @@ def validate_vuln_csv_contents(file_path):
             return False
         probability = vuln_df['probability']
         if pd.api.types.is_numeric_dtype(probability) and not pd.api.types.is_bool_dtype(probability):
-            if not (vuln_df['probability'].between(0, 1).all()):
+            if not (probability.notna().all() and probability.between(0, 1).all()):
                 logger.warning("probability column must contain values between 0 and 1.")
                 return False
         else:

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -960,7 +960,7 @@ def validate_vuln_csv_contents(file_path):
         ):
             logger.warning("vulnerability_id, intensity_bin_id, and damage_bin_id columns must contain integer values.")
             return False
-        if vuln_df['probability'].apply(lambda x: isinstance(x, (int, float))).all():
+        if np.issubdtype(vuln_df['probability'].dtype, np.number):
             if not (vuln_df['probability'].between(0, 1).all()):
                 logger.warning("probability column must contain values between 0 and 1.")
                 return False

--- a/oasislmf/utils/data.py
+++ b/oasislmf/utils/data.py
@@ -960,7 +960,8 @@ def validate_vuln_csv_contents(file_path):
         ):
             logger.warning("vulnerability_id, intensity_bin_id, and damage_bin_id columns must contain integer values.")
             return False
-        if np.issubdtype(vuln_df['probability'].dtype, np.number):
+        probability = vuln_df['probability']
+        if pd.api.types.is_numeric_dtype(probability) and not pd.api.types.is_bool_dtype(probability):
             if not (vuln_df['probability'].between(0, 1).all()):
                 logger.warning("probability column must contain values between 0 and 1.")
                 return False

--- a/tests/computation/test_run_exposure.py
+++ b/tests/computation/test_run_exposure.py
@@ -325,6 +325,22 @@ class _RunExposureIntegrationBase(ComputationChecker):
         )
         _assert_output_matches(out, EXPECTED_ACC_LOC)
 
+    def test_extra_summary_col_already_in_the_level_matches_the_plain_run(self):
+        """An extra_summary_cols entry the level already has is dropped rather than repeated.
+
+        extra_summary_cols comes straight from the CLI and is never checked against the level's
+        own columns. A repeat gives groupby a grouper that is not 1-dimensional, and on the gul
+        only path it gives the frame wide astype(str) a duplicate key.
+        """
+        out = self._output_file()
+        self._run(
+            out,
+            oed_location_csv=LOCATION,
+            oed_accounts_csv=ACCOUNTS,
+            extra_summary_cols=['PortNumber'],
+        )
+        _assert_output_matches(out, EXPECTED_ACC_LOC)
+
     def test_acc_loc_usd_output_matches_expected(self):
         out = self._output_file()
         self._run(

--- a/tests/preparation/test_sub_step_trigger_types.py
+++ b/tests/preparation/test_sub_step_trigger_types.py
@@ -1,0 +1,76 @@
+"""Pin the sub-step trigger type lookup against the row-wise assignment it replaced."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from oasislmf.preparation.il_inputs import get_sub_step_trigger_types
+from oasislmf.utils.fm import STEP_TRIGGER_TYPES
+
+COVERAGE_TYPE_IDS = [1, 2, 3, 4, 5]
+STEP_TRIGGER_TYPE_IDS = [0, 1, 2, 3, 4, 5, 6]
+
+
+def reference_sub_step_trigger_type(row):
+    """The row-wise assignment replaced by the get_sub_step_trigger_types lookup."""
+    try:
+        return STEP_TRIGGER_TYPES[row['steptriggertype']]['sub_step_trigger_types'][row['coverage_type_id']]
+    except KeyError:
+        return row['steptriggertype']
+
+
+def assign_sub_step_trigger_types(level_df):
+    """Assign the sub-step trigger types the way assign_level_calcrule_and_profile_ids does."""
+    step_rows = level_df[['steptriggertype', 'coverage_type_id']]
+    sub_step_trigger_type = get_sub_step_trigger_types().reindex(pd.MultiIndex.from_frame(step_rows))
+    has_sub_type = sub_step_trigger_type.notna().to_numpy()
+
+    assigned = level_df.copy()
+    assigned.loc[step_rows.index[has_sub_type], 'steptriggertype'] = pd.Series(
+        sub_step_trigger_type.to_numpy()[has_sub_type],
+        index=step_rows.index[has_sub_type], dtype=assigned['steptriggertype'].dtype)
+
+    return assigned['steptriggertype']
+
+
+@pytest.mark.parametrize('dtype', ['int64', 'int32', 'float64'])
+def test_matches_the_row_wise_assignment(dtype):
+    rng = np.random.default_rng(3)
+    level_df = pd.DataFrame({
+        'steptriggertype': rng.choice(STEP_TRIGGER_TYPE_IDS, 200).astype(dtype),
+        'coverage_type_id': rng.choice(COVERAGE_TYPE_IDS, 200).astype(dtype),
+    })
+
+    expected = level_df.apply(reference_sub_step_trigger_type, axis=1)
+
+    np.testing.assert_array_equal(
+        assign_sub_step_trigger_types(level_df).to_numpy().astype('int64'),
+        expected.to_numpy().astype('int64'),
+    )
+
+
+def test_covers_every_declared_pair():
+    pairs = [(step_trigger_type, coverage_type_id)
+             for step_trigger_type, info in STEP_TRIGGER_TYPES.items()
+             for coverage_type_id in info['sub_step_trigger_types']]
+    level_df = pd.DataFrame(pairs, columns=['steptriggertype', 'coverage_type_id'])
+
+    expected = level_df.apply(reference_sub_step_trigger_type, axis=1)
+
+    np.testing.assert_array_equal(assign_sub_step_trigger_types(level_df).to_numpy(), expected.to_numpy())
+    # every declared pair has a sub-type, so none of them keeps the trigger type it came in with
+    assert (assign_sub_step_trigger_types(level_df).to_numpy() != level_df['steptriggertype'].to_numpy()).any()
+
+
+def test_a_trigger_type_without_a_sub_type_is_left_alone():
+    level_df = pd.DataFrame({'steptriggertype': [4, 6, 5], 'coverage_type_id': [1, 1, 2]})
+
+    np.testing.assert_array_equal(assign_sub_step_trigger_types(level_df).to_numpy(), [4, 6, 5])
+
+
+def test_a_missing_trigger_type_is_left_alone():
+    level_df = pd.DataFrame({'steptriggertype': [5.0, np.nan], 'coverage_type_id': [1.0, 1.0]})
+
+    assigned = assign_sub_step_trigger_types(level_df).to_numpy()
+    assert assigned[0] == 1
+    assert np.isnan(assigned[1])

--- a/tests/preparation/test_sub_step_trigger_types.py
+++ b/tests/preparation/test_sub_step_trigger_types.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from oasislmf.preparation.il_inputs import get_sub_step_trigger_types
+from oasislmf.preparation.il_inputs import assign_sub_step_trigger_types as _assign_sub_step_trigger_types
 from oasislmf.utils.fm import STEP_TRIGGER_TYPES
 
 COVERAGE_TYPE_IDS = [1, 2, 3, 4, 5]
@@ -19,34 +19,74 @@ def reference_sub_step_trigger_type(row):
         return row['steptriggertype']
 
 
-def assign_sub_step_trigger_types(level_df):
-    """Assign the sub-step trigger types the way assign_level_calcrule_and_profile_ids does."""
-    step_rows = level_df[['steptriggertype', 'coverage_type_id']]
-    sub_step_trigger_type = get_sub_step_trigger_types().reindex(pd.MultiIndex.from_frame(step_rows))
-    has_sub_type = sub_step_trigger_type.notna().to_numpy()
+def assign_sub_step_trigger_types(level_df, step_filter=None):
+    """Call the assignment, so a regression in it fails these tests.
 
-    assigned = level_df.copy()
-    assigned.loc[step_rows.index[has_sub_type], 'steptriggertype'] = pd.Series(
-        sub_step_trigger_type.to_numpy()[has_sub_type],
-        index=step_rows.index[has_sub_type], dtype=assigned['steptriggertype'].dtype)
+    Only the reference implementation is duplicated here; the code under test is imported.
+    """
+    if step_filter is None:
+        step_filter = pd.Series(True, index=level_df.index)
 
-    return assigned['steptriggertype']
+    return _assign_sub_step_trigger_types(level_df.copy(), step_filter)['steptriggertype']
 
 
-@pytest.mark.parametrize('dtype', ['int64', 'int32', 'float64'])
+# Int32 is what the real pipeline carries: coverage_type_id_df gives steptriggertype a nullable
+# extension dtype, which numpy's astype cannot interpret
+@pytest.mark.parametrize('dtype', ['int64', 'int32', 'float64', 'object', 'Int32', 'Int64'])
 def test_matches_the_row_wise_assignment(dtype):
     rng = np.random.default_rng(3)
     level_df = pd.DataFrame({
-        'steptriggertype': rng.choice(STEP_TRIGGER_TYPE_IDS, 200).astype(dtype),
-        'coverage_type_id': rng.choice(COVERAGE_TYPE_IDS, 200).astype(dtype),
+        'steptriggertype': pd.Series(rng.choice(STEP_TRIGGER_TYPE_IDS, 200)).astype(dtype),
+        'coverage_type_id': pd.Series(rng.choice(COVERAGE_TYPE_IDS, 200)).astype(dtype),
     })
 
     expected = level_df.apply(reference_sub_step_trigger_type, axis=1)
+    assigned = assign_sub_step_trigger_types(level_df)
 
     np.testing.assert_array_equal(
-        assign_sub_step_trigger_types(level_df).to_numpy().astype('int64'),
-        expected.to_numpy().astype('int64'),
-    )
+        assigned.to_numpy().astype('int64'), expected.to_numpy().astype('int64'))
+    assert assigned.dtype == level_df['steptriggertype'].dtype
+
+
+def test_an_object_column_keeps_integers_rather_than_floats():
+    """The calc rules table is merged on steptriggertype, and 1.0 does not match the key 1.
+
+    Reindexing onto the MultiIndex introduces NaN, which promotes the lookup to float64. Masking
+    the NaN away afterwards does not convert the surviving values back, so an object column would
+    silently take floats and the merge would return a NaN calcrule_id for those rows.
+    """
+    level_df = pd.DataFrame({
+        'steptriggertype': pd.Series([5, 5, 4], dtype=object),
+        'coverage_type_id': pd.Series([1, 2, 1], dtype=object),
+    })
+
+    assigned = assign_sub_step_trigger_types(level_df)
+
+    assert assigned.dtype == object
+    assert not any(isinstance(value, float) for value in assigned), assigned.to_list()
+    # (5, 1) has sub-type 1; (5, 2) has none so keeps 5; (4, 1) has none so keeps 4
+    np.testing.assert_array_equal(assigned.to_numpy().astype('int64'), [1, 5, 4])
+
+
+def test_a_duplicated_index_is_assigned_positionally():
+    """level_df's index is not guaranteed unique, and reindexing onto duplicate labels raises."""
+    level_df = pd.DataFrame(
+        {'steptriggertype': [5, 5, 5, 1], 'coverage_type_id': [1, 2, 3, 4]}, index=[0, 0, 1, 1])
+
+    assigned = assign_sub_step_trigger_types(level_df)
+
+    # (5, 1) -> 1; (5, 2) has no sub-type so keeps 5; (5, 3) -> 2; (1, 4) -> 0
+    np.testing.assert_array_equal(assigned.to_numpy(), [1, 5, 2, 0])
+
+
+def test_only_the_filtered_rows_are_assigned():
+    """Non-step rows keep their trigger type even when the pair has a sub-type."""
+    level_df = pd.DataFrame({'steptriggertype': [5, 5], 'coverage_type_id': [1, 2]})
+    step_filter = pd.Series([True, False], index=level_df.index)
+
+    assigned = assign_sub_step_trigger_types(level_df, step_filter)
+
+    np.testing.assert_array_equal(assigned.to_numpy(), [1, 5])
 
 
 def test_covers_every_declared_pair():

--- a/tests/pytools/common/test_peril_filter.py
+++ b/tests/pytools/common/test_peril_filter.py
@@ -1,0 +1,101 @@
+"""Pin the peril filter shared by the gulpy and gulmc structure builders.
+
+``filter_area_peril_id`` narrows a run to the area perils covered by the requested perils. It is
+reached only through ``build_structures``, which needs a whole run directory, so neither of its
+two call sites is exercised by the gulpy or gulmc suites -- they never pass a ``peril_filter``.
+"""
+import numpy as np
+import pytest
+
+from oasislmf.pytools.common.data import areaperil_int
+from oasislmf.pytools.common.input_files import KEYS_DTYPE, filter_area_peril_id
+
+KEYS_ROWS = [
+    # (LocID, PerilID, CoverageTypeID, AreaPerilID, VulnerabilityID)
+    (1, 'WTC', 1, 10, 1),
+    (1, 'WSS', 1, 11, 1),
+    (2, 'WTC', 1, 10, 2),      # the same area peril as row 0, so the result must de-duplicate
+    (2, 'ORF', 1, 12, 2),
+    (3, 'WSS', 3, 13, 3),
+    (3, 'WTC', 3, 14, 3),
+]
+
+
+def make_keys(rows=KEYS_ROWS):
+    return np.array(rows, dtype=KEYS_DTYPE)
+
+
+def reference_filter_area_peril_id(keys_tb, peril_filter):
+    """The python set membership loop this replaced, kept as the reference implementation."""
+    peril_set = set(peril_filter)
+    mask = np.array([p in peril_set for p in keys_tb['PerilID']])
+    return np.unique(keys_tb['AreaPerilID'][mask])
+
+
+@pytest.mark.parametrize('peril_filter', [
+    ['WSS'],
+    ['WSS', 'WTC'],
+    ['WTC', 'WSS', 'ORF'],
+    ['ORF'],
+    {'WSS'},                 # a set, which is what the call sites used to build internally
+    ('WSS', 'ORF'),          # a tuple
+    ['wss'],                 # case mismatch matches nothing; peril ids are case sensitive
+    ['WSSX'],                # longer than the U3 field
+    ['WS'],                  # a prefix is not a match
+    ['QQ1'],                 # simply absent from the table
+])
+def test_matches_the_reference_implementation(peril_filter):
+    keys_tb = make_keys()
+
+    np.testing.assert_array_equal(
+        filter_area_peril_id(keys_tb, peril_filter),
+        reference_filter_area_peril_id(keys_tb, peril_filter),
+    )
+
+
+def test_selects_the_distinct_area_perils_of_the_matching_rows():
+    keys_tb = make_keys()
+
+    np.testing.assert_array_equal(filter_area_peril_id(keys_tb, ['WTC']), [10, 14])
+    np.testing.assert_array_equal(filter_area_peril_id(keys_tb, ['WSS']), [11, 13])
+    np.testing.assert_array_equal(filter_area_peril_id(keys_tb, ['WTC', 'WSS']), [10, 11, 13, 14])
+    assert filter_area_peril_id(keys_tb, ['QQ1']).size == 0
+
+
+def test_area_peril_id_dtype_is_preserved():
+    """The result indexes items['areaperil_id'], so it has to stay an integer array."""
+    result = filter_area_peril_id(make_keys(), ['WTC'])
+
+    assert result.dtype == np.dtype(areaperil_int)
+
+
+def test_empty_keys_table_gives_an_empty_integer_array():
+    """An empty keys table is not an error, and the result is still usable as an index.
+
+    The list comprehension this replaced built its mask with ``np.array([...])``, which on an
+    empty table produced a float64 array rather than a bool one -- so indexing with it raised
+    ``IndexError: arrays used as indices must be of integer (or boolean) type``.
+    """
+    empty = make_keys([])
+
+    result = filter_area_peril_id(empty, ['WTC'])
+
+    assert result.size == 0
+    assert result.dtype == np.dtype(areaperil_int)
+    # the same call against the implementation this replaced
+    with pytest.raises(IndexError):
+        reference_filter_area_peril_id(empty, ['WTC'])
+
+
+def test_a_bare_string_filter_matches_nothing():
+    """A string is iterated character by character, so it cannot match a three character peril id.
+
+    Pre-existing and unchanged: ``set('WSS')`` and ``list('WSS')`` are both ``['W', 'S', 'S']``.
+    ``oasislmf/execution/bash.py`` always passes a list, so this is not reachable from the CLI,
+    but it fails silently rather than loudly and is worth stating.
+    """
+    keys_tb = make_keys()
+
+    assert filter_area_peril_id(keys_tb, 'WSS').size == 0
+    np.testing.assert_array_equal(
+        filter_area_peril_id(keys_tb, 'WSS'), reference_filter_area_peril_id(keys_tb, 'WSS'))

--- a/tests/pytools/join-summary-info/test_join-summary-info.py
+++ b/tests/pytools/join-summary-info/test_join-summary-info.py
@@ -143,15 +143,44 @@ def test_join_parquet_with_summary_id_beyond_the_summary_info():
             data={"SummaryId": [1, 5, 2], "MeanLoss": [1.0, 2.0, 3.0]},
         )
 
-        # an unknown summary id joins to nothing, so only the first summary column is filled
+        # an unknown summary id joins to empty summary columns, the same as a gap does
         assert list(joined["PortNumber"]) == ["1", "", "2"]
+        assert list(joined["tiv"]) == ["10.0", "", "20.0"]
 
-        # the columns after it are missing rather than empty. Which value reports that is the
-        # pandas string dtype's to choose, None on the object dtype and NaN on StringDtype,
-        # so the test asks whether it is missing rather than which of the two it is.
-        tiv = list(joined["tiv"])
-        assert [tiv[0], tiv[2]] == ["10.0", "20.0"]
-        assert pd.isna(tiv[1])
+
+def test_join_parquet_with_every_summary_id_beyond_the_summary_info():
+    """Tests join-summary-info joins a file whose every summary id is unknown
+
+    Nothing to join is not an error, and the summary columns still have to be there for the
+    output to have the schema the joined file is supposed to have.
+    """
+    with TemporaryDirectory() as tmp_dir:
+        joined = write_parquet_pair(
+            tmp_dir,
+            summary_info={"summary_id": [1, 2], "PortNumber": ["1", "2"], "tiv": [10.0, 20.0]},
+            data={"SummaryId": [7, 8], "MeanLoss": [1.0, 2.0]},
+        )
+
+        assert list(joined.columns) == ["SummaryId", "MeanLoss", "PortNumber", "tiv"]
+        assert list(joined["PortNumber"]) == ["", ""]
+        assert list(joined["tiv"]) == ["", ""]
+
+
+def test_join_parquet_matches_csv_for_unknown_summary_ids(tmp_path):
+    """Tests both formats say the same thing about a summary id they cannot join"""
+    summary_info = pd.DataFrame({"summary_id": [1, 2], "PortNumber": ["1", "2"], "tiv": [10.0, 20.0]})
+    data = pd.DataFrame({"SummaryId": [1, 5, 2], "MeanLoss": [1.0, 2.0, 3.0]})
+
+    summary_info.to_csv(tmp_path / "gul_summary-info.csv", index=False)
+    data.to_csv(tmp_path / "aalgul_ord.csv", index=False)
+    main(summaryinfo=tmp_path / "gul_summary-info.csv", data=tmp_path / "aalgul_ord.csv",
+         output=tmp_path / "joined.csv")
+    joined_csv = pd.read_csv(tmp_path / "joined.csv", dtype=str).fillna("")
+
+    joined_parquet = write_parquet_pair(tmp_path, summary_info=summary_info, data=data)
+
+    assert list(joined_csv["PortNumber"]) == list(joined_parquet["PortNumber"])
+    assert list(joined_csv["tiv"]) == list(joined_parquet["tiv"])
 
 
 def test_missing_summary_col_parquet():

--- a/tests/pytools/join-summary-info/test_join-summary-info.py
+++ b/tests/pytools/join-summary-info/test_join-summary-info.py
@@ -108,6 +108,46 @@ def test_join_parquet():
             raise Exception(f"running 'join-summary-info {arg_str}' led to diff, see files at {error_path}") from e
 
 
+def write_parquet_pair(tmp_dir, summary_info, data):
+    summaryinfo_file = Path(tmp_dir, "gul_summary-info.parquet")
+    data_file = Path(tmp_dir, "aalgul_ord.parquet")
+    pd.DataFrame(summary_info).to_parquet(summaryinfo_file, index=False)
+    pd.DataFrame(data).to_parquet(data_file, index=False)
+    output_file = Path(tmp_dir, "joined_aalgul_ord.parquet")
+    main(summaryinfo=summaryinfo_file, data=data_file, output=output_file)
+
+    return pd.read_parquet(output_file)
+
+
+def test_join_parquet_with_sparse_summary_ids():
+    """Tests join-summary-info fills the gaps in non contiguous summary ids
+    """
+    with TemporaryDirectory() as tmp_dir:
+        joined = write_parquet_pair(
+            tmp_dir,
+            summary_info={"summary_id": [3, 1, 7], "PortNumber": ["1", "1", "2"], "tiv": [10.5, 20.0, 30.25]},
+            data={"SummaryId": [7, 1, 3, 2], "MeanLoss": [1.0, 2.0, 3.0, 4.0]},
+        )
+
+        assert list(joined["PortNumber"]) == ["2", "1", "1", ""]
+        assert list(joined["tiv"]) == ["30.25", "20.0", "10.5", ""]
+
+
+def test_join_parquet_with_summary_id_beyond_the_summary_info():
+    """Tests join-summary-info leaves the summary info blank for unknown summary ids
+    """
+    with TemporaryDirectory() as tmp_dir:
+        joined = write_parquet_pair(
+            tmp_dir,
+            summary_info={"summary_id": [1, 2], "PortNumber": ["1", "2"], "tiv": [10.0, 20.0]},
+            data={"SummaryId": [1, 5, 2], "MeanLoss": [1.0, 2.0, 3.0]},
+        )
+
+        # an unknown summary id joins to nothing, so only the first summary column is filled
+        assert list(joined["PortNumber"]) == ["1", "", "2"]
+        assert list(joined["tiv"]) == ["10.0", None, "20.0"]
+
+
 def test_missing_summary_col_parquet():
     """Tests join-summary-info with non-ORD parquet file, should not generate output
     """

--- a/tests/pytools/join-summary-info/test_join-summary-info.py
+++ b/tests/pytools/join-summary-info/test_join-summary-info.py
@@ -217,6 +217,51 @@ def test_join_parquet_with_no_summary_info_columns():
         assert list(joined["MeanLoss"]) == [1.0, 2.0, 3.0]
 
 
+def write_csv_pair(tmp_dir, summary_info, data):
+    summaryinfo_file = Path(tmp_dir, "gul_summary-info.csv")
+    data_file = Path(tmp_dir, "aalgul_ord.csv")
+    pd.DataFrame(summary_info).to_csv(summaryinfo_file, index=False)
+    pd.DataFrame(data).to_csv(data_file, index=False)
+    output_file = Path(tmp_dir, "joined_aalgul_ord.csv")
+    main(summaryinfo=summaryinfo_file, data=data_file, output=output_file)
+
+    return output_file
+
+
+def test_join_csv_with_no_summary_info_columns(tmp_path):
+    """Tests join-summary-info joins a summary info file holding nothing but summary_id
+
+    The csv counterpart of test_join_parquet_with_no_summary_info_columns. With no summary
+    columns to add there is nothing to separate them from the data, so a joined row must not
+    gain a trailing comma that a row with no summary info to join does not have -- that is a
+    ragged file, and pandas reads the extra field back by shifting the first column into the
+    index rather than by failing.
+    """
+    output_file = write_csv_pair(
+        tmp_path,
+        summary_info={"summary_id": [1, 2]},
+        data={"SummaryId": [1, 2, 9], "MeanLoss": [1.0, 2.0, 3.0]},
+    )
+
+    lines = output_file.read_text().strip().splitlines()
+    assert [line.count(",") for line in lines] == [1, 1, 1, 1]
+
+    joined = pd.read_csv(output_file)
+    assert list(joined.columns) == ["SummaryId", "MeanLoss"]
+    assert list(joined["MeanLoss"]) == [1.0, 2.0, 3.0]
+
+
+def test_join_matches_csv_with_no_summary_info_columns(tmp_path):
+    """Tests both formats say the same thing about a summary info file with no columns to join"""
+    summary_info = pd.DataFrame({"summary_id": [1, 2]})
+    data = pd.DataFrame({"SummaryId": [1, 2, 9], "MeanLoss": [1.0, 2.0, 3.0]})
+
+    joined_csv = pd.read_csv(write_csv_pair(tmp_path, summary_info=summary_info, data=data))
+    joined_parquet = write_parquet_pair(tmp_path, summary_info=summary_info, data=data)
+
+    pd.testing.assert_frame_equal(joined_csv, joined_parquet)
+
+
 def test_join_parquet_matches_csv_for_unknown_summary_ids(tmp_path):
     """Tests both formats say the same thing about a summary id they cannot join"""
     summary_info = pd.DataFrame({"summary_id": [1, 2], "PortNumber": ["1", "2"], "tiv": [10.0, 20.0]})

--- a/tests/pytools/join-summary-info/test_join-summary-info.py
+++ b/tests/pytools/join-summary-info/test_join-summary-info.py
@@ -166,6 +166,57 @@ def test_join_parquet_with_every_summary_id_beyond_the_summary_info():
         assert list(joined["tiv"]) == ["", ""]
 
 
+def test_join_parquet_with_a_negative_summary_id():
+    """Tests join-summary-info leaves a negative summary id blank rather than counting back
+
+    A negative id is a legal index into the summary table, so it would otherwise silently join
+    the row to some other summary's info.
+    """
+    with TemporaryDirectory() as tmp_dir:
+        joined = write_parquet_pair(
+            tmp_dir,
+            summary_info={"summary_id": [1, 2, 3], "PortNumber": ["1", "2", "3"], "tiv": [10.0, 20.0, 30.0]},
+            data={"SummaryId": [1, -1, -3, 3], "MeanLoss": [1.0, 2.0, 3.0, 4.0]},
+        )
+
+        assert list(joined["PortNumber"]) == ["1", "", "", "3"]
+        assert list(joined["tiv"]) == ["10.0", "", "", "30.0"]
+
+
+def test_join_matches_csv_for_a_negative_summary_id(tmp_path):
+    """Tests both formats say the same thing about a negative summary id"""
+    summary_info = pd.DataFrame({"summary_id": [1, 2, 3], "PortNumber": ["1", "2", "3"], "tiv": [10.0, 20.0, 30.0]})
+    data = pd.DataFrame({"SummaryId": [1, -1, -3, 3], "MeanLoss": [1.0, 2.0, 3.0, 4.0]})
+
+    summary_info.to_csv(tmp_path / "gul_summary-info.csv", index=False)
+    data.to_csv(tmp_path / "aalgul_ord.csv", index=False)
+    main(summaryinfo=tmp_path / "gul_summary-info.csv", data=tmp_path / "aalgul_ord.csv",
+         output=tmp_path / "joined.csv")
+    joined_csv = pd.read_csv(tmp_path / "joined.csv", dtype=str).fillna("")
+
+    joined_parquet = write_parquet_pair(tmp_path, summary_info=summary_info, data=data)
+
+    assert list(joined_csv["PortNumber"]) == list(joined_parquet["PortNumber"])
+    assert list(joined_csv["tiv"]) == list(joined_parquet["tiv"])
+
+
+def test_join_parquet_with_no_summary_info_columns():
+    """Tests join-summary-info joins a summary info file holding nothing but summary_id
+
+    There is no summary info to add, so every row joins to nothing and the data file comes back
+    unchanged rather than the join failing.
+    """
+    with TemporaryDirectory() as tmp_dir:
+        joined = write_parquet_pair(
+            tmp_dir,
+            summary_info={"summary_id": [1, 2]},
+            data={"SummaryId": [1, 2, 9], "MeanLoss": [1.0, 2.0, 3.0]},
+        )
+
+        assert list(joined.columns) == ["SummaryId", "MeanLoss"]
+        assert list(joined["MeanLoss"]) == [1.0, 2.0, 3.0]
+
+
 def test_join_parquet_matches_csv_for_unknown_summary_ids(tmp_path):
     """Tests both formats say the same thing about a summary id they cannot join"""
     summary_info = pd.DataFrame({"summary_id": [1, 2], "PortNumber": ["1", "2"], "tiv": [10.0, 20.0]})

--- a/tests/pytools/join-summary-info/test_join-summary-info.py
+++ b/tests/pytools/join-summary-info/test_join-summary-info.py
@@ -145,7 +145,13 @@ def test_join_parquet_with_summary_id_beyond_the_summary_info():
 
         # an unknown summary id joins to nothing, so only the first summary column is filled
         assert list(joined["PortNumber"]) == ["1", "", "2"]
-        assert list(joined["tiv"]) == ["10.0", None, "20.0"]
+
+        # the columns after it are missing rather than empty. Which value reports that is the
+        # pandas string dtype's to choose, None on the object dtype and NaN on StringDtype,
+        # so the test asks whether it is missing rather than which of the two it is.
+        tiv = list(joined["tiv"])
+        assert [tiv[0], tiv[2]] == ["10.0", "20.0"]
+        assert pd.isna(tiv[1])
 
 
 def test_missing_summary_col_parquet():

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -1538,6 +1538,67 @@ class TestValidateVulnerabilityReplacements(TestCase):
                     self.assertTrue(message_found, "Expected log message not found")
 
 
+class TestValidateVulnCsvProbabilityDtype(TestCase):
+    """The probability dtype branch of validate_vuln_csv_contents.
+
+    Its reject path is reached by no other test in this file: every fixture uses a float64
+    probability column, so only the accept branch ever runs.
+    """
+
+    def setUp(self):
+        self.logger_patch = patch('oasislmf.utils.data.logger')
+        self.mock_logger = self.logger_patch.start()
+
+    def tearDown(self):
+        self.logger_patch.stop()
+
+    def _validate(self, probability):
+        rows = len(probability)
+        vuln_df = pd.DataFrame({
+            'vulnerability_id': [2] * rows, 'intensity_bin_id': [1] * rows,
+            'damage_bin_id': [1] * rows, 'probability': probability,
+        })
+        with patch('pandas.read_csv', return_value=vuln_df):
+            return validate_vuln_csv_contents('any_path.csv')
+
+    def test_float_probability_is_accepted(self):
+        self.assertTrue(self._validate([0.5, 1.0, 0.0]))
+
+    def test_integer_probability_is_accepted(self):
+        # 0 and 1 are legal probabilities, and such a column reads back from a csv as int64
+        self.assertTrue(self._validate([0, 1]))
+
+    def test_probability_outside_the_unit_interval_is_rejected(self):
+        self.assertFalse(self._validate([1.5]))
+
+    def test_boolean_probability_is_rejected(self):
+        """A True/False column compares inside [0, 1] but is not a probability column.
+
+        The per-value ``isinstance(x, (int, float))`` check this replaced accepted it, because
+        bool is a subclass of int, so True passed as the probability 1.
+        """
+        self.assertFalse(self._validate([True, False]))
+
+    def test_object_probability_is_rejected(self):
+        """An object column is rejected even when every value in it is a python number.
+
+        ``Series.apply`` unboxes to python scalars, so the check this replaced saw plain floats
+        here and accepted them. pd.read_csv cannot produce this, but the tests in this file mock
+        read_csv and inject frames directly, so it is reachable from a fixture.
+        """
+        self.assertFalse(self._validate(pd.Series([0.5, 0.25], dtype=object)))
+
+    def test_non_numeric_probability_is_rejected(self):
+        self.assertFalse(self._validate(['most of it']))
+        self.mock_logger.warning.assert_called_with('probability column must contain numeric values.')
+
+    def test_nullable_extension_dtype_probability_is_rejected(self):
+        """np.issubdtype cannot interpret a pandas extension dtype, so the outer except warns."""
+        self.assertFalse(self._validate(pd.array([0.5, 0.25], dtype='Float64')))
+        assert any('Error occurred while validating CSV file' in args[0]
+                   for args, _ in self.mock_logger.warning.call_args_list)
+
+
 class TestValidateAnalysisOedFields(TestCase):
     def setUp(self):
         self.logger_patch = patch('oasislmf.utils.data.logger')

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -1607,6 +1607,21 @@ class TestValidateVulnCsvProbabilityDtype(TestCase):
         self.assertFalse(self._validate(pd.array([0.5, 1.25], dtype='Float64')))
         self.mock_logger.warning.assert_called_with('probability column must contain values between 0 and 1.')
 
+    def test_missing_probability_is_rejected(self):
+        """A missing value is not a probability in [0, 1], whichever dtype carries it.
+
+        ``between`` yields False for a float64 NaN but pd.NA for a nullable one, and ``all()``
+        skips NA by default, so the same missing value was rejected in a float64 column and
+        accepted in a nullable one.
+        """
+        for probability in [pd.array([0.5, None], dtype='Float64'),
+                            pd.array([1, None], dtype='Int64'),
+                            [0.5, float('nan')]]:
+            with self.subTest(dtype=getattr(probability, 'dtype', 'float64')):
+                self.assertFalse(self._validate(probability))
+                self.mock_logger.warning.assert_called_with(
+                    'probability column must contain values between 0 and 1.')
+
 
 class TestValidateAnalysisOedFields(TestCase):
     def setUp(self):

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -1589,14 +1589,23 @@ class TestValidateVulnCsvProbabilityDtype(TestCase):
         self.assertFalse(self._validate(pd.Series([0.5, 0.25], dtype=object)))
 
     def test_non_numeric_probability_is_rejected(self):
-        self.assertFalse(self._validate(['most of it']))
-        self.mock_logger.warning.assert_called_with('probability column must contain numeric values.')
+        """The rejection must be reported as such whatever dtype the strings arrive as.
 
-    def test_nullable_extension_dtype_probability_is_rejected(self):
-        """np.issubdtype cannot interpret a pandas extension dtype, so the outer except warns."""
-        self.assertFalse(self._validate(pd.array([0.5, 0.25], dtype='Float64')))
-        assert any('Error occurred while validating CSV file' in args[0]
-                   for args, _ in self.mock_logger.warning.call_args_list)
+        pandas is moving to a dedicated string dtype, and np.issubdtype cannot interpret one --
+        it raises, and the outer except turns a plain 'this column is not numeric' into an
+        internal error message, which is not what a file validator should tell a user.
+        """
+        for dtype in [None, 'object', 'string']:
+            with self.subTest(dtype=dtype):
+                self.assertFalse(self._validate(pd.Series(['most of it'], dtype=dtype)))
+                self.mock_logger.warning.assert_called_with(
+                    'probability column must contain numeric values.')
+
+    def test_nullable_extension_dtype_probability_is_accepted(self):
+        """A nullable Float64 column is a numeric probability column like any other."""
+        self.assertTrue(self._validate(pd.array([0.5, 0.25], dtype='Float64')))
+        self.assertFalse(self._validate(pd.array([0.5, 1.25], dtype='Float64')))
+        self.mock_logger.warning.assert_called_with('probability column must contain values between 0 and 1.')
 
 
 class TestValidateAnalysisOedFields(TestCase):


### PR DESCRIPTION
Part of #2100.

Seven small row-wise passes over data that scales with the exposure or the output, each replaced by the array operation it was spelling out by hand:

- gul/gulmc build_structures: the peril filter mask was a python set lookup per keys row, now np.isin (2M keys rows: 0.68s -> 0.006s). The keys dtype and the filter itself were duplicated between the two callers and are now shared as `KEYS_DTYPE` / `filter_area_peril_id` in `pytools/common/input_files.py`, which is also what makes them testable. This fixes a latent crash: on an empty keys table the list comprehension produced a float64 array, so indexing with it raised `IndexError: arrays used as indices must be of integer (or boolean) type`.
- gulmc get_dynamic_footprint_adjustments: the zero-adjustment fallback built one tuple per item, now np.zeros with the item ids assigned in
- il_inputs: the StepTriggerType sub-type was resolved by a row-wise apply with try/except, now a lookup indexed by (steptriggertype, coverage_type_id). The five lines that apply it are extracted as `assign_sub_step_trigger_types` so the tests exercise the production code rather than a copy of it; a pair with no sub-type keeps its trigger type as before.
- join_summary_info: the summary info was scattered by index in a loop and, for parquet, joined per row by agg(",".join) and indexed per row by apply
- getmodel _build_footprint: groupby.transform(lambda x: x / x.sum()) per areaperil, now a divide by transform('sum')
- exposure run: apply(str) per column, now astype(str)

None of the changed lines is inside an `@njit` function, so none of the numba hazards — nopython support, object-mode fallback, allocation inside prange, or the known gulpy-vs-gulmc fastmath codegen divergence — are in play here.

## The one that is not bit-for-bit equal

The footprint probabilities now divide by a groupby sum, which differs from summing each group separately in the last bits of a float64. Measured over 400 randomised trials the largest relative difference is 5.97e-16, one to two ULP, appearing at group sizes 10, 100 and 100000.

`probability` in `EventDynamic` is `oasis_float`, which defaults to f4, and over 301,689 rows **0** values differed after the cast — so the written footprint is identical in practice. Two caveats worth stating rather than papering over: that f4 absorption is empirical, not a proof (a 1e-16 perturbation straddles an f4 rounding boundary with probability ~1e-9 per value, which stops being negligible on a model with hundreds of millions of footprint rows); and under `OASIS_FLOAT=f8`, which is supported and exercised in the test suite, the written probabilities *will* differ in the last bits. The values are a renormalisation, so a 1-ULP shift carries no meaning either way.

## Correction to an earlier version of this description

An earlier version of this description said `validate_vuln_csv_contents`' old `isinstance(x, (int, float))` check "rejected an integer or float32 column because np.int64 and np.float32 are not int or float subclasses". That is wrong. While `isinstance(np.int64(1), int)` is indeed False, `Series.apply` maps over `.astype(object)`, which unboxes to python `int`/`float` — so `int64`, `int32`, `float32` and `float64` columns were **all** accepted already, and none of the cited scenarios was reachable anyway, since the sole call path is `pd.read_csv(file_path)` with no `dtype=`.

The change to `np.issubdtype(dtype, np.number)` is a safe speedup on every reachable input. Its real deltas are all in the stricter direction and none is reachable from `read_csv`:

- a `bool` column: accepted before (`True` -> 1, inside [0,1]), rejected now. The new answer is the better one.
- an `object` column holding python numbers: accepted before, rejected now.
- a pandas extension dtype such as `Float64`: `np.issubdtype` raises `TypeError`, which the function's outer `except Exception` turns into a warning and a False.

All three are now pinned by tests, which matters because `tests/utils/test_data.py` mocks `pandas.read_csv` and injects hand-built frames, so a fixture can reach them even though a real csv cannot.

## Fixes #2114

Found while checking the join_summary_info change against pandas 3's string dtype. A summary id past the end of the summary info joined to `""`, which splits into one field however many summary columns there are: a partly-unmatched file was written with the first summary column empty and the rest null, and a file where nothing matched raised `ValueError: Columns must be same length as key`. It now joins to the same empty columns a gap in the summary info already joins to, which is also what the CSV path already writes. The crash is on main too, not from this branch.

Note this half is a **user-visible output change**, not only a crash fix: a consumer reading the joined parquet now gets `""` where it previously got null, so `.isna()`/`.dropna()`/`fillna` behaviour flips. Since `CHANGELOG.rst` is generated at publish time from PR titles, that change would otherwise reach users under the heading "Array operations speedup". Happy to split it into its own PR if that reads better — see the discussion on #2100.

## Three edges closed while the files were open

Each was reachable and silently wrong or a crash, and each has a test that fails without the fix:

- **A negative `SummaryId` joined to the wrong summary.** `summary_id <= max_summary_id` is true for a negative id, which is a legal numpy index, so the row silently took its summary info counted back from the end of the table. Pre-existing, in both the parquet and csv paths, and now bounded below in both.
- **A summary-info file holding nothing but `summary_id` crashed the parquet path.** `.iloc[:, 0]` on a frame with no remaining columns raises `IndexError`. The csv path already handled it, and the data file now comes back unchanged rather than the join failing.
- **A repeated `--extra-summary-cols` crashed `oasislmf exposure run`.** `extra_summary_cols` comes straight from the CLI and was never checked against the level's own `summary_cols`, so naming a column the level already has gave groupby a grouper that is not 1-dimensional (and, on the gul-only path, gave the frame-wide `astype(str)` a duplicate key). The columns are de-duplicated now. Also pre-existing.

## Tests

`tests/fm/test_fmpy.py` 21 passed (covers step policies end to end), gul/gulmc 1272 passed, and `tests/computation/test_run_exposure.py` 58 passed against five unchanged expected-output CSVs.

New:
- 14 tests for the shared peril filter, diffed against a verbatim copy of the set-membership loop it replaces across list/set/tuple/case-mismatch/prefix/absent filter shapes, plus the empty-keys case — which asserts the *old* implementation raises, pinning the crash the change fixes.
- 12 for the sub-step trigger type lookup and its application, parametrised over `int64`/`int32`/`float64`/`object`/`Int32`/`Int64`. `Int32` is what the real pipeline carries, and it is the one a numpy `astype` cannot handle.
- 7 for the `validate_vuln_csv_contents` probability dtype branch, whose reject path no test reached before.
- 7 for the join, covering the #2114 fix plus the negative-id and no-info-column edges above, with the parquet and csv paths cross-checked against each other.
