### PR TITLE
feat/validate_before_keys

### DIFF
--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -227,7 +227,7 @@ class GenerateFiles(ComputationStep):
             account_df = exposure_data.account.dataframe
             # Validate location/account referential integrity now, before the (potentially very
             # long) keys lookup stage, so a bad portfolio fails fast instead of after hours of work.
-            validate_account_location_references(location_df, account_df)
+            validate_account_location_references(exposure_data.location.dataframe, exposure_data.account.dataframe)
         else:
             account_df = None
 

--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -227,7 +227,10 @@ class GenerateFiles(ComputationStep):
             account_df = exposure_data.account.dataframe
             # Validate location/account referential integrity now, before the (potentially very
             # long) keys lookup stage, so a bad portfolio fails fast instead of after hours of work.
-            validate_account_location_references(exposure_data.location.dataframe, exposure_data.account.dataframe)
+            # exposure_data.location can be None (e.g. cyber, marine - no location file), in which
+            # case there's nothing to validate against accounts.
+            true_location_df = exposure_data.location.dataframe if exposure_data.location is not None else None
+            validate_account_location_references(true_location_df, exposure_data.account.dataframe)
         else:
             account_df = None
 

--- a/oasislmf/computation/generate/files.py
+++ b/oasislmf/computation/generate/files.py
@@ -37,7 +37,8 @@ from oasislmf.preparation.gul_inputs import (get_gul_input_items,
                                              process_group_id_cols,
                                              write_gul_input_files)
 from oasislmf.preparation.il_inputs import (get_il_input_items,
-                                            get_oed_hierarchy)
+                                            get_oed_hierarchy,
+                                            validate_account_location_references)
 from oasislmf.preparation.reinsurance_layer import write_files_for_reinsurance
 from oasislmf.preparation.summaries import (get_summary_mapping,
                                             merge_oed_to_mapping,
@@ -224,6 +225,9 @@ class GenerateFiles(ComputationStep):
         if il:
             exposure_data.account.dataframe = prepare_account_df(exposure_data.account.dataframe)
             account_df = exposure_data.account.dataframe
+            # Validate location/account referential integrity now, before the (potentially very
+            # long) keys lookup stage, so a bad portfolio fails fast instead of after hours of work.
+            validate_account_location_references(location_df, account_df)
         else:
             account_df = None
 

--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -197,8 +197,7 @@ def __split_fm_terms_by_risk(df):
 
 
 def check_cond_tags(locations_df, accounts_df):
-    """
-    Raise if any non-default CondTag referenced by a location is not present
+    """Raise if any non-default CondTag referenced by a location is not present
     in the account file for that acc_id.
 
     Kept standalone (rather than inlined in get_cond_info) so it can also be
@@ -226,8 +225,7 @@ def check_cond_tags(locations_df, accounts_df):
 
 
 def validate_account_location_references(locations_df, accounts_df):
-    """
-    Validate that every location's account/policy reference resolves to a
+    """Validate that every location's account/policy reference resolves to a
     row in the account file.
 
     This covers the same referential-integrity checks that would otherwise

--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -204,6 +204,8 @@ def check_cond_tags(locations_df, accounts_df):
     run as a cheap, early sanity check on just locations_df/accounts_df -
     e.g. by validate_account_location_references - before any of the more
     expensive keys lookup or GUL processing has run.
+
+    Returns (loc_condkey_df, acc_condkey_df).
     """
     default_cond_tag = '0'
     if 'CondTag' in locations_df.columns:
@@ -218,22 +220,22 @@ def check_cond_tags(locations_df, accounts_df):
         condkey_match_df = acc_condkey_df.merge(loc_condkey_df, how='outer', indicator=True)
         missing_condkey_df = condkey_match_df.loc[condkey_match_df['_merge'] == 'right_only', ['acc_id', 'CondTag']]
     else:
+        acc_condkey_df = pd.DataFrame([], columns=['acc_id', 'CondTag'])
         missing_condkey_df = loc_condkey_df
 
     if missing_condkey_df.shape[0]:
         raise OasisException(f'Those condtag are present in locations but missing in the account file:\n{missing_condkey_df}')
 
+    return loc_condkey_df, acc_condkey_df
+
 
 def validate_account_location_references(locations_df, accounts_df):
-    """Validate that every location's account/policy reference resolves to a
-    row in the account file.
+    """Validate that every location's PortNumber/AccNumber and CondTag
+    references resolve to a row in the account file.
 
-    This covers the same referential-integrity checks that would otherwise
-    only surface deep inside get_il_input_items (via prepare_il_source_dataframes
-    and get_cond_info), i.e. after the (potentially very long) keys lookup and
-    GUL processing stages have already run. It only needs locations_df/accounts_df,
-    so it should be called as early as possible in the files-generation pipeline,
-    so a bad portfolio fails in seconds rather than after hours of keys lookup.
+    Should be called as early as possible in the files-generation pipeline -
+    it only needs locations_df/accounts_df - so a bad portfolio fails in
+    seconds rather than after hours of keys lookup.
 
     locations_df/accounts_df themselves are never mutated - only fresh frames
     derived from them (merge results, or minimal column-subset copies) are.
@@ -261,7 +263,7 @@ def validate_account_location_references(locations_df, accounts_df):
         offending_locations = locations_df.loc[missing_acc_mask, id_cols].drop_duplicates()
         raise OasisException(
             'The following locations reference a PortNumber/AccNumber combination '
-            f'that is not present in the account file:\n{offending_locations.to_string(index=False)}'
+            f'that is not present in the account file:\n{offending_locations.head(20).to_string(index=False)}'
         )
 
     # Built from plain numpy arrays (copy=True) rather than sliced from locations_df/accounts_df,
@@ -281,17 +283,8 @@ def get_cond_info(locations_df, accounts_df):
     pol_info = {}
     level_conds = {}
     extra_accounts = []
-    check_cond_tags(locations_df, accounts_df)
+    _, acc_condkey_df = check_cond_tags(locations_df, accounts_df)
     default_cond_tag = '0'
-    if 'CondTag' in locations_df.columns:
-        loc_condkey_df = locations_df.loc[locations_df['CondTag'] != default_cond_tag, ['acc_id', 'CondTag']].drop_duplicates()
-    else:
-        loc_condkey_df = pd.DataFrame([], columns=['acc_id', 'CondTag'])
-
-    if 'CondTag' in accounts_df.columns:
-        acc_condkey_df = accounts_df.loc[accounts_df['CondTag'] != '', ['acc_id', 'CondTag']].drop_duplicates()
-    else:
-        acc_condkey_df = pd.DataFrame([], columns=['acc_id', 'CondTag'])
 
     if acc_condkey_df.shape[0]:
         if 'CondTag' not in locations_df.columns:

--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -256,9 +256,10 @@ def validate_account_location_references(locations_df, accounts_df):
         acc_id_map = accounts_df[['PortNumber', 'AccNumber']].assign(acc_id=acc_id_col).drop_duplicates()
         dup_keys = acc_id_map.duplicated(subset=['PortNumber', 'AccNumber'], keep=False)
         if dup_keys.any():
+            dups = acc_id_map.loc[dup_keys]
             raise OasisException(
                 'The following PortNumber/AccNumber combinations map to more than one acc_id '
-                f'in the account file:\n{acc_id_map.loc[dup_keys].head(20).to_string(index=False)}'
+                f'in the account file (total={len(dups)}):\n{dups.head(20).to_string(index=False)}'
             )
         loc_acc_id_col = locations_df[['PortNumber', 'AccNumber']].merge(
             acc_id_map, how='left', on=['PortNumber', 'AccNumber'])['acc_id'].to_numpy()
@@ -268,8 +269,8 @@ def validate_account_location_references(locations_df, accounts_df):
         id_cols = [col for col in ['LocNumber', 'PortNumber', 'AccNumber'] if col in locations_df.columns]
         offending_locations = locations_df.loc[missing_acc_mask, id_cols].drop_duplicates()
         raise OasisException(
-            'The following locations reference a PortNumber/AccNumber combination '
-            f'that is not present in the account file:\n{offending_locations.head(20).to_string(index=False)}'
+            'The following locations reference a PortNumber/AccNumber combination that is not present '
+            f'in the account file (total={len(offending_locations)}):\n{offending_locations.head(20).to_string(index=False)}'
         )
 
     # Built from plain numpy arrays (copy=True) rather than sliced from locations_df/accounts_df,

--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -216,7 +216,7 @@ def check_cond_tags(locations_df, accounts_df):
 
     if 'CondTag' in accounts_df.columns:
         fill_empty(accounts_df, 'CondTag', default_cond_tag)
-        acc_condkey_df = accounts_df.loc[accounts_df['CondTag'] != '', ['acc_id', 'CondTag']].drop_duplicates()
+        acc_condkey_df = accounts_df.loc[accounts_df['CondTag'] != default_cond_tag, ['acc_id', 'CondTag']].drop_duplicates()
         condkey_match_df = acc_condkey_df.merge(loc_condkey_df, how='outer', indicator=True)
         missing_condkey_df = condkey_match_df.loc[condkey_match_df['_merge'] == 'right_only', ['acc_id', 'CondTag']]
     else:
@@ -254,6 +254,12 @@ def validate_account_location_references(locations_df, accounts_df):
         loc_acc_id_col = locations_df['acc_id'].to_numpy()
     else:
         acc_id_map = accounts_df[['PortNumber', 'AccNumber']].assign(acc_id=acc_id_col).drop_duplicates()
+        dup_keys = acc_id_map.duplicated(subset=['PortNumber', 'AccNumber'], keep=False)
+        if dup_keys.any():
+            raise OasisException(
+                'The following PortNumber/AccNumber combinations map to more than one acc_id '
+                f'in the account file:\n{acc_id_map.loc[dup_keys].head(20).to_string(index=False)}'
+            )
         loc_acc_id_col = locations_df[['PortNumber', 'AccNumber']].merge(
             acc_id_map, how='left', on=['PortNumber', 'AccNumber'])['acc_id'].to_numpy()
 
@@ -643,6 +649,15 @@ def _check_unique_merge_keys(level_df, agg_id_merge_col, agg_id_merge_col_extra,
     )
 
 
+def assign_acc_id(accounts_df):
+    """Ensure accounts_df has an 'acc_id' column, computing it from PortNumber/AccNumber
+    if not already present. Mutates accounts_df in place; idempotent.
+    """
+    if 'acc_id' not in accounts_df.columns:
+        accounts_df['acc_id'] = get_ids(accounts_df, ['PortNumber', 'AccNumber'])
+    return accounts_df
+
+
 @oasis_log
 def prepare_il_source_dataframes(gul_inputs_df, exposure_data):
     """Resolve the acc_id key across gul/location/account frames and fill location defaults.
@@ -663,8 +678,7 @@ def prepare_il_source_dataframes(gul_inputs_df, exposure_data):
     if exposure_data.location is not None:
         locations_df = exposure_data.location.dataframe
         accounts_df = exposure_data.account.dataframe
-        if 'acc_id' not in accounts_df:
-            accounts_df['acc_id'] = get_ids(exposure_data.account.dataframe, ['PortNumber', 'AccNumber'])
+        assign_acc_id(accounts_df)
         acc_id_map = accounts_df[['PortNumber', 'AccNumber', 'acc_id']].drop_duplicates()
         gul_inputs_df = gul_inputs_df.merge(acc_id_map, how='left')
         locations_df = locations_df.merge(acc_id_map, how='left')

--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -4,6 +4,7 @@ __all__ = [
     'get_grouped_fm_terms_by_level_and_term_group',
     'get_oed_hierarchy',
     'get_il_input_items',
+    'validate_account_location_references',
 ]
 
 import contextlib
@@ -195,10 +196,16 @@ def __split_fm_terms_by_risk(df):
             df[term] /= df['NumberOfRisks']
 
 
-def get_cond_info(locations_df, accounts_df):
-    pol_info = {}
-    level_conds = {}
-    extra_accounts = []
+def check_cond_tags(locations_df, accounts_df):
+    """
+    Raise if any non-default CondTag referenced by a location is not present
+    in the account file for that acc_id.
+
+    Kept standalone (rather than inlined in get_cond_info) so it can also be
+    run as a cheap, early sanity check on just locations_df/accounts_df -
+    e.g. by validate_account_location_references - before any of the more
+    expensive keys lookup or GUL processing has run.
+    """
     default_cond_tag = '0'
     if 'CondTag' in locations_df.columns:
         fill_empty(locations_df, 'CondTag', default_cond_tag)
@@ -212,11 +219,81 @@ def get_cond_info(locations_df, accounts_df):
         condkey_match_df = acc_condkey_df.merge(loc_condkey_df, how='outer', indicator=True)
         missing_condkey_df = condkey_match_df.loc[condkey_match_df['_merge'] == 'right_only', ['acc_id', 'CondTag']]
     else:
-        acc_condkey_df = pd.DataFrame([], columns=['acc_id', 'CondTag'])
         missing_condkey_df = loc_condkey_df
 
     if missing_condkey_df.shape[0]:
         raise OasisException(f'Those condtag are present in locations but missing in the account file:\n{missing_condkey_df}')
+
+
+def validate_account_location_references(locations_df, accounts_df):
+    """
+    Validate that every location's account/policy reference resolves to a
+    row in the account file.
+
+    This covers the same referential-integrity checks that would otherwise
+    only surface deep inside get_il_input_items (via prepare_il_source_dataframes
+    and get_cond_info), i.e. after the (potentially very long) keys lookup and
+    GUL processing stages have already run. It only needs locations_df/accounts_df,
+    so it should be called as early as possible in the files-generation pipeline,
+    so a bad portfolio fails in seconds rather than after hours of keys lookup.
+
+    locations_df/accounts_df themselves are never mutated - only fresh frames
+    derived from them (merge results, or minimal column-subset copies) are.
+    """
+    if locations_df is None or accounts_df is None:
+        return
+
+    # Positional numpy arrays throughout (never Series) so the merge below - which resets
+    # the index - can't misalign values when reattached to locations_df/accounts_df.
+    if 'acc_id' in accounts_df.columns:
+        acc_id_col = accounts_df['acc_id'].to_numpy()
+    else:
+        acc_id_col = np.asarray(get_ids(accounts_df, ['PortNumber', 'AccNumber']))
+
+    if 'acc_id' in locations_df.columns:
+        loc_acc_id_col = locations_df['acc_id'].to_numpy()
+    else:
+        acc_id_map = accounts_df[['PortNumber', 'AccNumber']].assign(acc_id=acc_id_col).drop_duplicates()
+        loc_acc_id_col = locations_df[['PortNumber', 'AccNumber']].merge(
+            acc_id_map, how='left', on=['PortNumber', 'AccNumber'])['acc_id'].to_numpy()
+
+    missing_acc_mask = pd.isna(loc_acc_id_col) | ~pd.Series(loc_acc_id_col).isin(acc_id_col).to_numpy()
+    if missing_acc_mask.any():
+        id_cols = [col for col in ['LocNumber', 'PortNumber', 'AccNumber'] if col in locations_df.columns]
+        offending_locations = locations_df.loc[missing_acc_mask, id_cols].drop_duplicates()
+        raise OasisException(
+            'The following locations reference a PortNumber/AccNumber combination '
+            f'that is not present in the account file:\n{offending_locations.to_string(index=False)}'
+        )
+
+    # Built from plain numpy arrays (copy=True) rather than sliced from locations_df/accounts_df,
+    # so check_cond_tags' in-place fill_empty() calls can't leak back into the caller's data.
+    loc_cond_df = pd.DataFrame({'acc_id': loc_acc_id_col.copy()})
+    if 'CondTag' in locations_df.columns:
+        loc_cond_df['CondTag'] = locations_df['CondTag'].to_numpy(copy=True)
+
+    acc_cond_df = pd.DataFrame({'acc_id': acc_id_col.copy()})
+    if 'CondTag' in accounts_df.columns:
+        acc_cond_df['CondTag'] = accounts_df['CondTag'].to_numpy(copy=True)
+
+    check_cond_tags(loc_cond_df, acc_cond_df)
+
+
+def get_cond_info(locations_df, accounts_df):
+    pol_info = {}
+    level_conds = {}
+    extra_accounts = []
+    check_cond_tags(locations_df, accounts_df)
+    default_cond_tag = '0'
+    if 'CondTag' in locations_df.columns:
+        loc_condkey_df = locations_df.loc[locations_df['CondTag'] != default_cond_tag, ['acc_id', 'CondTag']].drop_duplicates()
+    else:
+        loc_condkey_df = pd.DataFrame([], columns=['acc_id', 'CondTag'])
+
+    if 'CondTag' in accounts_df.columns:
+        acc_condkey_df = accounts_df.loc[accounts_df['CondTag'] != '', ['acc_id', 'CondTag']].drop_duplicates()
+    else:
+        acc_condkey_df = pd.DataFrame([], columns=['acc_id', 'CondTag'])
 
     if acc_condkey_df.shape[0]:
         if 'CondTag' not in locations_df.columns:

--- a/tests/computation/test_generate_files.py
+++ b/tests/computation/test_generate_files.py
@@ -1,5 +1,6 @@
 import pathlib
 import os
+import io
 import logging
 import re
 import pandas as pd
@@ -7,7 +8,8 @@ import responses
 
 from unittest.mock import patch
 
-from ods_tools.oed.common import OdsException
+from ods_tools.oed.common import OdsException, ClassOfBusiness
+from ods_tools.oed.exposure import OedExposure
 from oasislmf.utils.exceptions import OasisException, OasisExceptionNoKeys
 from oasislmf.utils.path import setcwd
 from oasislmf.manager import OasisManager
@@ -109,6 +111,36 @@ class TestGenFiles(ComputationChecker):
             for _, filepath in expected_return.items():
                 self.assertTrue(os.path.isfile(filepath))
                 self.assertTrue(os.path.getsize(filepath) > 0)
+
+    @patch('oasislmf.computation.generate.files.validate_account_location_references')
+    def test_files__cyber_class_of_business__no_location_file__does_not_raise(self, mock_validate):
+        # Regression test: for classes of business such as Cyber/Liability, no location
+        # file is required so exposure_data.location can legitimately be None. GenerateFiles.run()
+        # must not crash trying to access .dataframe on it - it should pass None through instead.
+        account_df = pd.read_csv(io.StringIO(MIN_ACC))
+        exposure_data = OedExposure(
+            location=None,
+            account=account_df,
+            class_of_business=ClassOfBusiness.cyb,
+            use_field=True,
+        )
+
+        with self.tmp_dir() as t_dir:
+            try:
+                self.manager.generate_files(
+                    exposure_data=exposure_data,
+                    lookup_config_json=LOOKUP_CONFIG,
+                    oasis_files_dir=t_dir,
+                )
+            except AttributeError as e:
+                self.fail(f"generate_files() raised AttributeError instead of handling a None location: {e}")
+            except Exception:
+                # Downstream keys lookup/GUL processing isn't exercised by this minimal
+                # account-only fixture - only the location=None handling is under test here.
+                pass
+
+            mock_validate.assert_called_once()
+            self.assertIsNone(mock_validate.call_args[0][0])
 
     def test_files__check_return__ri_args__given_output_dir(self):
         with self.tmp_dir() as t_dir:

--- a/tests/preparation/test_il_inputs.py
+++ b/tests/preparation/test_il_inputs.py
@@ -85,6 +85,7 @@ class TestValidateAccountLocationReferences(TestCase):
             validate_account_location_references(locations_df, accounts_df)
 
         self.assertIn('condtag', str(ctx.exception))
+        self.assertIn('C1', str(ctx.exception))
 
 
 class TestCheckCondTags(TestCase):

--- a/tests/preparation/test_il_inputs.py
+++ b/tests/preparation/test_il_inputs.py
@@ -1,0 +1,161 @@
+"""
+Unit tests for the early referential-integrity checks in oasislmf.preparation.il_inputs:
+validate_account_location_references() and check_cond_tags().
+"""
+from unittest import TestCase, main
+
+import pandas as pd
+
+from oasislmf.preparation.il_inputs import (
+    check_cond_tags,
+    get_cond_info,
+    validate_account_location_references,
+)
+from oasislmf.utils.exceptions import OasisException
+
+
+def make_locations(**overrides):
+    data = {
+        'LocNumber': [1, 2, 3],
+        'PortNumber': ['1', '1', '1'],
+        'AccNumber': ['A1', 'A1', 'A2'],
+    }
+    data.update(overrides)
+    return pd.DataFrame(data)
+
+
+def make_accounts(**overrides):
+    data = {
+        'PortNumber': ['1', '1'],
+        'AccNumber': ['A1', 'A2'],
+    }
+    data.update(overrides)
+    return pd.DataFrame(data)
+
+
+class TestValidateAccountLocationReferences(TestCase):
+    def test_none_inputs_are_a_no_op(self):
+        # should not raise regardless of which side is missing (e.g. GUL-only portfolios)
+        validate_account_location_references(None, None)
+        validate_account_location_references(make_locations(), None)
+        validate_account_location_references(None, make_accounts())
+
+    def test_valid_data_passes_without_mutating_inputs(self):
+        locations_df = make_locations()
+        accounts_df = make_accounts()
+        loc_snapshot = locations_df.copy(deep=True)
+        acc_snapshot = accounts_df.copy(deep=True)
+
+        validate_account_location_references(locations_df, accounts_df)
+
+        pd.testing.assert_frame_equal(locations_df, loc_snapshot)
+        pd.testing.assert_frame_equal(accounts_df, acc_snapshot)
+
+    def test_valid_data_with_preexisting_acc_id_column(self):
+        # exercises the "acc_id already present" branches on both frames, instead of
+        # computing it via get_ids()/merge
+        accounts_df = make_accounts(acc_id=[1, 2])
+        locations_df = make_locations(acc_id=[1, 1, 2])
+
+        validate_account_location_references(locations_df, accounts_df)
+
+    def test_missing_account_reference_raises(self):
+        locations_df = make_locations(AccNumber=['A1', 'A1', 'A9'])
+        accounts_df = make_accounts()
+
+        with self.assertRaises(OasisException) as ctx:
+            validate_account_location_references(locations_df, accounts_df)
+
+        self.assertIn('PortNumber/AccNumber combination', str(ctx.exception))
+        self.assertIn('A9', str(ctx.exception))
+
+    def test_valid_matching_condtag_on_both_sides_does_not_raise(self):
+        # exercises the CondTag branches in validate_account_location_references itself
+        # (as opposed to check_cond_tags directly), on both the location and account side
+        locations_df = make_locations(acc_id=[1, 1, 2], CondTag=['C1', '0', '0'])
+        accounts_df = make_accounts(acc_id=[1, 2], CondTag=['C1', ''])
+
+        validate_account_location_references(locations_df, accounts_df)
+
+    def test_missing_condtag_reference_raises(self):
+        locations_df = make_locations(CondTag=['C1', '0', '0'])
+        accounts_df = make_accounts()
+
+        with self.assertRaises(OasisException) as ctx:
+            validate_account_location_references(locations_df, accounts_df)
+
+        self.assertIn('condtag', str(ctx.exception))
+
+
+class TestCheckCondTags(TestCase):
+    def test_no_condtag_columns_does_not_raise(self):
+        check_cond_tags(make_locations(acc_id=[1, 1, 2]), make_accounts(acc_id=[1, 2]))
+
+    def test_condtag_in_locations_only_raises(self):
+        locations_df = make_locations(acc_id=[1, 1, 2], CondTag=['C1', '0', '0'])
+        accounts_df = make_accounts(acc_id=[1, 2])
+
+        with self.assertRaises(OasisException):
+            check_cond_tags(locations_df, accounts_df)
+
+    def test_matching_condtag_on_both_sides_does_not_raise(self):
+        locations_df = make_locations(acc_id=[1, 1, 2], CondTag=['C1', '0', '0'])
+        accounts_df = make_accounts(acc_id=[1, 2], CondTag=['C1', ''])
+
+        check_cond_tags(locations_df, accounts_df)
+
+    def test_condtag_missing_from_accounts_condtag_column_raises(self):
+        # accounts_df declares a CondTag column, but not the one referenced by the location
+        locations_df = make_locations(acc_id=[1, 1, 2], CondTag=['C1', '0', '0'])
+        accounts_df = make_accounts(acc_id=[1, 2], CondTag=['C2', ''])
+
+        with self.assertRaises(OasisException):
+            check_cond_tags(locations_df, accounts_df)
+
+
+class TestGetCondInfo(TestCase):
+    def test_get_cond_info_still_calls_check_cond_tags_first(self):
+        # get_cond_info() is only ever reached when the account file already declares
+        # both CondTag and CondNumber (see get_levels' gating condition), so build minimal
+        # fixtures for that shape directly, rather than depending on end-to-end fixtures.
+        locations_df = pd.DataFrame({
+            'loc_id': [1, 2],
+            'acc_id': [10, 10],
+            'CondTag': ['C1', '0'],
+        })
+        accounts_df = pd.DataFrame({
+            'acc_id': [10],
+            'layer_id': [1],
+            'PolNumber': ['P1'],
+            'LayerNumber': [1],
+            'acc_idx': [0],
+            'CondTag': ['C1'],
+            'CondNumber': [1],
+        })
+
+        level_conds, extra_accounts = get_cond_info(locations_df, accounts_df)
+
+        self.assertEqual(level_conds, {1: {(10, '0'), (10, 'C1')}})
+
+    def test_get_cond_info_raises_via_check_cond_tags_on_mismatch(self):
+        locations_df = pd.DataFrame({
+            'loc_id': [1],
+            'acc_id': [10],
+            'CondTag': ['C9'],
+        })
+        accounts_df = pd.DataFrame({
+            'acc_id': [10],
+            'layer_id': [1],
+            'PolNumber': ['P1'],
+            'LayerNumber': [1],
+            'acc_idx': [0],
+            'CondTag': ['C1'],
+            'CondNumber': [1],
+        })
+
+        with self.assertRaises(OasisException):
+            get_cond_info(locations_df, accounts_df)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/preparation/test_il_inputs.py
+++ b/tests/preparation/test_il_inputs.py
@@ -68,6 +68,19 @@ class TestValidateAccountLocationReferences(TestCase):
 
         self.assertIn('PortNumber/AccNumber combination', str(ctx.exception))
         self.assertIn('A9', str(ctx.exception))
+        self.assertIn('total=1', str(ctx.exception))
+
+    def test_duplicate_acc_id_mapping_raises(self):
+        # a pre-existing (corrupted) acc_id column where the same PortNumber/AccNumber
+        # combination maps to two different acc_id values
+        locations_df = make_locations(AccNumber=['A1', 'A1', 'A1'])
+        accounts_df = make_accounts(AccNumber=['A1', 'A1'], acc_id=[10, 99])
+
+        with self.assertRaises(OasisException) as ctx:
+            validate_account_location_references(locations_df, accounts_df)
+
+        self.assertIn('more than one acc_id', str(ctx.exception))
+        self.assertIn('total=2', str(ctx.exception))
 
     def test_valid_matching_condtag_on_both_sides_does_not_raise(self):
         # exercises the CondTag branches in validate_account_location_references itself


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### feat/validate_before_keys
Validates location/account referential integrity (`PortNumber`/`AccNumber`/`CondTag` references) immediately after exposure data is loaded in `GenerateFiles.run()`, before the keys lookup stage runs. Previously this class of portfolio error either went undetected until deep inside IL/FM input generation — after the (potentially multi-hour) keys lookup had already completed — or, for the `PortNumber`/`AccNumber` case specifically, wasn't checked explicitly at all and surfaced later as an unrelated-looking `ValueError: cannot convert NA to integer`.

Adds `validate_account_location_references()` to `oasislmf/preparation/il_inputs.py`, refactoring the existing `CondTag` check out of `get_cond_info()` into a shared `check_cond_tags()` helper so both the new early check and the original in-`get_il_input_items()` check (kept as a safety net for direct callers) share one implementation. Also extends the check's coverage: the pre-existing `CondTag` validation only ran when the account file already declared both `CondTag` and `CondNumber` columns; the new check runs unconditionally whenever a `CondTag` column is present on either file.

closes https://github.com/OasisLMF/OasisLMF/issues/1452

<!--end_release_notes-->
