### PR TITLE
Issue 2109 repeated exposure run header issue

### DIFF
--- a/oasislmf/computation/run/exposure.py
+++ b/oasislmf/computation/run/exposure.py
@@ -265,6 +265,10 @@ class RunExposure(ComputationStep):
             all_losses_df = summary_gul_df.merge(how='left', right=summary_il_df, on=group_by_cols)
             all_losses_df = all_losses_df.merge(how='left', right=summary_ri_df, on=group_by_cols)
 
+        # Convert summary cols to strings for formatting. loss_factor_idx is left
+        # numeric so that it can still be compared against the loop index below.
+        all_losses_df[summary_cols] = all_losses_df[summary_cols].astype(str)
+
         for i in range(len(self.loss_factor)):
 
             if include_loss_factor:
@@ -303,15 +307,11 @@ class RunExposure(ComputationStep):
                         self.loss_factor[i],
                         total_gul, total_il, total_ri_ceded)
 
-            # Convert output cols to strings for formatting
-            for c in group_by_cols:
-                all_losses_df[c] = all_losses_df[c].apply(str)
-
             if self.print_summary:
                 cols_to_print = all_loss_cols.copy()
                 if include_loss_factor:
                     print_dataframe(
-                        all_losses_df[all_losses_df.loss_factor_idx == str(i)],
+                        all_losses_df[all_losses_df.loss_factor_idx == i],
                         frame_header=header,
                         cols=cols_to_print)
                 else:

--- a/oasislmf/computation/run/exposure.py
+++ b/oasislmf/computation/run/exposure.py
@@ -321,9 +321,6 @@ class RunExposure(ComputationStep):
                         self.loss_factor[i],
                         total_gul, total_il, total_ri_ceded)
 
-            # Convert output cols to strings for formatting
-            all_losses_df[group_by_cols] = all_losses_df[group_by_cols].astype(str)
-
             if self.print_summary:
                 cols_to_print = all_loss_cols.copy()
                 if include_loss_factor:

--- a/oasislmf/pytools/common/input_files.py
+++ b/oasislmf/pytools/common/input_files.py
@@ -8,8 +8,7 @@ from pathlib import Path
 
 from oasislmf.pytools.common.data import (
     oasis_int, oasis_float,
-    areaperil_int, load_as_ndarray, nb_oasis_int,
-    correlations_headers, correlations_dtype, coverages_headers,
+    areaperil_int, load_as_ndarray, correlations_headers, correlations_dtype, coverages_headers,
     occurrence_dtype, occurrence_granular_dtype, periods_dtype, quantile_dtype,
     quantile_interval_dtype, returnperiods_dtype,
 )

--- a/tests/computation/test_run_exposure.py
+++ b/tests/computation/test_run_exposure.py
@@ -1,4 +1,7 @@
+import io
 import os
+import re
+from contextlib import redirect_stdout
 from tempfile import NamedTemporaryFile
 from unittest.mock import patch
 
@@ -288,6 +291,13 @@ class _RunExposureIntegrationBase(ComputationChecker):
     def _run(self, output_file, **kwargs):
         return _run_exposure(output_file, **self.extra_kwargs, **kwargs)
 
+    def _run_capturing_summary(self, output_file, **kwargs):
+        params = {**BASE_PARAMS, **self.extra_kwargs, **kwargs, 'print_summary': True}
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            RunExposure(output_file=output_file, **params).run()
+        return buffer.getvalue()
+
     def test_acc_loc_run_returns_il_true_ril_false(self):
         il, ril = self._run(
             self._output_file(),
@@ -380,6 +390,21 @@ class _RunExposureIntegrationBase(ComputationChecker):
             loss_factor=[0.5],
         )
         _assert_output_matches(out, EXPECTED_LOSS_HALF)
+
+    def test_multiple_loss_factors_gul_totals_match_output(self):
+        out = self._output_file()
+        summary = self._run_capturing_summary(
+            out,
+            oed_location_csv=LOCATION,
+            oed_accounts_csv=ACCOUNTS,
+            loss_factor=[0.5, 1.0],
+        )
+        printed = [float(t.replace(',', '')) for t in re.findall(r'total gul=([\d,]+)', summary)]
+        expected = pd.read_csv(out).groupby('loss_factor_idx')['loss_gul'].sum()
+
+        self.assertEqual(len(printed), 2)
+        for idx, total in enumerate(printed):
+            self.assertAlmostEqual(total, expected[idx], delta=1)
 
 
 class TestRunExposureIntegration(_RunExposureIntegrationBase):


### PR DESCRIPTION
Fixes #2109.

`oasislmf exposure run` with more than one `--loss-factor` reported `total gul=0` in the summary header of every loss factor after the first.

```
Losses (loss factor=50.00%;  total gul=29,434,165,226; total il=13,189,168,265)
Losses (loss factor=100.00%; total gul=0;              total il=19,729,855,444)   before
Losses (loss factor=100.00%; total gul=58,868,330,451; total il=19,729,855,444)   after
```

## Cause

The loop over loss factors in `RunExposure.run` converted the group-by columns — which include `loss_factor_idx` — to strings at the end of each iteration, while `total_gul` was computed at the top of the same loop by comparing that column against the integer loop index. The first iteration saw integers and reported correctly; from the second on, `loss_factor_idx == i` matched no rows and the empty selection summed to 0.

Only GUL was affected because `total_il` and `total_ri_net` read from `ils_df` and `rils_df`, separate frames the conversion never touched.

## Change

Hoist the conversion out of the loop and apply it to `summary_cols` only, leaving `loss_factor_idx` numeric so both the total and the print filter compare against `i` directly. The `str(i)` in the print filter only existed to compensate for the in-loop conversion, so it goes with it.

The conversion is hoisted to *before* the loop rather than after. It currently runs ahead of every `print_dataframe` call, so the summary tables are already rendered from strings; moving it after the loop would change how every table renders. Placing it before keeps that behaviour and confines the change to the broken total. `astype(str)` on the block also replaces the per-column `apply(str)`.

## Verification

- `validation/insurance -l 0.5 1.0`: printed output byte-identical to `main` apart from the corrected total (diffed ~72k normalised lines).
- Same run with `--output-file`: CSV byte-identical (144k lines) — `loss_factor_idx` serialises to the same text as an int.
- `validation/reinsurance1 -l 0.5 1.0`: GUL totals now scale correctly across both factors.
- `tests/computation/test_run_exposure.py`: 58 passed. The 2 failures in `test_generate_losses.py` are pre-existing on `main`.

## Test

`test_multiple_loss_factors_gul_totals_match_output` runs with `loss_factor=[0.5, 1.0]`, parses the printed headers and asserts each total matches the per-factor `loss_gul` sum in the output CSV. It fails on unfixed code with `AssertionError: 0.0 != 6800000.0`.

No existing test used more than one loss factor, which is why this went unnoticed.

## Not in scope

`total ri ceded` is also wrong for loss factors after the first, but from an unrelated defect in `GenerateLossesDeterministic` — `run_ri_layer` truncates the GUL stream to one sample, so RI losses only exist for the first factor. It sits in a different module, needs a fixture check, and is tracked in #2118. The original description of #2109 wrongly claimed `total ri ceded` was unaffected; both that and its claim that GUL should not scale with the loss factor have been corrected on the issue.
