### PR TITLE
fix/exposure_run_preanalysis

### DIFF
--- a/oasislmf/computation/run/exposure.py
+++ b/oasislmf/computation/run/exposure.py
@@ -16,6 +16,7 @@ from oasislmf.computation.base import ComputationStep
 from oasislmf.computation.generate.files import GenerateFiles
 from oasislmf.computation.generate.keys import GenerateKeysDeterministic
 from oasislmf.computation.generate.losses import GenerateLossesDeterministic
+from oasislmf.computation.hooks.pre_analysis import ExposurePreAnalysis
 from oasislmf.preparation.il_inputs import get_oed_hierarchy
 from oasislmf.preparation.summaries import calculated_summary_cols
 from oasislmf.pytools.fm.portfolio_complexity import (
@@ -36,6 +37,11 @@ class RunExposure(ComputationStep):
     loss factors (loss % of TIV).
     """
     step_params = [
+        {'name': 'exposure_pre_analysis_module', 'required': False, 'is_path': True,
+         'pre_exist': True, 'help': 'Exposure Pre-Analysis lookup module path'},
+        # No '-a' flag: already taken by kernel_alloc_rule_il below.
+        {'name': 'analysis_settings_json', 'is_path': True, 'pre_exist': True,
+         'help': 'Analysis settings JSON file path'},
         {'name': 'src_dir', 'flag': '-s', 'is_path': True, 'pre_exist': True, 'help': ''},
         {'name': 'run_dir', 'flag': '-r', 'is_path': True, 'pre_exist': False, 'help': ''},
         {'name': 'check_oed', 'type': str2bool, 'const': True, 'nargs': '?', 'default': True, 'help': 'if True check input oed files'},
@@ -74,7 +80,7 @@ class RunExposure(ComputationStep):
          'help': 'if True, compute and report portfolio complexity metrics (GUL dimensions always; IL/RI FM structure when present)'},
     ]
 
-    chained_commands = [GenerateKeysDeterministic]
+    chained_commands = [GenerateKeysDeterministic, ExposurePreAnalysis]
 
     def get_exposure_data_config(self):
         def _resolve(override, key):
@@ -120,13 +126,21 @@ class RunExposure(ComputationStep):
         self.oasis_files_dir = src_dir
         exposure_data = get_exposure_data(self, add_internal_col=True)
 
+        if not os.path.exists(run_dir):
+            os.makedirs(run_dir)
+
+        # 0. Run model's exposure pre-analysis hook, if configured, so 'exposure run'
+        # validates and loss-tests the same (post-transform) exposure a real analysis would.
+        if self.exposure_pre_analysis_module:
+            ExposurePreAnalysis(**{
+                **self.kwargs,
+                **{"exposure_data": exposure_data, "oasis_files_dir": run_dir},
+            }).run()
+
         il = bool(exposure_data.account)
         ril = all([exposure_data.ri_info, exposure_data.ri_scope, il])
 
         self.logger.debug('\nRunning deterministic losses (GUL=True, IL={}, RIL={})\n'.format(il, ril))
-
-        if not os.path.exists(run_dir):
-            os.makedirs(run_dir)
 
         # 1. Create Deterministic keys file
         keys_fp = GenerateKeysDeterministic(**{**self.kwargs, **{"exposure_data": exposure_data, "oasis_files_dir": run_dir}}).run()[0]

--- a/tests/computation/test_run_exposure.py
+++ b/tests/computation/test_run_exposure.py
@@ -1,3 +1,4 @@
+import json
 import os
 from tempfile import NamedTemporaryFile
 from unittest.mock import patch
@@ -390,3 +391,67 @@ class TestRunExposureIntegration(_RunExposureIntegrationBase):
 class TestRunExposureIntegrationIntermediaryCsv(_RunExposureIntegrationBase):
     """Integration tests with intermediary_csv=True."""
     extra_kwargs = {'intermediary_csv': True}
+
+
+def _write_tiv_multiplier_module(module_path):
+    with open(module_path, 'w') as f:
+        f.write('''
+class ExposurePreAnalysis:
+    def __init__(self, exposure_data, exposure_pre_analysis_setting, **kwargs):
+        self.exposure_data = exposure_data
+        self.multiplier = exposure_pre_analysis_setting['BuildingTIV_multiplier']
+
+    def run(self):
+        loc_df = self.exposure_data.location.dataframe
+        loc_df['BuildingTIV'] = loc_df['BuildingTIV'] * self.multiplier
+''')
+
+
+def _write_setting_json(setting_path, multiplier):
+    with open(setting_path, 'w') as f:
+        json.dump({'BuildingTIV_multiplier': multiplier}, f)
+
+
+class TestRunExposurePreAnalysisHook(ComputationChecker):
+    """Regression tests for GH #2115: 'exposure run' must run a model's
+    exposure_pre_analysis_module, the same as 'model run' / 'generate-oasis-files'.
+    """
+
+    def setUp(self):
+        self.tmp = self.tmp_dir()
+
+    def _run_with_hook(self, out, multiplier):
+        module_path = os.path.join(self.tmp.name, 'epa.py')
+        setting_path = os.path.join(self.tmp.name, 'epa_setting.json')
+        _write_tiv_multiplier_module(module_path)
+        _write_setting_json(setting_path, multiplier)
+        return _run_exposure(
+            out,
+            oed_location_csv=LOCATION,
+            oed_accounts_csv=ACCOUNTS,
+            exposure_pre_analysis_module=module_path,
+            exposure_pre_analysis_setting_json=setting_path,
+        )
+
+    def test_pre_analysis_hook_modifies_exposure_before_keys_and_losses(self):
+        baseline_out = os.path.join(self.tmp.name, 'baseline.csv')
+        _run_exposure(baseline_out, oed_location_csv=LOCATION, oed_accounts_csv=ACCOUNTS)
+
+        doubled_out = os.path.join(self.tmp.name, 'doubled.csv')
+        self._run_with_hook(doubled_out, multiplier=2)
+
+        baseline = pd.read_csv(baseline_out)
+        doubled = pd.read_csv(doubled_out)
+        pd.testing.assert_series_equal(
+            doubled['loss_gul'],
+            baseline['loss_gul'] * 2,
+            check_names=False,
+            rtol=1e-4,
+        )
+
+    def test_without_pre_analysis_module_output_is_unaffected(self):
+        """Regression guard: adding the hook chain must not change behaviour
+        for callers who never set exposure_pre_analysis_module."""
+        out = os.path.join(self.tmp.name, 'output.csv')
+        _run_exposure(out, oed_location_csv=LOCATION, oed_accounts_csv=ACCOUNTS)
+        _assert_output_matches(out, EXPECTED_ACC_LOC)


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->
<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### fix/exposure_run_preanalysis
`oasislmf exposure run` previously ignored a model's `exposure_pre_analysis_module` entirely (silently dropping it with an "Unknown option(s)" warning), so it validated and loss-tested the raw, pre-transform OED instead of the same post-transform exposure a real `model run` / `generate-oasis-files` would process. `exposure run` now runs the configured hook before generating keys and deterministic losses, matching the existing behaviour of `model run` and `generate-oasis-files`. Note: in `exposure run`, `-a` still means `--kernel-alloc-rule-il` (unchanged, for backward compatibility) rather than `--analysis-settings-json` as in the other two commands — use the long-form `--analysis-settings-json` flag here.

Closes #2115
<!--end_release_notes-->
