### PR TITLE
Fix fmpy back-allocation rule 1 for layers above layer 1

### DIFF
--- a/oasislmf/pytools/fm/compute_sparse.py
+++ b/oasislmf/pytools/fm/compute_sparse.py
@@ -931,8 +931,8 @@ def compute_event(compute_info,
 
                             child_sidx = sidx_val[child_sidx_start: child_sidx_end]
                             child_loss = loss_val[loss_indptr[child['loss'] + profile_i]: loss_indptr[child['loss'] + profile_i] + child_val_count]
-                            child_net = loss_val[loss_indptr[child['net_loss'] + profile_i]
-                                : loss_indptr[child['net_loss'] + profile_i] + child_val_count]
+                            child_net = loss_val[loss_indptr[child['net_loss']]
+                                : loss_indptr[child['net_loss']] + child_val_count]
 
                             for val_i in range(child_val_count):
                                 child_loss[val_i] = child_net[val_i] * temp_node_loss[profile_i, child_sidx[val_i]]

--- a/oasislmf/pytools/fm/compute_sparse.py
+++ b/oasislmf/pytools/fm/compute_sparse.py
@@ -931,7 +931,7 @@ def compute_event(compute_info,
 
                             child_sidx = sidx_val[child_sidx_start: child_sidx_end]
                             child_loss = loss_val[loss_indptr[child['loss'] + profile_i]: loss_indptr[child['loss'] + profile_i] + child_val_count]
-                            child_net = loss_val[loss_indptr[child['net_loss'] + profile_i]: loss_indptr[child['net_loss'] + profile_i] + child_val_count]
+                            child_net = loss_val[loss_indptr[child['net_loss']]: loss_indptr[child['net_loss']] + child_val_count]
 
                             for val_i in range(child_val_count):
                                 child_loss[val_i] = child_net[val_i] * temp_node_loss[profile_i, child_sidx[val_i]]

--- a/oasislmf/pytools/fm/compute_sparse.py
+++ b/oasislmf/pytools/fm/compute_sparse.py
@@ -931,8 +931,7 @@ def compute_event(compute_info,
 
                             child_sidx = sidx_val[child_sidx_start: child_sidx_end]
                             child_loss = loss_val[loss_indptr[child['loss'] + profile_i]: loss_indptr[child['loss'] + profile_i] + child_val_count]
-                            child_net = loss_val[loss_indptr[child['net_loss']]
-                                : loss_indptr[child['net_loss']] + child_val_count]
+                            child_net = loss_val[loss_indptr[child['net_loss'] + profile_i]: loss_indptr[child['net_loss'] + profile_i] + child_val_count]
 
                             for val_i in range(child_val_count):
                                 child_loss[val_i] = child_net[val_i] * temp_node_loss[profile_i, child_sidx[val_i]]

--- a/tests/pytools/fm/test_back_allocation.py
+++ b/tests/pytools/fm/test_back_allocation.py
@@ -1,0 +1,118 @@
+"""End to end tests of the fm back-allocation rules on a small multi layer structure."""
+import struct
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from oasislmf.pytools.common.event_stream import ITEM_STREAM, LOSS_STREAM_ID, stream_info_to_bytes
+from oasislmf.pytools.fm import manager
+
+# two items in one aggregation, one level, two layers limited to 3000 and 1000
+FM_PROGRAMME = """from_agg_id,level_id,to_agg_id
+1,1,1
+2,1,1
+"""
+
+FM_POLICYTC = """level_id,agg_id,layer_id,profile_id
+1,1,1,2
+1,1,2,3
+"""
+
+FM_PROFILE = """profile_id,calcrule_id,deductible1,deductible2,deductible3,attachment1,limit1,share1,share2,share3
+1,100,0,0,0,0,0,0,0,0
+2,14,0,0,0,0,3000,0,0,0
+3,14,0,0,0,0,1000,0,0,0
+"""
+
+# output ids in item then layer order
+FM_XREF = """output,agg_id,layer_id
+1,1,1
+2,1,2
+3,2,1
+4,2,2
+"""
+
+GULS = {1: 1000.0, 2: 3000.0}
+
+
+def write_static(path):
+    for name, content in [('fm_programme', FM_PROGRAMME), ('fm_policytc', FM_POLICYTC),
+                          ('fm_profile', FM_PROFILE), ('fm_xref', FM_XREF)]:
+        (path / f'{name}.csv').write_text(content)
+
+
+def write_gul_stream(path, guls, max_sidx=1):
+    """Write a loss stream holding one event with a single sample per item."""
+    with open(path, 'wb') as stream:
+        stream.write(stream_info_to_bytes(LOSS_STREAM_ID, ITEM_STREAM))
+        stream.write(np.int32(max_sidx).tobytes())
+        for item_id, loss in guls.items():
+            stream.write(struct.pack('=ii', 1, item_id))
+            for sidx in range(1, max_sidx + 1):
+                stream.write(struct.pack('=if', sidx, loss))
+            stream.write(struct.pack('=if', 0, 0.))  # delimiter
+    return path
+
+
+def read_loss_stream(path):
+    """Return {(output_id, sidx): loss} for the sampled sidx only."""
+    data = np.fromfile(path, dtype='b')
+    losses = {}
+    cursor = 8  # stream_type + max_sidx
+    while cursor < data.nbytes:
+        _, output_id = struct.unpack_from('=ii', data, cursor)
+        cursor += 8
+        while cursor < data.nbytes:
+            sidx, loss = struct.unpack_from('=if', data, cursor)
+            cursor += 8
+            if sidx == 0:
+                break
+            if sidx > 0:
+                losses[(output_id, sidx)] = loss
+    return losses
+
+
+def run_fm(tmp_path, allocation_rule):
+    write_static(tmp_path)
+    gul_path = write_gul_stream(tmp_path / 'guls.bin', GULS)
+    out_path = tmp_path / 'fm.bin'
+    manager.run(create_financial_structure_files=True, allocation_rule=allocation_rule,
+                static_path=str(tmp_path))
+    manager.run(create_financial_structure_files=False, allocation_rule=allocation_rule,
+                static_path=str(tmp_path), files_in=[str(gul_path)], files_out=[str(out_path)],
+                net_loss=None, storage_method='sparse', low_memory=False, sort_output=True,
+                stepped=None)
+    return read_loss_stream(out_path)
+
+
+@pytest.mark.parametrize('allocation_rule, expected', [
+    # layer 1 loss is min(4000, 3000) = 3000, layer 2 loss is min(4000, 1000) = 1000.
+    # rule 1 splits each layer by the ground up losses of 1000 and 3000, so both layers
+    # split 1:3. rules 2 and 3 have nothing below them here, so they agree.
+    (1, {1: 750., 2: 250., 3: 2250., 4: 750.}),
+    (2, {1: 750., 2: 250., 3: 2250., 4: 750.}),
+    (3, {1: 750., 2: 250., 3: 2250., 4: 750.}),
+])
+def test_back_allocation_is_per_layer(tmp_path, allocation_rule, expected):
+    losses = run_fm(tmp_path, allocation_rule)
+
+    assert_allclose([losses[(output_id, 1)] for output_id in sorted(expected)],
+                    [expected[output_id] for output_id in sorted(expected)], rtol=1e-6)
+
+
+@pytest.mark.parametrize('allocation_rule', [1, 2, 3])
+def test_back_allocated_losses_sum_to_the_layer_loss(tmp_path, allocation_rule):
+    """Each layer's item losses must add back up to that layer's loss.
+
+    Allocation rule 1 read the ground up losses with a layer offset that the storage does
+    not have, so every layer above the first was allocated with another node's losses and
+    did not add back up. See https://github.com/OasisLMF/OasisLMF/issues/2131.
+    """
+    losses = run_fm(tmp_path, allocation_rule)
+
+    layer_1 = losses[(1, 1)] + losses[(3, 1)]  # output ids 1 and 3 are layer 1
+    layer_2 = losses[(2, 1)] + losses[(4, 1)]  # output ids 2 and 4 are layer 2
+
+    assert layer_1 == pytest.approx(3000., rel=1e-6)
+    assert layer_2 == pytest.approx(1000., rel=1e-6)

--- a/tests/pytools/fm/test_back_allocation.py
+++ b/tests/pytools/fm/test_back_allocation.py
@@ -1,11 +1,11 @@
 """End to end tests of the fm back-allocation rules on a small multi layer structure."""
-import struct
-
-import numpy as np
+import pandas as pd
 import pytest
 from numpy.testing import assert_allclose
 
-from oasislmf.pytools.common.event_stream import ITEM_STREAM, LOSS_STREAM_ID, stream_info_to_bytes
+from oasislmf.pytools.common.event_stream import LOSS_STREAM_ID
+from oasislmf.pytools.converters.bintocsv.manager import bintocsv
+from oasislmf.pytools.converters.csvtobin.manager import csvtobin
 from oasislmf.pytools.fm import manager
 
 # two items in one aggregation, one level, two layers limited to 3000 and 1000
@@ -33,7 +33,12 @@ FM_XREF = """output,agg_id,layer_id
 4,2,2
 """
 
-GULS = {1: 1000.0, 2: 3000.0}
+GULS = """event_id,item_id,sidx,loss
+1,1,1,1000.0
+1,2,1,3000.0
+"""
+
+MAX_SAMPLE_INDEX = 1
 
 
 def write_static(path):
@@ -42,40 +47,15 @@ def write_static(path):
         (path / f'{name}.csv').write_text(content)
 
 
-def write_gul_stream(path, guls, max_sidx=1):
-    """Write a loss stream holding one event with a single sample per item."""
-    with open(path, 'wb') as stream:
-        stream.write(stream_info_to_bytes(LOSS_STREAM_ID, ITEM_STREAM))
-        stream.write(np.int32(max_sidx).tobytes())
-        for item_id, loss in guls.items():
-            stream.write(struct.pack('=ii', 1, item_id))
-            for sidx in range(1, max_sidx + 1):
-                stream.write(struct.pack('=if', sidx, loss))
-            stream.write(struct.pack('=if', 0, 0.))  # delimiter
-    return path
-
-
-def read_loss_stream(path):
-    """Return {(output_id, sidx): loss} for the sampled sidx only."""
-    data = np.fromfile(path, dtype='b')
-    losses = {}
-    cursor = 8  # stream_type + max_sidx
-    while cursor < data.nbytes:
-        _, output_id = struct.unpack_from('=ii', data, cursor)
-        cursor += 8
-        while cursor < data.nbytes:
-            sidx, loss = struct.unpack_from('=if', data, cursor)
-            cursor += 8
-            if sidx == 0:
-                break
-            if sidx > 0:
-                losses[(output_id, sidx)] = loss
-    return losses
-
-
 def run_fm(tmp_path, allocation_rule):
+    """Return {(output_id, sidx): loss} for the sampled sidx only."""
     write_static(tmp_path)
-    gul_path = write_gul_stream(tmp_path / 'guls.bin', GULS)
+
+    gul_path = tmp_path / 'guls.bin'
+    (tmp_path / 'guls.csv').write_text(GULS)
+    csvtobin(tmp_path / 'guls.csv', gul_path, 'gul',
+             stream_type=LOSS_STREAM_ID, max_sample_index=MAX_SAMPLE_INDEX)
+
     out_path = tmp_path / 'fm.bin'
     manager.run(create_financial_structure_files=True, allocation_rule=allocation_rule,
                 static_path=str(tmp_path))
@@ -83,7 +63,11 @@ def run_fm(tmp_path, allocation_rule):
                 static_path=str(tmp_path), files_in=[str(gul_path)], files_out=[str(out_path)],
                 net_loss=None, storage_method='sparse', low_memory=False, sort_output=True,
                 stepped=None)
-    return read_loss_stream(out_path)
+
+    bintocsv(out_path, tmp_path / 'fm.csv', 'fm')
+    losses = pd.read_csv(tmp_path / 'fm.csv')
+    losses = losses[losses['sidx'] > 0]
+    return {(row.output_id, row.sidx): row.loss for row in losses.itertuples()}
 
 
 @pytest.mark.parametrize('allocation_rule, expected', [


### PR DESCRIPTION
Fixes #2131.

## The bug

`is_allocation_rule_a1` in `compute_sparse.py` makes two passes over the base children. The pass that builds the denominator reads each child's ground up loss with no profile offset, and the pass that applies the factor reads the same field **with** one:

```python
child_loss = loss_val[loss_indptr[child['net_loss']]: ...]                  # denominator
...
child_net  = loss_val[loss_indptr[child['net_loss'] + profile_i]: ...]      # numerator
```

`net_loss` is allocated one slot per node, not one per layer (`financial_structure.py`, `node['net_loss'], loss_i = loss_i, loss_i + 1`), so `+ profile_i` is only in range for `profile_i == 0`. For any layer above the first it reads past that node's single slot and into the next node's loss buffer, so the weights have nothing to do with that item's ground up loss and no longer sum to 1. Layer 1 was always correct; every layer above it was allocated with another node's losses and did not add back up to the layer's loss.

## The fix

Drop the offset so both passes read the one slot that exists. This is the last `net_loss` access in the module that carried an offset — `load_net_value` and the `keep_input_loss` write already used it unoffset.

## Results

Two items in one aggregation (ground up 1,000 and 3,000), two layers limited to 3,000 and 1,000. Layer 2's loss is 1,000 and should split 1:3:

| output_id | item | layer | expected | before | after |
|---|---|---|---|---|---|
| 1 | 1 | 1 | 750  | 750 | 750 |
| 2 | 1 | 2 | 250  | **562.50** | 250 |
| 3 | 2 | 1 | 2250 | 2250 | 2250 |
| 4 | 2 | 2 | 750  | 750 | 750 |

On the #2055 reproduction (one account, four single layer policies) fmpy `-a1` goes from **148,407.46** to **491,749.50**, against `fmcalc -a1` on 491,749.83.

Checked more broadly against ktools `fmcalc -a1` over 120 randomly generated multi level, multi layer structures (81 of them multi layer):

| | matching fmcalc | differing |
|---|---|---|
| before | 46 | **74** |
| after | **120** | 0 |

## Tests

New `tests/pytools/fm/test_back_allocation.py` runs a small multi layer structure end to end through `manager.run` for rules 1, 2 and 3, and asserts both the exact per item losses and the invariant that each layer's item losses add back up to that layer's loss. The two rule 1 tests fail on `main` and pass with this change; the rule 2 and 3 cases pass either way and are there as controls.

The static input is written as CSV in a `tmp_path`, which `load_static` accepts, so the test needs no ktools binaries. There was no end to end coverage of the fm calculation in `tests/pytools/fm` before this, and nothing anywhere exercises a non default allocation rule, which is why this went unnoticed.

## Not addressed

`temp_node_loss` is not guarded against being zero in the same branch — the division is guarded on the numerator (`if node_loss[val_i]:`) but not the denominator, so a node with loss but no ground up loss would divide by zero under `fastmath`. Left alone as it is a separate concern and I have no case that reaches it; noted in #2131.
