### PR TITLE
Fix IntCastingNaNError in write_empty_policy_layer when an account has no policy-layer terms

### DIFF
--- a/oasislmf/preparation/il_inputs.py
+++ b/oasislmf/preparation/il_inputs.py
@@ -1663,7 +1663,7 @@ def reset_gul_inputs(gul_inputs_df):
 
 def write_empty_policy_layer(gul_inputs_df, cur_level_id, agg_key, fm_policytc_csv, fm_policytc_bin,
                              fm_programme_csv, fm_programme_bin, chunksize):
-    gul_inputs_df["agg_id"] = gul_inputs_df.groupby(agg_key, sort=False, observed=True).ngroup().astype('int32') + 1
+    gul_inputs_df["agg_id"] = gul_inputs_df.groupby(agg_key, sort=False, observed=True, dropna=False).ngroup().astype('int32') + 1
     gul_inputs_df["profile_id"] = 1
     gul_inputs_df["level_id"] = cur_level_id
     fm_policytc_df = gul_inputs_df.loc[:, fm_policytc_headers]

--- a/tests/preparation/test_il_inputs.py
+++ b/tests/preparation/test_il_inputs.py
@@ -1,16 +1,22 @@
 """
 Unit tests for the early referential-integrity checks in oasislmf.preparation.il_inputs:
-validate_account_location_references() and check_cond_tags().
+validate_account_location_references() and check_cond_tags(), and for
+write_empty_policy_layer().
 """
+import os
+from tempfile import TemporaryDirectory
 from unittest import TestCase, main
 
+import numpy as np
 import pandas as pd
 
 from oasislmf.preparation.il_inputs import (
     check_cond_tags,
     get_cond_info,
     validate_account_location_references,
+    write_empty_policy_layer,
 )
+from oasislmf.pytools.common.data import fm_programme_dtype
 from oasislmf.utils.exceptions import OasisException
 
 
@@ -169,6 +175,64 @@ class TestGetCondInfo(TestCase):
 
         with self.assertRaises(OasisException):
             get_cond_info(locations_df, accounts_df)
+
+
+def run_write_empty_policy_layer(gul_inputs_df, agg_key, cur_level_id=3):
+    with TemporaryDirectory() as d:
+        policytc_path = os.path.join(d, 'fm_policytc.bin')
+        programme_path = os.path.join(d, 'fm_programme.bin')
+        with open(policytc_path, 'wb') as policytc_bin, open(programme_path, 'wb') as programme_bin:
+            write_empty_policy_layer(gul_inputs_df, cur_level_id, agg_key, None, policytc_bin,
+                                     None, programme_bin, 100000)
+        return np.fromfile(programme_path, dtype=fm_programme_dtype)
+
+
+def make_policy_layer_gul_inputs(**overrides):
+    data = {
+        'item_id': [1, 2, 3],
+        'agg_id_prev': [1, 2, 3],
+        'layer_id': [1, 1, 1],
+        'acc_id': [1, 1, 1],
+        'PolNumber': ['P1', 'P1', 'P1'],
+    }
+    data.update(overrides)
+    return pd.DataFrame(data)
+
+
+class TestWriteEmptyPolicyLayer(TestCase):
+    def test_nan_in_agg_key_does_not_raise(self):
+        # regression test for #2098: an account with no policy layer terms at all leaves
+        # NaNs in the layer agg_key, and a dropna=True groupby gave those rows a NaN
+        # ngroup(), which then failed to cast to int32
+        gul_inputs_df = make_policy_layer_gul_inputs(PolNumber=['P1', np.nan, 'P1'])
+
+        programme = run_write_empty_policy_layer(gul_inputs_df, ['acc_id', 'PolNumber'])
+
+        self.assertEqual(gul_inputs_df['agg_id'].tolist(), [1, 2, 1])
+        self.assertEqual(gul_inputs_df['agg_id'].dtype, np.int32)
+        self.assertEqual(sorted(programme[['from_agg_id', 'to_agg_id']].tolist()),
+                         [(1, 1), (2, 2), (3, 1)])
+
+    def test_all_nan_agg_key_groups_every_row_together(self):
+        gul_inputs_df = make_policy_layer_gul_inputs(PolNumber=[np.nan] * 3)
+
+        programme = run_write_empty_policy_layer(gul_inputs_df, ['acc_id', 'PolNumber'])
+
+        self.assertEqual(gul_inputs_df['agg_id'].tolist(), [1, 1, 1])
+        self.assertEqual(sorted(programme[['from_agg_id', 'to_agg_id']].tolist()),
+                         [(1, 1), (2, 1), (3, 1)])
+
+    def test_agg_key_without_nan_is_unaffected(self):
+        gul_inputs_df = make_policy_layer_gul_inputs(PolNumber=['P1', 'P2', 'P1'])
+
+        programme = run_write_empty_policy_layer(gul_inputs_df, ['acc_id', 'PolNumber'])
+
+        self.assertEqual(gul_inputs_df['agg_id'].tolist(), [1, 2, 1])
+        self.assertEqual(gul_inputs_df['level_id'].tolist(), [3, 3, 3])
+        self.assertEqual(gul_inputs_df['profile_id'].tolist(), [1, 1, 1])
+        self.assertEqual(sorted(programme['level_id'].tolist()), [3, 3, 3])
+        self.assertEqual(sorted(programme[['from_agg_id', 'to_agg_id']].tolist()),
+                         [(1, 1), (2, 2), (3, 1)])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Related to #2098 — but see **What actually triggers it** below: the exposure described in that issue does not reproduce the crash on `main`, and #2112 has probably already addressed the run that was reported. Deliberately not marked as fixing it.

<!--start_release_notes-->
### Fix `IntCastingNaNError` when a policy-layer aggregation key contains a null

Input generation no longer crashes with `pandas.errors.IntCastingNaNError` when the policy-layer aggregation key contains a null value. This is the "this FM level has no terms" branch of IL input generation, where the aggregation key is not guaranteed to be fully populated; null key values now form their own aggregation group instead of being dropped.
<!--end_release_notes-->

## Problem

`write_empty_policy_layer` is the "this FM level has no terms" branch of `get_il_input_items`. It builds `agg_id` with

```python
gul_inputs_df.groupby(agg_key, sort=False, observed=True).ngroup().astype('int32') + 1
```

`groupby` defaults to `dropna=True`, so any row with a `NaN` in one of the `agg_key` columns is excluded from the grouping and gets a `NaN` (float) group number from `.ngroup()`. The following `.astype('int32')` then raises:

```
pandas.errors.IntCastingNaNError: Cannot convert non-finite values (NA or inf) to integer
```

Because this is the no-terms branch, a partially populated `agg_key` is an expected condition rather than an anomaly, so dropping those rows was never the intent.

## What actually triggers it

Worth being precise, because the exposure described in #2098 is not the trigger. `agg_key` comes from `fm_aggregation_profile[level_id]['FMAggKey']`, and every agg profile shipped in this repo (`oasislmf/_data/default_fm_agg_profile.json`, plus the copies under `OasisPiWind/tests/ci/expected/*/input/`) defines the policy-layer key as `acc_id` alone. `acc_id` is an `int64` derived from `get_ids(PortNumber, AccNumber)` and cannot hold a null unless the location-to-account merge misses.

Building that exposure exactly — single account, `LayerLimit=0`, no `LayerParticipation`/`LayerAttachment`/`LayerNumber` columns — and running it through `RunExposure` on `main` with the function instrumented shows `write_empty_policy_layer` *is* entered, with `agg_key = ['acc_id']`, 0 nulls, dtype `int64`, and no crash.

So reaching the crash needs a null in the policy-layer key, which in practice means one of:

* a **custom `fm_aggregation_profile`** naming a null-able field at level 11. `PolNumber` is the obvious candidate: `il_inputs.py:1458` sets it to `pd.NA` and it is only backfilled in `finalize_il_inputs` or by `merge_level_terms_into_gul` when a level *has* terms, so at this branch it is entirely `pd.NA`. Forcing it into the key reproduces the reported error exactly.
* a **null `acc_id`**, from a location whose `PortNumber`/`AccNumber` is absent from the account file.

The second route is the likely origin of #2098, which was reported on 2.5.6. `validate_account_location_references` landed in 2.5.7 (#2112) and now rejects orphan locations up front with a named `OasisException`, so that data problem fails fast and never reaches this line. This change is therefore the backstop behind #2112, not the fix for the run that was reported — it closes the remaining route in (1) and any future null the upstream validation does not cover.

## Change

[oasislmf/preparation/il_inputs.py](oasislmf/preparation/il_inputs.py) — pass `dropna=False` to the `groupby` in `write_empty_policy_layer`.

`NaN` key values now form groups of their own instead of being dropped, so every row receives a real integer `agg_id` and the `int32` cast is safe. Behaviour for `agg_key`s with no `NaN`s is unchanged — `dropna` only affects rows that would otherwise have been excluded, and `ngroup()` numbering is identical either way when the key has no nulls.

No numeric risk: this branch hard-codes `profile_id = 1`, the passthrough profile (`calcrule_id = 100`), so no limit, deductible, share or attachment value is written here and the "wrong fill value" class of bug cannot arise. Any key that *did* contain a null crashed before, so there is no input whose output changes silently. `:1666` was also the only one of the four `ngroup()` call sites in `oasislmf/` not already passing `dropna=False`.

## Tests

[tests/preparation/test_il_inputs.py](tests/preparation/test_il_inputs.py) — new `TestWriteEmptyPolicyLayer` covering the function end-to-end (it writes real `fm_policytc`/`fm_programme` binaries to a temp dir and reads back `fm_programme`):

- `test_nan_in_agg_key_does_not_raise` — regression test for #2098: one `NaN` in the key no longer raises, and `agg_id` is `int32` with the expected grouping.
- `test_all_nan_agg_key_groups_every_row_together` — an entirely `NaN` key collapses to a single group.
- `test_agg_key_without_nan_is_unaffected` — the no-`NaN` path is untouched, including `level_id`/`profile_id` and the emitted `fm_programme` rows.

`pytest tests/preparation/test_il_inputs.py` — 16 passed.

