### PR TITLE
 Pre-analysis hook constructs the user's class twice and prints kwargs

### DIFF
--- a/oasislmf/computation/hooks/pre_analysis.py
+++ b/oasislmf/computation/hooks/pre_analysis.py
@@ -122,8 +122,6 @@ class ExposurePreAnalysis(ComputationStep):
         self.logger.info('\nPre-analysis original files: {}'.format(
             json.dumps(original_files, indent=4)))
 
-        print(kwargs)
-        print(_class(**kwargs))
         _class_return = _class(**kwargs).run()
 
         exposure_data.save(path=input_dir, version_name='', save_config=True, unknown_columns=ids_option)

--- a/tests/model_preparation/test_exposure_pre_analysis.py
+++ b/tests/model_preparation/test_exposure_pre_analysis.py
@@ -112,3 +112,47 @@ def test_wrong_class():
         with pytest.raises(OasisException, match=f"class {kwargs['exposure_pre_analysis_class_name']} "
                            f"is not defined in module {kwargs['exposure_pre_analysis_module']}"):
             OasisManager().exposure_pre_analysis(**kwargs)
+
+
+def write_counting_epa_module(module_path, counter_path):
+    with open(module_path, 'w') as f:
+        f.write(f'''
+class ExposurePreAnalysis:
+    """
+    Records every instantiation so the caller can assert it is built once.
+    """
+
+    def __init__(self, exposure_data, exposure_pre_analysis_setting, **kwargs):
+        self.exposure_data = exposure_data
+        self.exposure_pre_analysis_setting = exposure_pre_analysis_setting
+        with open({counter_path!r}, 'a') as counter:
+            counter.write('init\\n')
+
+    def run(self):
+        self.exposure_data.location.dataframe['BuildingTIV'] = (self.exposure_data.location.dataframe['BuildingTIV']
+                                                                * self.exposure_pre_analysis_setting['BuildingTIV_multiplyer'])
+''')
+
+
+def test_exposure_pre_analysis_class_is_built_once(capsys):
+    with TemporaryDirectory() as d:
+        counter_path = os.path.join(d, 'init_count.txt')
+        kwargs = {'oasis_files_dir': d,
+                  'exposure_pre_analysis_module': os.path.join(d, 'exposure_pre_analysis_counting.py'),
+                  'oed_location_csv': os.path.join(d, 'input_{}'.format(SOURCE_FILENAMES['oed_location_csv'])),
+                  'exposure_pre_analysis_setting_json': os.path.join(d, 'exposure_pre_analysis_setting.json'),
+                  'check_oed': False}
+
+        write_counting_epa_module(kwargs['exposure_pre_analysis_module'], counter_path)
+        write_oed_location(kwargs['oed_location_csv'])
+        write_exposure_pre_analysis_setting_json(kwargs['exposure_pre_analysis_setting_json'])
+
+        OasisManager().exposure_pre_analysis(**kwargs)
+
+        with open(counter_path) as counter:
+            assert counter.read() == 'init\n'
+
+        with open(os.path.join(d, SOURCE_FILENAMES['oed_location_csv'])) as new_oed_location_csv:
+            assert new_oed_location_csv.read() == output_oed_location
+
+        assert 'exposure_pre_analysis_setting' not in capsys.readouterr().out


### PR DESCRIPTION
Fixes #2151.

## The bug

Two debug `print` statements were left in `ExposurePreAnalysis.run` immediately before the real call:

```python
print(kwargs)
print(_class(**kwargs))
_class_return = _class(**kwargs).run()
```

`print(_class(**kwargs))` builds a whole instance of the model's pre-analysis class just to print its default `repr`, throws it away, and then builds a second one for `.run()`. Anything the model does in `__init__` happens twice, and since `exposure_data` is passed by reference, a class that modifies the exposure in `__init__` rather than in `run()` applies its modification twice with nothing in the logs to say so.

`print(kwargs)` dumps the whole keyword dict — the `OedExposure` object, the directories, the model `settings` and the parsed contents of `exposure_pre_analysis_setting_json` — to stdout rather than through `self.logger`, so it is unlevelled, unsuppressible and ends up in worker stdout on the platform. Every other status line in this method goes through `self.logger.info`.

Both lines have been there since #1171 (Jan 2023, 1.27.0) and were never touched again.

## The fix

Delete them. The `original_files` / `modified_files` `logger.info` calls either side already report what the hook did, so no information is lost.

## Tests

`tests/model_preparation/test_exposure_pre_analysis.py` only ever checked the resulting OED file, never how many times the class was built or what reached stdout, which is why this sat unnoticed for three years. New `test_exposure_pre_analysis_class_is_built_once` points `exposure_pre_analysis_module` at a class whose `__init__` appends to a counter file, and asserts:

* the counter has exactly one line — the class is constructed once;
* the OED output still matches, so the single construction is the one that ran;
* `exposure_pre_analysis_setting` does not appear on stdout.

On `main` it fails with `assert 'init\ninit\n' == 'init\n'`; with this change the file's five tests pass.

<!--start_release_notes-->
### Pre-analysis hook no longer runs the model's class twice or prints its settings
Removed two leftover debug `print` statements from the exposure pre-analysis hook. The model's pre-analysis class is now constructed once instead of twice, so any side effects in its `__init__` no longer happen twice, and the pre-analysis keyword arguments — including the contents of the pre-analysis settings JSON — are no longer printed to stdout.

Both statements have been present since 1.27.0. A model whose pre-analysis class modifies the exposure in `__init__` rather than in `run()` has therefore been applying that modification twice, and its results change with this release — correctly, but silently.
<!--end_release_notes-->

