### PR TITLE
Reproject rtree geometry to EPSG:4326 before spatial join (#2134)

### DIFF
--- a/oasislmf/lookup/builtin.py
+++ b/oasislmf/lookup/builtin.py
@@ -718,6 +718,11 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
                 UserWarning,
             )
             gdf_geometry = gdf_geometry.set_crs("EPSG:4326")
+        elif gdf_geometry.crs != "EPSG:4326":
+            # The OED locations are always built in EPSG:4326 (see get_geometry below) and
+            # nearest_neighbor assumes WGS84, so reproject the geometry to match before the
+            # spatial join and nearest-neighbour search (issue #2134).
+            gdf_geometry = gdf_geometry.to_crs("EPSG:4326")
 
         if nearest_neighbor_max_distance > 0:
             if BallTree is None:

--- a/tests/lookup/test_builtin.py
+++ b/tests/lookup/test_builtin.py
@@ -184,6 +184,35 @@ def test_build_rtree_associates_correctly(locations_by_name, expected_ids, reque
     )
 
 
+def test_build_rtree_reprojects_non_4326_geometry(rtree_locations_all_coordinates, tmp_path):
+    """Test that the rtree builtin associates correctly when the geometry file is not in EPSG:4326.
+
+    The OED locations are always built in EPSG:4326, so a geometry file in any other CRS must be
+    reprojected before the spatial join, otherwise no locations match (issue #2134). This reprojects
+    the WGS84 fixture to EPSG:27700 and expects the same associations as the EPSG:4326 case.
+    """
+    gpd = pytest.importorskip("geopandas", reason="geopandas not installed")
+
+    projected_file = tmp_path / "rtree_areas_epsg27700.parquet"
+    gpd.read_parquet(FILES_DIR / "rtree_areas.parquet").to_crs("EPSG:27700").to_parquet(projected_file)
+
+    rtree = Lookup(config={}).build_rtree(
+        file_path=projected_file.as_posix(),
+        file_type="parquet",
+        id_columns="poly_id",
+        nearest_neighbor_max_distance=12000,  # Euclidean distance in metres, not spherical distance.
+    )
+    output = rtree(rtree_locations_all_coordinates)
+    expected = rtree_locations_all_coordinates.copy().assign(poly_id=[1, 2, 1, OASIS_UNKNOWN_ID])
+
+    # Sort values so order doesn't matter.
+    pd.testing.assert_frame_equal(
+        output.sort_values("locname"),
+        expected.sort_values("locname"),
+        check_dtype=False,
+    )
+
+
 def test_build_rtree_accepts_deprecated_parameter(rtree_locations_all_coordinates):
     """Test that the rtree builtin still works with the deprecated parameter."""
     with pytest.warns(DeprecationWarning):


### PR DESCRIPTION
Hi OasisLMF team,

This is my first contribution to OasisLMF. If I've missed anything (branch, labels, coding style, anything in the PR template, etc.), please let me know and I'll sort it out. This PR addresses issue #2134. Cheers, Peter

<!--start_release_notes-->
### rtree lookup now reprojects geometry data to EPSG:4326
The rtree builtin lookup now reprojects the vendor geometry dataset (area perils / sections) to EPSG:4326 before the spatial join. Previously, a geometry file in any other CRS produced no location matches.
<!--end_release_notes-->

## The problem

The rtree lookup joins the OED locations to a vendor geometry dataset. The locations are always built in EPSG:4326, but the geometry was used in whatever CRS its file declared and never reprojected. When that CRS was not 4326, the two datasets were in different coordinate spaces, so the spatial join found nothing and every location came back unmatched. geopandas also prints a "CRS mismatch" warning in that case.

The existing code only handled a missing CRS (it assumed 4326), not a different one. The nearest-neighbour fallback is affected too, since it assumes WGS84.

## The change

Reproject the geometry to EPSG:4326 right after it is loaded, immediately after the existing missing-CRS handling, so both the spatial join and the nearest-neighbour search run in the same CRS as the locations. It is a small, contained change in oasislmf/lookup/builtin.py:

```python
elif gdf_geometry.crs != "EPSG:4326":
    # The OED locations are always built in EPSG:4326 (see get_geometry below) and
    # nearest_neighbor assumes WGS84, so reproject the geometry to match before the
    # spatial join and nearest-neighbour search (issue #2134).
    gdf_geometry = gdf_geometry.to_crs("EPSG:4326")
```

Files already in EPSG:4326, and files with no CRS at all, behave exactly as before.

## Testing

Added a regression test in tests/lookup/test_builtin.py. It reprojects the existing WGS84 test fixture to EPSG:27700, runs the rtree lookup, and expects the same associations as the EPSG:4326 case. Verified locally:

- Before the change, the new test fails: every location is unmatched, with the CRS mismatch warning coming from the spatial join.
- After the change, it passes.
- The full tests/lookup suite passes with no regressions (48 passed, 1 skipped), and the existing rtree tests on the 4326 fixture are unaffected.

## A couple of notes

- I based this on main, since that is where the current open and recently merged PRs are going. CONTRIBUTING mentions develop, so let me know if you would prefer a different target branch and I'll rebase.
- Reprojecting to 4326 also fixes the nearest-neighbour fallback, which assumes WGS84, so both paths are consistent afterwards.
