### PR TITLE
fix/elt-plt-reset-state-buffer-full

### DIFF
--- a/oasislmf/pytools/common/data.py
+++ b/oasislmf/pytools/common/data.py
@@ -29,7 +29,7 @@ areaperil_int_size = areaperil_int.itemsize
 null_index = oasis_int.type(-1)
 
 # A default buffer size for nd arrays to be initialised to
-DEFAULT_BUFFER_SIZE = 1_000_000
+DEFAULT_BUFFER_SIZE = int(os.environ.get('OASIS_DEFAULT_BUFFER_SIZE', 1_000_000))
 
 # Mean type numbers for outputs (SampleType)
 MEAN_TYPE_ANALYTICAL = 1

--- a/oasislmf/pytools/elt/manager.py
+++ b/oasislmf/pytools/elt/manager.py
@@ -209,34 +209,32 @@ def read_buffer(
             sdloss = np.float64(0.0)
         return meanloss, sdloss
 
+    def _reservation_overflows(idx, reservation, capacity, name):
+        # Buffer genuinely too small for even one summary (idx == 0, i.e. buffer is
+        # already empty): flushing can never make room, so return would loop forever.
+        if idx + reservation > capacity:
+            if idx == 0:
+                raise ValueError(
+                    f"{name} reservation of {reservation} rows for a single summary exceeds the "
+                    f"output buffer capacity of {capacity}; increase OASIS_DEFAULT_BUFFER_SIZE."
+                )
+            return True
+        return False
+
     while cursor < valid_buff:
         if not state["reading_losses"]:
             # Reserve room for the next summary's worst-case output before reading
             # anything of it, so writes below can never run past the end of a buffer.
             # +2 (not +1): both MEAN_IDX and NUMBER_OF_AFFECTED_RISK_IDX can each add
             # one extra SELT row on top of the len_sample real samples.
-            if state["compute_selt"] and si + state["len_sample"] + 2 > selt_data.shape[0]:
-                if si == 0:
-                    raise ValueError(
-                        f"SELT reservation of {state['len_sample'] + 2} rows for a single summary exceeds the "
-                        f"output buffer capacity of {selt_data.shape[0]}; increase OASIS_DEFAULT_BUFFER_SIZE."
-                    )
-                _update_idxs()
-                return cursor, state["current_event_id"], item_id, 1
-            if state["compute_melt"] and mi + 2 > melt_data.shape[0]:
-                if mi == 0:
-                    raise ValueError(
-                        f"MELT reservation of 2 rows for a single summary exceeds the output buffer "
-                        f"capacity of {melt_data.shape[0]}; increase OASIS_DEFAULT_BUFFER_SIZE."
-                    )
-                _update_idxs()
-                return cursor, state["current_event_id"], item_id, 1
-            if state["compute_qelt"] and qi + len(intervals) > qelt_data.shape[0]:
-                if qi == 0:
-                    raise ValueError(
-                        f"QELT reservation of {len(intervals)} rows for a single summary exceeds the "
-                        f"output buffer capacity of {qelt_data.shape[0]}; increase OASIS_DEFAULT_BUFFER_SIZE."
-                    )
+            buffer_full = False
+            if state["compute_selt"] and _reservation_overflows(si, state["len_sample"] + 2, selt_data.shape[0], "SELT"):
+                buffer_full = True
+            if state["compute_melt"] and _reservation_overflows(mi, 2, melt_data.shape[0], "MELT"):
+                buffer_full = True
+            if state["compute_qelt"] and _reservation_overflows(qi, len(intervals), qelt_data.shape[0], "QELT"):
+                buffer_full = True
+            if buffer_full:
                 _update_idxs()
                 return cursor, state["current_event_id"], item_id, 1
 

--- a/oasislmf/pytools/elt/manager.py
+++ b/oasislmf/pytools/elt/manager.py
@@ -213,9 +213,8 @@ def read_buffer(
         if not state["reading_losses"]:
             # Reserve room for the next summary's worst-case output before reading
             # anything of it, so writes below can never run past the end of a buffer.
-            # +2 (not +1) since both MEAN_IDX and NUMBER_OF_AFFECTED_RISK_IDX can each
-            # add one extra SELT row on top of the len_sample real samples (see
-            # elt_selt_special_sidx_issue.md - a separate, pre-existing issue).
+            # +2 (not +1): both MEAN_IDX and NUMBER_OF_AFFECTED_RISK_IDX can each add
+            # one extra SELT row on top of the len_sample real samples.
             if state["compute_selt"] and si + state["len_sample"] + 2 > selt_data.shape[0]:
                 _update_idxs()
                 return cursor, state["current_event_id"], item_id, 1

--- a/oasislmf/pytools/elt/manager.py
+++ b/oasislmf/pytools/elt/manager.py
@@ -52,6 +52,7 @@ class ELTReader(EventReader):
             ('compute_selt', np.bool_),
             ('compute_melt', np.bool_),
             ('compute_qelt', np.bool_),
+            ('current_event_id', event_id_dtype),
             ('summary_id', summary_id_dtype),
             ('impacted_exposure', oasis_float),
             ('non_zero_samples', oasis_int),
@@ -172,7 +173,8 @@ def read_buffer(
         unique_event_ids, event_rates
 ):
     # Initialise idxs
-    last_event_id = event_id
+    # Read from state, not the event_id param: the caller always passes 0 on a fresh call.
+    last_event_id = state["current_event_id"]
     si = selt_idx[0]
     mi = melt_idx[0]
     qi = qelt_idx[0]
@@ -209,6 +211,21 @@ def read_buffer(
 
     while cursor < valid_buff:
         if not state["reading_losses"]:
+            # Reserve room for the next summary's worst-case output before reading
+            # anything of it, so writes below can never run past the end of a buffer.
+            # +2 (not +1) since both MEAN_IDX and NUMBER_OF_AFFECTED_RISK_IDX can each
+            # add one extra SELT row on top of the len_sample real samples (see
+            # elt_selt_special_sidx_issue.md - a separate, pre-existing issue).
+            if state["compute_selt"] and si + state["len_sample"] + 2 > selt_data.shape[0]:
+                _update_idxs()
+                return cursor, state["current_event_id"], item_id, 1
+            if state["compute_melt"] and mi + 2 > melt_data.shape[0]:
+                _update_idxs()
+                return cursor, state["current_event_id"], item_id, 1
+            if state["compute_qelt"] and qi + len(intervals) > qelt_data.shape[0]:
+                _update_idxs()
+                return cursor, state["current_event_id"], item_id, 1
+
             # Read summary header
             if valid_buff - cursor >= summaryset_id_dtype_size + event_id_dtype_size + summary_id_dtype_size + loss_dtype_size:
                 # Need to read summary_set_id from summary info first
@@ -217,10 +234,14 @@ def read_buffer(
                     state["read_summary_set_id"] = True
                 event_id_new, cursor = mv_read(byte_mv, cursor, event_id_dtype, event_id_dtype_size)
                 if last_event_id != 0 and event_id_new != last_event_id:
-                    # New event, return to process the previous event
+                    # New event, return to process the previous event. Clear current_event_id
+                    # so the resumed call (event_id param resets to 0) doesn't re-detect this
+                    # same boundary and loop forever.
+                    state["current_event_id"] = 0
                     _update_idxs()
                     return cursor - event_id_dtype_size, last_event_id, item_id, 1
                 event_id = event_id_new
+                state["current_event_id"] = event_id_new
                 state["summary_id"], cursor = mv_read(byte_mv, cursor, summary_id_dtype, summary_id_dtype_size)
                 state["impacted_exposure"], cursor = mv_read(byte_mv, cursor, loss_dtype, loss_dtype_size)
                 state["reading_losses"] = True
@@ -285,12 +306,6 @@ def read_buffer(
                         )
                         mi += 1
 
-                        if mi >= melt_data.shape[0]:
-                            # Output array is full
-                            _reset_state()
-                            _update_idxs()
-                            return cursor, event_id, item_id, 1
-
                 # Update QELT data
                 if state["compute_qelt"]:
                     if state["impacted_exposure"] > 0:
@@ -314,11 +329,6 @@ def read_buffer(
                                 loss=loss
                             )
                             qi += 1
-                            if qi >= qelt_data.shape[0]:
-                                # Output array is full
-                                _reset_state()
-                                _update_idxs()
-                                return cursor, event_id, item_id, 1
 
                 # Reset variables
                 _reset_state()
@@ -340,10 +350,6 @@ def read_buffer(
                         impacted_exposure=state["impacted_exposure"] if loss != 0 else 0
                     )
                     si += 1
-                    if si >= selt_data.shape[0]:
-                        # Output array is full
-                        _update_idxs()
-                        return cursor, event_id, item_id, 1
 
                 if sidx > 0:
                     if loss > 0:
@@ -357,7 +363,7 @@ def read_buffer(
 
     # Update the indices
     _update_idxs()
-    return cursor, event_id, item_id, 0
+    return cursor, state["current_event_id"], item_id, 0
 
 
 def read_input_files(run_dir, compute_melt, compute_qelt, sample_size):

--- a/oasislmf/pytools/elt/manager.py
+++ b/oasislmf/pytools/elt/manager.py
@@ -30,7 +30,7 @@ loss_dtype, loss_dtype_size = def_to_type_and_size("loss")
 class ELTReader(EventReader):
     """Read an event loss stream and compute the ELT outputs (SELT, MELT, QELT)."""
 
-    def __init__(self, len_sample, compute_selt, compute_melt, compute_qelt, unique_event_ids, event_rates, intervals):
+    def __init__(self, len_sample, compute_selt, compute_melt, compute_qelt, unique_event_ids, event_rates, intervals, n_files=1):
         self.logger = logger
 
         # Buffer for SELT data
@@ -61,7 +61,10 @@ class ELTReader(EventReader):
             ('losses_vec', oasis_float, (len_sample,)),
         ])
 
-        self.state = np.zeros(1, dtype=read_buffer_state_dtype)[0]
+        # One state row per input file/stream (indexed by file_idx in read_buffer below) -
+        # tracking (reading_losses, current_event_id, ...) per-stream, not reader-wide, so
+        # interleaved multi-file reads can't leak one file's last event id into another's.
+        self.state = np.zeros(n_files, dtype=read_buffer_state_dtype)
         self.state["len_sample"] = len_sample
         self.state["reading_losses"] = False
         self.state["read_summary_set_id"] = False
@@ -71,8 +74,6 @@ class ELTReader(EventReader):
         self.unique_event_ids = unique_event_ids.astype(oasis_int)
         self.event_rates = event_rates.astype(oasis_float)
         self.intervals = intervals
-
-        self.curr_file_idx = None  # Current summary file idx being read
 
     def get_data(self, out_type):
         if out_type == "selt":
@@ -95,18 +96,11 @@ class ELTReader(EventReader):
             raise RuntimeError(f"Unknown out_type {out_type}")
 
     def read_buffer(self, byte_mv, cursor, valid_buff, event_id, item_id, file_idx):
-        # Check for new file idx to read summary_set_id at the start of each summary file stream
-        # This is not done by init_streams_in as the summary_set_id is unique to the summary_stream only
-        if self.curr_file_idx is not None and self.curr_file_idx != file_idx:
-            self.curr_file_idx = file_idx
-            self.state["read_summary_set_id"] = False
-        else:
-            self.curr_file_idx = file_idx
-
-        # Pass state variables to read_buffer
+        # Each file gets its own state row (see __init__), so read_summary_set_id
+        # naturally starts False per-file - no reset-on-file-switch needed here.
         cursor, event_id, item_id, ret = read_buffer(
             byte_mv, cursor, valid_buff, event_id, item_id, self.selt_data, self.selt_idx,
-            self.state, self.melt_data, self.melt_idx, self.qelt_data, self.qelt_idx, self.intervals,
+            self.state[file_idx], self.melt_data, self.melt_idx, self.qelt_data, self.qelt_idx, self.intervals,
             self.unique_event_ids, self.event_rates
         )
         return cursor, event_id, item_id, ret
@@ -173,8 +167,11 @@ def read_buffer(
         unique_event_ids, event_rates
 ):
     # Initialise idxs
-    # Read from state, not the event_id param: the caller always passes 0 on a fresh call.
+    # Read from state, not the event_id param: the caller always passes 0 on a fresh call,
+    # including a resume where reading_losses is already True and no header gets read below
+    # (so event_id would otherwise stay at the caller's 0 for every write this call).
     last_event_id = state["current_event_id"]
+    event_id = state["current_event_id"]
     si = selt_idx[0]
     mi = melt_idx[0]
     qi = qelt_idx[0]
@@ -490,7 +487,8 @@ def run(
             outmap["qelt"]["compute"],
             file_data["unique_event_ids"],
             file_data["event_rates"],
-            file_data["intervals"]
+            file_data["intervals"],
+            n_files=len(streams_in)
         )
 
         # Initialise output files ELT

--- a/oasislmf/pytools/elt/manager.py
+++ b/oasislmf/pytools/elt/manager.py
@@ -216,12 +216,27 @@ def read_buffer(
             # +2 (not +1): both MEAN_IDX and NUMBER_OF_AFFECTED_RISK_IDX can each add
             # one extra SELT row on top of the len_sample real samples.
             if state["compute_selt"] and si + state["len_sample"] + 2 > selt_data.shape[0]:
+                if si == 0:
+                    raise ValueError(
+                        f"SELT reservation of {state['len_sample'] + 2} rows for a single summary exceeds the "
+                        f"output buffer capacity of {selt_data.shape[0]}; increase OASIS_DEFAULT_BUFFER_SIZE."
+                    )
                 _update_idxs()
                 return cursor, state["current_event_id"], item_id, 1
             if state["compute_melt"] and mi + 2 > melt_data.shape[0]:
+                if mi == 0:
+                    raise ValueError(
+                        f"MELT reservation of 2 rows for a single summary exceeds the output buffer "
+                        f"capacity of {melt_data.shape[0]}; increase OASIS_DEFAULT_BUFFER_SIZE."
+                    )
                 _update_idxs()
                 return cursor, state["current_event_id"], item_id, 1
             if state["compute_qelt"] and qi + len(intervals) > qelt_data.shape[0]:
+                if qi == 0:
+                    raise ValueError(
+                        f"QELT reservation of {len(intervals)} rows for a single summary exceeds the "
+                        f"output buffer capacity of {qelt_data.shape[0]}; increase OASIS_DEFAULT_BUFFER_SIZE."
+                    )
                 _update_idxs()
                 return cursor, state["current_event_id"], item_id, 1
 

--- a/oasislmf/pytools/elt/manager.py
+++ b/oasislmf/pytools/elt/manager.py
@@ -287,6 +287,7 @@ def read_buffer(
 
                         if mi >= melt_data.shape[0]:
                             # Output array is full
+                            _reset_state()
                             _update_idxs()
                             return cursor, event_id, item_id, 1
 
@@ -315,6 +316,7 @@ def read_buffer(
                             qi += 1
                             if qi >= qelt_data.shape[0]:
                                 # Output array is full
+                                _reset_state()
                                 _update_idxs()
                                 return cursor, event_id, item_id, 1
 

--- a/oasislmf/pytools/plt/manager.py
+++ b/oasislmf/pytools/plt/manager.py
@@ -61,6 +61,7 @@ class PLTReader(EventReader):
             ('compute_splt', np.bool_),
             ('compute_mplt', np.bool_),
             ('compute_qplt', np.bool_),
+            ('current_event_id', event_id_dtype),
             ('summary_id', summary_id_dtype),
             ('exposure_value', loss_dtype),
             ('max_loss', loss_dtype),
@@ -83,6 +84,13 @@ class PLTReader(EventReader):
         self.period_weights = period_weights
         self.granular_date = granular_date
         self.intervals = intervals
+
+        # Worst-case number of periods any single event maps to, used to reserve
+        # output buffer capacity for a summary before reading it (see read_buffer).
+        if len(occ_csr.occ_offsets) > 1:
+            self.max_records_per_event = int(np.diff(occ_csr.occ_offsets).max())
+        else:
+            self.max_records_per_event = 0
 
         self.curr_file_idx = None  # Current summary file idx being read
 
@@ -126,6 +134,7 @@ class PLTReader(EventReader):
             self.period_weights,
             self.granular_date,
             self.intervals,
+            self.max_records_per_event,
         )
         return cursor, event_id, item_id, ret
 
@@ -227,9 +236,11 @@ def read_buffer(
         period_weights,
         granular_date,
         intervals,
+        max_records_per_event,
 ):
     # Initialise idxs
-    last_event_id = event_id
+    # Read from state, not the event_id param: the caller always passes 0 on a fresh call.
+    last_event_id = state["current_event_id"]
     si = splt_idx[0]
     mi = mplt_idx[0]
     qi = qplt_idx[0]
@@ -269,6 +280,20 @@ def read_buffer(
     # Read input loop
     while cursor < valid_buff:
         if not state["reading_losses"]:
+            # Reserve room for the next summary's worst-case output before reading
+            # anything of it, so writes below can never run past the end of a buffer.
+            # MPLT/QPLT can write up to max_records_per_event rows per record loop;
+            # MPLT does this twice per summary (analytical mean, then sample mean).
+            if state["compute_splt"] and si + max_records_per_event * (state["len_sample"] + 1) > splt_data.shape[0]:
+                _update_idxs()
+                return cursor, state["current_event_id"], item_id, 1
+            if state["compute_mplt"] and mi + 2 * max_records_per_event > mplt_data.shape[0]:
+                _update_idxs()
+                return cursor, state["current_event_id"], item_id, 1
+            if state["compute_qplt"] and qi + max_records_per_event * len(intervals) > qplt_data.shape[0]:
+                _update_idxs()
+                return cursor, state["current_event_id"], item_id, 1
+
             # Read summary header
             if valid_buff - cursor >= event_id_dtype_size + summary_id_dtype_size + summaryset_id_dtype_size + loss_dtype_size:
                 # Need to read summary_set_id from summary info first
@@ -277,10 +302,14 @@ def read_buffer(
                     state["read_summary_set_id"] = True
                 event_id_new, cursor = mv_read(byte_mv, cursor, event_id_dtype, event_id_dtype_size)
                 if last_event_id != 0 and event_id_new != last_event_id:
-                    # New event, return to process the previous event
+                    # New event, return to process the previous event. Clear current_event_id
+                    # so the resumed call (event_id param resets to 0) doesn't re-detect this
+                    # same boundary and loop forever.
+                    state["current_event_id"] = 0
                     _update_idxs()
                     return cursor - event_id_dtype_size, last_event_id, item_id, 1
                 event_id = event_id_new
+                state["current_event_id"] = event_id_new
                 state["summary_id"], cursor = mv_read(byte_mv, cursor, summary_id_dtype, summary_id_dtype_size)
                 state["exposure_value"], cursor = mv_read(byte_mv, cursor, loss_dtype, loss_dtype_size)
                 state["reading_losses"] = True
@@ -317,11 +346,6 @@ def read_buffer(
                                     max_impacted_exposure=state["max_impacted_exposure"],
                                 )
                                 mi += 1
-                                if mi >= mplt_data.shape[0]:
-                                    # Output array full
-                                    _reset_state()
-                                    _update_idxs()
-                                    return cursor, event_id, item_id, 1
 
                 # Update QPLT data
                 if state["compute_qplt"]:
@@ -347,11 +371,6 @@ def read_buffer(
                                 loss=loss
                             )
                             qi += 1
-                            if qi >= qplt_data.shape[0]:
-                                # Output array full
-                                _reset_state()
-                                _update_idxs()
-                                return cursor, event_id, item_id, 1
                 _reset_state()
                 continue
 
@@ -376,10 +395,6 @@ def read_buffer(
                             impacted_exposure=impacted_exposure,
                         )
                         si += 1
-                        if si >= splt_data.shape[0]:
-                            # Output array full
-                            _update_idxs()
-                            return cursor, event_id, item_id, 1
             if sidx == MAX_LOSS_IDX:
                 state["max_loss"] = loss
             elif sidx == MEAN_IDX:
@@ -403,10 +418,6 @@ def read_buffer(
                             max_impacted_exposure=state["exposure_value"],
                         )
                         mi += 1
-                        if mi >= mplt_data.shape[0]:
-                            # Output array full
-                            _update_idxs()
-                            return cursor, event_id, item_id, 1
             else:
                 # Update state variables
                 if sidx > 0:
@@ -421,7 +432,7 @@ def read_buffer(
 
     # Update the indices
     _update_idxs()
-    return cursor, event_id, item_id, 0
+    return cursor, state["current_event_id"], item_id, 0
 
 
 def read_input_files(run_dir, compute_qplt, sample_size):

--- a/oasislmf/pytools/plt/manager.py
+++ b/oasislmf/pytools/plt/manager.py
@@ -285,12 +285,27 @@ def read_buffer(
             # MPLT/QPLT can write up to max_records_per_event rows per record loop;
             # MPLT does this twice per summary (analytical mean, then sample mean).
             if state["compute_splt"] and si + max_records_per_event * (state["len_sample"] + 1) > splt_data.shape[0]:
+                if si == 0:
+                    raise ValueError(
+                        f"SPLT reservation of {max_records_per_event * (state['len_sample'] + 1)} rows for a single "
+                        f"summary exceeds the output buffer capacity of {splt_data.shape[0]}; increase OASIS_DEFAULT_BUFFER_SIZE."
+                    )
                 _update_idxs()
                 return cursor, state["current_event_id"], item_id, 1
             if state["compute_mplt"] and mi + 2 * max_records_per_event > mplt_data.shape[0]:
+                if mi == 0:
+                    raise ValueError(
+                        f"MPLT reservation of {2 * max_records_per_event} rows for a single summary exceeds the "
+                        f"output buffer capacity of {mplt_data.shape[0]}; increase OASIS_DEFAULT_BUFFER_SIZE."
+                    )
                 _update_idxs()
                 return cursor, state["current_event_id"], item_id, 1
             if state["compute_qplt"] and qi + max_records_per_event * len(intervals) > qplt_data.shape[0]:
+                if qi == 0:
+                    raise ValueError(
+                        f"QPLT reservation of {max_records_per_event * len(intervals)} rows for a single summary "
+                        f"exceeds the output buffer capacity of {qplt_data.shape[0]}; increase OASIS_DEFAULT_BUFFER_SIZE."
+                    )
                 _update_idxs()
                 return cursor, state["current_event_id"], item_id, 1
 

--- a/oasislmf/pytools/plt/manager.py
+++ b/oasislmf/pytools/plt/manager.py
@@ -39,6 +39,7 @@ class PLTReader(EventReader):
         period_weights,
         granular_date,
         intervals,
+        n_files=1,
     ):
         self.logger = logger
 
@@ -72,7 +73,10 @@ class PLTReader(EventReader):
             ('hasrec', np.bool_),
         ])
 
-        self.state = np.zeros(1, dtype=read_buffer_state_dtype)[0]
+        # One state row per input file/stream (indexed by file_idx in read_buffer below) -
+        # tracking (reading_losses, current_event_id, ...) per-stream, not reader-wide, so
+        # interleaved multi-file reads can't leak one file's last event id into another's.
+        self.state = np.zeros(n_files, dtype=read_buffer_state_dtype)
         self.state["reading_losses"] = False  # Set to true after reading header in read_buffer
         self.state["read_summary_set_id"] = False
         self.state["len_sample"] = len_sample
@@ -91,8 +95,6 @@ class PLTReader(EventReader):
             self.max_records_per_event = int(np.diff(occ_csr.occ_offsets).max())
         else:
             self.max_records_per_event = 0
-
-        self.curr_file_idx = None  # Current summary file idx being read
 
     def get_data(self, out_type):
         if out_type == "splt":
@@ -115,18 +117,11 @@ class PLTReader(EventReader):
             raise RuntimeError(f"Unknown out_type {out_type}")
 
     def read_buffer(self, byte_mv, cursor, valid_buff, event_id, item_id, file_idx):
-        # Check for new file idx to read summary_set_id at the start of each summary file stream
-        # This is not done by init_streams_in as the summary_set_id is unique to the summary_stream only
-        if self.curr_file_idx is not None and self.curr_file_idx != file_idx:
-            self.curr_file_idx = file_idx
-            self.state["read_summary_set_id"] = False
-        else:
-            self.curr_file_idx = file_idx
-
-        # Pass state variables to read_buffer
+        # Each file gets its own state row (see __init__), so read_summary_set_id
+        # naturally starts False per-file - no reset-on-file-switch needed here.
         cursor, event_id, item_id, ret = read_buffer(
             byte_mv, cursor, valid_buff, event_id, item_id,
-            self.state,
+            self.state[file_idx],
             self.splt_data, self.splt_idx,
             self.mplt_data, self.mplt_idx,
             self.qplt_data, self.qplt_idx,
@@ -239,8 +234,11 @@ def read_buffer(
         max_records_per_event,
 ):
     # Initialise idxs
-    # Read from state, not the event_id param: the caller always passes 0 on a fresh call.
+    # Read from state, not the event_id param: the caller always passes 0 on a fresh call,
+    # including a resume where reading_losses is already True and no header gets read below
+    # (so event_id would otherwise stay at the caller's 0 for every write this call).
     last_event_id = state["current_event_id"]
+    event_id = state["current_event_id"]
     si = splt_idx[0]
     mi = mplt_idx[0]
     qi = qplt_idx[0]
@@ -560,6 +558,7 @@ def run(
             file_data["period_weights"],
             file_data["granular_date"],
             file_data["intervals"],
+            n_files=len(streams_in),
         )
 
         # Initialise output files PLT

--- a/oasislmf/pytools/plt/manager.py
+++ b/oasislmf/pytools/plt/manager.py
@@ -319,6 +319,7 @@ def read_buffer(
                                 mi += 1
                                 if mi >= mplt_data.shape[0]:
                                     # Output array full
+                                    _reset_state()
                                     _update_idxs()
                                     return cursor, event_id, item_id, 1
 
@@ -348,6 +349,7 @@ def read_buffer(
                             qi += 1
                             if qi >= qplt_data.shape[0]:
                                 # Output array full
+                                _reset_state()
                                 _update_idxs()
                                 return cursor, event_id, item_id, 1
                 _reset_state()

--- a/oasislmf/pytools/plt/manager.py
+++ b/oasislmf/pytools/plt/manager.py
@@ -277,6 +277,18 @@ def read_buffer(
             sdloss = np.float64(0.0)
         return meanloss, sdloss
 
+    def _reservation_overflows(idx, reservation, capacity, name):
+        # Buffer genuinely too small for even one summary (idx == 0, i.e. buffer is
+        # already empty): flushing can never make room, so return would loop forever.
+        if idx + reservation > capacity:
+            if idx == 0:
+                raise ValueError(
+                    f"{name} reservation of {reservation} rows for a single summary exceeds the "
+                    f"output buffer capacity of {capacity}; increase OASIS_DEFAULT_BUFFER_SIZE."
+                )
+            return True
+        return False
+
     # Read input loop
     while cursor < valid_buff:
         if not state["reading_losses"]:
@@ -284,28 +296,16 @@ def read_buffer(
             # anything of it, so writes below can never run past the end of a buffer.
             # MPLT/QPLT can write up to max_records_per_event rows per record loop;
             # MPLT does this twice per summary (analytical mean, then sample mean).
-            if state["compute_splt"] and si + max_records_per_event * (state["len_sample"] + 1) > splt_data.shape[0]:
-                if si == 0:
-                    raise ValueError(
-                        f"SPLT reservation of {max_records_per_event * (state['len_sample'] + 1)} rows for a single "
-                        f"summary exceeds the output buffer capacity of {splt_data.shape[0]}; increase OASIS_DEFAULT_BUFFER_SIZE."
-                    )
-                _update_idxs()
-                return cursor, state["current_event_id"], item_id, 1
-            if state["compute_mplt"] and mi + 2 * max_records_per_event > mplt_data.shape[0]:
-                if mi == 0:
-                    raise ValueError(
-                        f"MPLT reservation of {2 * max_records_per_event} rows for a single summary exceeds the "
-                        f"output buffer capacity of {mplt_data.shape[0]}; increase OASIS_DEFAULT_BUFFER_SIZE."
-                    )
-                _update_idxs()
-                return cursor, state["current_event_id"], item_id, 1
-            if state["compute_qplt"] and qi + max_records_per_event * len(intervals) > qplt_data.shape[0]:
-                if qi == 0:
-                    raise ValueError(
-                        f"QPLT reservation of {max_records_per_event * len(intervals)} rows for a single summary "
-                        f"exceeds the output buffer capacity of {qplt_data.shape[0]}; increase OASIS_DEFAULT_BUFFER_SIZE."
-                    )
+            buffer_full = False
+            if state["compute_splt"] and _reservation_overflows(
+                    si, max_records_per_event * (state["len_sample"] + 1), splt_data.shape[0], "SPLT"):
+                buffer_full = True
+            if state["compute_mplt"] and _reservation_overflows(mi, 2 * max_records_per_event, mplt_data.shape[0], "MPLT"):
+                buffer_full = True
+            if state["compute_qplt"] and _reservation_overflows(
+                    qi, max_records_per_event * len(intervals), qplt_data.shape[0], "QPLT"):
+                buffer_full = True
+            if buffer_full:
                 _update_idxs()
                 return cursor, state["current_event_id"], item_id, 1
 

--- a/tests/pytools/eltpy/test_eltpy.py
+++ b/tests/pytools/eltpy/test_eltpy.py
@@ -5,6 +5,7 @@ import sys
 from tempfile import TemporaryDirectory
 import numpy as np
 import pandas as pd
+import pytest
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -12,6 +13,7 @@ from oasislmf.pytools.common.event_stream import SUMMARY_STREAM_ID, stream_info_
 from oasislmf.pytools.common.input_files import read_event_rates
 from oasislmf.pytools.elt.manager import main
 from oasislmf.pytools.common.data import (oasis_int, oasis_float, quantile_interval_dtype)
+from oasislmf.utils.exceptions import OasisStreamException
 
 TESTS_ASSETS_DIR = Path(__file__).parent.parent.parent.joinpath("assets").joinpath("test_eltpy")
 
@@ -373,3 +375,26 @@ def test_qelt_buffer_full_across_summaries():
         assert len(qelt) == 6, f"expected 6 QELT rows (3 summaries x 2 intervals), got {len(qelt)}"
         assert list(qelt["SummaryId"]) == [101, 101, 102, 102, 103, 103]
         assert (qelt["EventId"] == 999).all()
+
+
+def test_selt_reservation_impossible_raises_instead_of_hanging():
+    """If a single summary's worst-case SELT output can never fit in the buffer
+    (e.g. sample size too large for DEFAULT_BUFFER_SIZE), read_buffer must raise
+    rather than repeatedly yield a "buffer full" signal with zero progress, which
+    would otherwise hang run() in an infinite loop.
+    """
+    sample_size = 5
+    summaries = [(999, 101, 1000.0, [(i, float(i)) for i in range(1, sample_size + 1)])]
+    stream_bytes = _build_summary_stream(sample_size, summaries)
+
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        stream_file = tmp_dir / "summary.bin"
+        stream_file.write_bytes(stream_bytes)
+        selt_out = tmp_dir / "selt.csv"
+
+        # Buffer smaller than a single summary's worst case (len_sample + 2 = 7).
+        with patch('oasislmf.pytools.elt.manager.DEFAULT_BUFFER_SIZE', 3), \
+                patch('oasislmf.pytools.elt.manager.read_event_rates', return_value=(np.array([], dtype=oasis_int), np.array([], dtype=oasis_float))):
+            with pytest.raises(OasisStreamException, match="SELT reservation"):
+                main(run_dir=tmp_dir, files_in=stream_file, selt=selt_out, ext="csv")

--- a/tests/pytools/eltpy/test_eltpy.py
+++ b/tests/pytools/eltpy/test_eltpy.py
@@ -288,10 +288,8 @@ def test_melt_buffer_full_immediately_before_new_event():
 def test_selt_reservation_holds_with_mean_and_affected_risk_idx():
     """The SELT buffer-capacity reservation must account for every sidx that currently
     reaches SELT's write path: the len_sample real samples, plus MEAN_IDX, plus
-    NUMBER_OF_AFFECTED_RISK_IDX (both of the latter still fall into SELT's "normal data
-    record" branch - a separate, pre-existing issue tracked in
-    elt_selt_special_sidx_issue.md, not fixed here). Undersizing the reservation is a
-    silent out-of-bounds write under numba, not a catchable Python exception.
+    NUMBER_OF_AFFECTED_RISK_IDX. Undersizing the reservation is a silent out-of-bounds
+    write under numba, not a catchable Python exception.
     """
     sample_size = 2
     summaries = [

--- a/tests/pytools/eltpy/test_eltpy.py
+++ b/tests/pytools/eltpy/test_eltpy.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock, patch
 
 from oasislmf.pytools.common.event_stream import SUMMARY_STREAM_ID, stream_info_to_bytes, MEAN_IDX, NUMBER_OF_AFFECTED_RISK_IDX
 from oasislmf.pytools.common.input_files import read_event_rates
+import oasislmf.pytools.elt.manager as elt_manager
 from oasislmf.pytools.elt.manager import main
 from oasislmf.pytools.common.data import (oasis_int, oasis_float, quantile_interval_dtype)
 from oasislmf.utils.exceptions import OasisStreamException
@@ -398,3 +399,59 @@ def test_selt_reservation_impossible_raises_instead_of_hanging():
                 patch('oasislmf.pytools.elt.manager.read_event_rates', return_value=(np.array([], dtype=oasis_int), np.array([], dtype=oasis_float))):
             with pytest.raises(OasisStreamException, match="SELT reservation"):
                 main(run_dir=tmp_dir, files_in=stream_file, selt=selt_out, ext="csv")
+
+
+def test_multifile_current_event_id_not_leaked_across_files():
+    """current_event_id (and the rest of read_buffer's per-record state) is tracked
+    per input file, not reader-wide. Without that, switching from file A to file B
+    could compare file B's first header against file A's last event id, spuriously
+    re-yielding file A's already-reported event with zero new rows whenever the two
+    files' event ids happen to differ. Verify each file's first read_buffer call
+    starts with current_event_id == 0 (no leakage), and output content is unaffected.
+    """
+    sample_size = 2
+    stream_a = _build_summary_stream(sample_size, [
+        (999, 101, 1000.0, [(1, 10.0), (2, 20.0)]),
+        (999, 102, 2000.0, [(1, 30.0), (2, 40.0)]),
+    ])
+    stream_b = _build_summary_stream(sample_size, [
+        (1000, 201, 3000.0, [(1, 50.0), (2, 60.0)]),
+        (1000, 202, 4000.0, [(1, 70.0), (2, 80.0)]),
+    ])
+
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        file_a = tmp_dir / "a.bin"
+        file_b = tmp_dir / "b.bin"
+        file_a.write_bytes(stream_a)
+        file_b.write_bytes(stream_b)
+        melt_out = tmp_dir / "melt.csv"
+
+        calls = []
+        orig_read_buffer = elt_manager.ELTReader.read_buffer
+
+        def spy_read_buffer(self, byte_mv, cursor, valid_buff, event_id, item_id, file_idx):
+            current_event_id_before = int(self.state[file_idx]["current_event_id"])
+            result = orig_read_buffer(self, byte_mv, cursor, valid_buff, event_id, item_id, file_idx)
+            calls.append((file_idx, current_event_id_before, result[3]))
+            return result
+
+        with patch.object(elt_manager.ELTReader, "read_buffer", spy_read_buffer), \
+                patch('oasislmf.pytools.elt.manager.read_event_rates', return_value=(np.array([], dtype=oasis_int), np.array([], dtype=oasis_float))):
+            main(run_dir=tmp_dir, files_in=[file_a, file_b], melt=melt_out, ext="csv")
+
+        # Each file's very first read_buffer call must start with current_event_id == 0 -
+        # not just the reader's first-ever call across all files.
+        first_call_per_file = {}
+        for file_idx, current_event_id_before, _ret in calls:
+            first_call_per_file.setdefault(file_idx, current_event_id_before)
+        assert all(v == 0 for v in first_call_per_file.values()), first_call_per_file
+
+        # No spurious extra yield: exactly one read_buffer call per file (each file
+        # is small enough to finish in one call with no event boundary inside it).
+        assert len(calls) == 2, f"expected 1 read_buffer call per file (2 total), got {len(calls)}: {calls}"
+
+        melt = pd.read_csv(melt_out)
+        assert len(melt) == 8, f"expected 8 MELT rows (4 summaries x 2), got {len(melt)}"
+        assert list(melt["EventId"]) == [999, 999, 999, 999, 1000, 1000, 1000, 1000]
+        assert list(melt["SummaryId"]) == [101, 101, 102, 102, 201, 201, 202, 202]

--- a/tests/pytools/eltpy/test_eltpy.py
+++ b/tests/pytools/eltpy/test_eltpy.py
@@ -1,5 +1,6 @@
 from io import BufferedReader
 import shutil
+import struct
 import sys
 from tempfile import TemporaryDirectory
 import numpy as np
@@ -7,11 +8,44 @@ import pandas as pd
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+from oasislmf.pytools.common.event_stream import SUMMARY_STREAM_ID, stream_info_to_bytes, MEAN_IDX, NUMBER_OF_AFFECTED_RISK_IDX
 from oasislmf.pytools.common.input_files import read_event_rates
 from oasislmf.pytools.elt.manager import main
-from oasislmf.pytools.common.data import (oasis_int, oasis_float)
+from oasislmf.pytools.common.data import (oasis_int, oasis_float, quantile_interval_dtype)
 
 TESTS_ASSETS_DIR = Path(__file__).parent.parent.parent.joinpath("assets").joinpath("test_eltpy")
+
+
+def _build_summary_stream(sample_size, summaries):
+    """Build a minimal summary-stream binary: header, one summaryset_id, then per summary
+    (event_id, summary_id, impacted_exposure, samples..., terminator).
+
+    summaries: list of (event_id, summary_id, impacted_exposure, [(sidx, loss), ...])
+    """
+    buf = bytearray()
+    buf += struct.pack("<i", np.frombuffer(stream_info_to_bytes(SUMMARY_STREAM_ID, sample_size), dtype=np.int32)[0])
+    buf += struct.pack("<i", sample_size)
+    buf += struct.pack("<i", 1)  # summaryset_id, read once
+    for event_id, summary_id, impacted_exposure, samples in summaries:
+        buf += struct.pack("<i", event_id)
+        buf += struct.pack("<i", summary_id)
+        buf += struct.pack("<f", impacted_exposure)
+        for sidx, loss in samples:
+            buf += struct.pack("<i", sidx)
+            buf += struct.pack("<f", loss)
+        buf += struct.pack("<i", 0)
+        buf += struct.pack("<f", 0.0)
+    return bytes(buf)
+
+
+def _make_intervals(quantiles, sample_size):
+    rows = []
+    for q in quantiles:
+        pos = (sample_size - 1) * q + 1
+        integer_part = int(pos)
+        fractional_part = pos - integer_part
+        rows.append((q, integer_part, fractional_part))
+    return np.array(rows, dtype=quantile_interval_dtype)
 
 
 def case_runner(test_name, out_ext="csv", with_event_rate=False):
@@ -183,3 +217,100 @@ def test_selt_stdin(monkeypatch):
                             Path(error_path, "py_selt.csv"))
             arg_str = ' '.join([f"{k}={v}" for k, v in kwargs.items()])
             raise Exception(f"running 'eltpy {arg_str}' led to diff, see files at {error_path}") from e
+
+
+def test_melt_qelt_buffer_full_across_summaries():
+    """A MELT/QELT output buffer filling up mid-run must not skip, duplicate, or
+    misattribute rows for any summary, including ones that don't trigger the overflow
+    themselves. Uses a tiny DEFAULT_BUFFER_SIZE to force this deterministically.
+    """
+    sample_size = 3
+    summaries = [
+        (999, 101, 1000.0, [(1, 10.0), (2, 20.0), (3, 30.0)]),
+        (999, 102, 2000.0, [(1, 40.0), (2, 50.0), (3, 60.0)]),
+        (999, 103, 3000.0, [(1, 70.0), (2, 80.0), (3, 90.0)]),
+    ]
+    stream_bytes = _build_summary_stream(sample_size, summaries)
+    intervals = _make_intervals([0.5], sample_size)
+
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        stream_file = tmp_dir / "summary.bin"
+        stream_file.write_bytes(stream_bytes)
+        melt_out = tmp_dir / "melt.csv"
+        qelt_out = tmp_dir / "qelt.csv"
+
+        with patch('oasislmf.pytools.elt.manager.DEFAULT_BUFFER_SIZE', 4), \
+             patch('oasislmf.pytools.elt.manager.read_event_rates', return_value=(np.array([], dtype=oasis_int), np.array([], dtype=oasis_float))), \
+             patch('oasislmf.pytools.elt.manager.read_quantile', return_value=intervals):
+            main(run_dir=tmp_dir, files_in=stream_file, melt=melt_out, qelt=qelt_out, ext="csv")
+
+        melt = pd.read_csv(melt_out)
+        qelt = pd.read_csv(qelt_out)
+
+        assert len(melt) == 6, f"expected 6 MELT rows (3 summaries x 2), got {len(melt)}"
+        assert list(melt["SummaryId"]) == [101, 101, 102, 102, 103, 103]
+        assert (melt["EventId"] == 999).all()
+
+        assert len(qelt) == 3, f"expected 3 QELT rows (3 summaries x 1 interval), got {len(qelt)} - MELT's overflow must not skip QELT"
+        assert list(qelt["SummaryId"]) == [101, 102, 103]
+        assert (qelt["EventId"] == 999).all()
+
+
+def test_melt_buffer_full_immediately_before_new_event():
+    """A MELT buffer-full flush that happens to land right before a genuine new event
+    must still detect that event boundary correctly (not merge or lose it).
+    """
+    sample_size = 2
+    summaries = [
+        (1000719084, 3820941, 100.0, [(1, 1.0), (2, 2.0)]),
+        (1000719084, 3820948, 200.0, [(1, 3.0), (2, 4.0)]),
+        (1100028063, 111, 300.0, [(1, 5.0), (2, 6.0)]),
+    ]
+    stream_bytes = _build_summary_stream(sample_size, summaries)
+
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        stream_file = tmp_dir / "summary.bin"
+        stream_file.write_bytes(stream_bytes)
+        melt_out = tmp_dir / "melt.csv"
+
+        with patch('oasislmf.pytools.elt.manager.DEFAULT_BUFFER_SIZE', 4), \
+             patch('oasislmf.pytools.elt.manager.read_event_rates', return_value=(np.array([], dtype=oasis_int), np.array([], dtype=oasis_float))):
+            main(run_dir=tmp_dir, files_in=stream_file, melt=melt_out, ext="csv")
+
+        melt = pd.read_csv(melt_out)
+        assert len(melt) == 6
+        assert list(melt["EventId"]) == [1000719084] * 4 + [1100028063] * 2
+        assert list(melt["SummaryId"]) == [3820941, 3820941, 3820948, 3820948, 111, 111]
+
+
+def test_selt_reservation_holds_with_mean_and_affected_risk_idx():
+    """The SELT buffer-capacity reservation must account for every sidx that currently
+    reaches SELT's write path: the len_sample real samples, plus MEAN_IDX, plus
+    NUMBER_OF_AFFECTED_RISK_IDX (both of the latter still fall into SELT's "normal data
+    record" branch - a separate, pre-existing issue tracked in
+    elt_selt_special_sidx_issue.md, not fixed here). Undersizing the reservation is a
+    silent out-of-bounds write under numba, not a catchable Python exception.
+    """
+    sample_size = 2
+    summaries = [
+        (999, 101, 1000.0, [(NUMBER_OF_AFFECTED_RISK_IDX, 2.0), (MEAN_IDX, 15.0), (1, 10.0), (2, 20.0)]),
+    ]
+    stream_bytes = _build_summary_stream(sample_size, summaries)
+
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        stream_file = tmp_dir / "summary.bin"
+        stream_file.write_bytes(stream_bytes)
+        selt_out = tmp_dir / "selt.csv"
+
+        # Buffer sized to exactly what the reservation should reserve (len_sample + 2,
+        # for the 2 samples + MEAN_IDX + NUMBER_OF_AFFECTED_RISK_IDX).
+        with patch('oasislmf.pytools.elt.manager.DEFAULT_BUFFER_SIZE', sample_size + 2), \
+             patch('oasislmf.pytools.elt.manager.read_event_rates', return_value=(np.array([], dtype=oasis_int), np.array([], dtype=oasis_float))):
+            main(run_dir=tmp_dir, files_in=stream_file, selt=selt_out, ext="csv")
+
+        selt = pd.read_csv(selt_out)
+        assert len(selt) == sample_size + 2, f"expected {sample_size + 2} rows (MEAN_IDX + NUMBER_OF_AFFECTED_RISK_IDX + {sample_size} samples), got {len(selt)}"
+        assert sorted(selt["SampleId"]) == [-4, -1, 1, 2]

--- a/tests/pytools/eltpy/test_eltpy.py
+++ b/tests/pytools/eltpy/test_eltpy.py
@@ -241,8 +241,8 @@ def test_melt_qelt_buffer_full_across_summaries():
         qelt_out = tmp_dir / "qelt.csv"
 
         with patch('oasislmf.pytools.elt.manager.DEFAULT_BUFFER_SIZE', 4), \
-             patch('oasislmf.pytools.elt.manager.read_event_rates', return_value=(np.array([], dtype=oasis_int), np.array([], dtype=oasis_float))), \
-             patch('oasislmf.pytools.elt.manager.read_quantile', return_value=intervals):
+                patch('oasislmf.pytools.elt.manager.read_event_rates', return_value=(np.array([], dtype=oasis_int), np.array([], dtype=oasis_float))), \
+                patch('oasislmf.pytools.elt.manager.read_quantile', return_value=intervals):
             main(run_dir=tmp_dir, files_in=stream_file, melt=melt_out, qelt=qelt_out, ext="csv")
 
         melt = pd.read_csv(melt_out)
@@ -276,7 +276,7 @@ def test_melt_buffer_full_immediately_before_new_event():
         melt_out = tmp_dir / "melt.csv"
 
         with patch('oasislmf.pytools.elt.manager.DEFAULT_BUFFER_SIZE', 4), \
-             patch('oasislmf.pytools.elt.manager.read_event_rates', return_value=(np.array([], dtype=oasis_int), np.array([], dtype=oasis_float))):
+                patch('oasislmf.pytools.elt.manager.read_event_rates', return_value=(np.array([], dtype=oasis_int), np.array([], dtype=oasis_float))):
             main(run_dir=tmp_dir, files_in=stream_file, melt=melt_out, ext="csv")
 
         melt = pd.read_csv(melt_out)
@@ -306,9 +306,70 @@ def test_selt_reservation_holds_with_mean_and_affected_risk_idx():
         # Buffer sized to exactly what the reservation should reserve (len_sample + 2,
         # for the 2 samples + MEAN_IDX + NUMBER_OF_AFFECTED_RISK_IDX).
         with patch('oasislmf.pytools.elt.manager.DEFAULT_BUFFER_SIZE', sample_size + 2), \
-             patch('oasislmf.pytools.elt.manager.read_event_rates', return_value=(np.array([], dtype=oasis_int), np.array([], dtype=oasis_float))):
+                patch('oasislmf.pytools.elt.manager.read_event_rates', return_value=(np.array([], dtype=oasis_int), np.array([], dtype=oasis_float))):
             main(run_dir=tmp_dir, files_in=stream_file, selt=selt_out, ext="csv")
 
         selt = pd.read_csv(selt_out)
-        assert len(selt) == sample_size + 2, f"expected {sample_size + 2} rows (MEAN_IDX + NUMBER_OF_AFFECTED_RISK_IDX + {sample_size} samples), got {len(selt)}"
+        expected_rows = sample_size + 2
+        assert len(selt) == expected_rows, (
+            f"expected {expected_rows} rows (MEAN_IDX + NUMBER_OF_AFFECTED_RISK_IDX + {sample_size} samples), got {len(selt)}"
+        )
         assert sorted(selt["SampleId"]) == [-4, -1, 1, 2]
+
+
+def test_selt_buffer_full_across_summaries():
+    """A SELT output buffer filling up mid-run must not skip, duplicate, or
+    misattribute rows for any summary. Uses a tiny DEFAULT_BUFFER_SIZE to force
+    this deterministically.
+    """
+    sample_size = 2
+    summaries = [
+        (999, 101, 1000.0, [(1, 10.0), (2, 20.0)]),
+        (999, 102, 2000.0, [(1, 40.0), (2, 50.0)]),
+        (999, 103, 3000.0, [(1, 70.0), (2, 80.0)]),
+    ]
+    stream_bytes = _build_summary_stream(sample_size, summaries)
+
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        stream_file = tmp_dir / "summary.bin"
+        stream_file.write_bytes(stream_bytes)
+        selt_out = tmp_dir / "selt.csv"
+
+        with patch('oasislmf.pytools.elt.manager.DEFAULT_BUFFER_SIZE', 5), \
+                patch('oasislmf.pytools.elt.manager.read_event_rates', return_value=(np.array([], dtype=oasis_int), np.array([], dtype=oasis_float))):
+            main(run_dir=tmp_dir, files_in=stream_file, selt=selt_out, ext="csv")
+
+        selt = pd.read_csv(selt_out)
+        assert len(selt) == 6, f"expected 6 SELT rows (3 summaries x 2 samples), got {len(selt)}"
+        assert list(selt["SummaryId"]) == [101, 101, 102, 102, 103, 103]
+        assert (selt["EventId"] == 999).all()
+
+
+def test_qelt_buffer_full_across_summaries():
+    """A QELT output buffer filling up mid-run (without MELT also overflowing) must
+    not skip, duplicate, or misattribute rows for any summary.
+    """
+    sample_size = 3
+    summaries = [
+        (999, 101, 1000.0, [(1, 10.0), (2, 20.0), (3, 30.0)]),
+        (999, 102, 2000.0, [(1, 40.0), (2, 50.0), (3, 60.0)]),
+        (999, 103, 3000.0, [(1, 70.0), (2, 80.0), (3, 90.0)]),
+    ]
+    stream_bytes = _build_summary_stream(sample_size, summaries)
+    intervals = _make_intervals([0.25, 0.75], sample_size)
+
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        stream_file = tmp_dir / "summary.bin"
+        stream_file.write_bytes(stream_bytes)
+        qelt_out = tmp_dir / "qelt.csv"
+
+        with patch('oasislmf.pytools.elt.manager.DEFAULT_BUFFER_SIZE', 3), \
+                patch('oasislmf.pytools.elt.manager.read_quantile', return_value=intervals):
+            main(run_dir=tmp_dir, files_in=stream_file, qelt=qelt_out, ext="csv")
+
+        qelt = pd.read_csv(qelt_out)
+        assert len(qelt) == 6, f"expected 6 QELT rows (3 summaries x 2 intervals), got {len(qelt)}"
+        assert list(qelt["SummaryId"]) == [101, 101, 102, 102, 103, 103]
+        assert (qelt["EventId"] == 999).all()

--- a/tests/pytools/eltpy/test_eltpy.py
+++ b/tests/pytools/eltpy/test_eltpy.py
@@ -451,7 +451,11 @@ def test_multifile_current_event_id_not_leaked_across_files():
         # is small enough to finish in one call with no event boundary inside it).
         assert len(calls) == 2, f"expected 1 read_buffer call per file (2 total), got {len(calls)}: {calls}"
 
+        # read_streams interleaves files via a selector, so file processing order isn't
+        # guaranteed (confirmed: CI processed file B before file A here) - compare content
+        # order-independently rather than assuming file A's rows come first.
         melt = pd.read_csv(melt_out)
         assert len(melt) == 8, f"expected 8 MELT rows (4 summaries x 2), got {len(melt)}"
-        assert list(melt["EventId"]) == [999, 999, 999, 999, 1000, 1000, 1000, 1000]
-        assert list(melt["SummaryId"]) == [101, 101, 102, 102, 201, 201, 202, 202]
+        expected = sorted([(999, 101), (999, 101), (999, 102), (999, 102),
+                           (1000, 201), (1000, 201), (1000, 202), (1000, 202)])
+        assert sorted(zip(melt["EventId"], melt["SummaryId"])) == expected

--- a/tests/pytools/pltpy/test_pltpy.py
+++ b/tests/pytools/pltpy/test_pltpy.py
@@ -12,6 +12,7 @@ from tempfile import TemporaryDirectory
 from oasislmf.pytools.common.event_stream import SUMMARY_STREAM_ID, stream_info_to_bytes
 from oasislmf.pytools.common.id_index import build as id_index_build
 from oasislmf.pytools.common.input_files import OccurrenceCSR
+import oasislmf.pytools.plt.manager as plt_manager
 from oasislmf.pytools.plt.manager import main
 from oasislmf.utils.exceptions import OasisStreamException
 
@@ -411,3 +412,62 @@ def test_splt_reservation_impossible_raises_instead_of_hanging():
                 patch('oasislmf.pytools.plt.manager.read_periods', return_value=period_weights):
             with pytest.raises(OasisStreamException, match="SPLT reservation"):
                 main(run_dir=tmp_dir, files_in=stream_file, splt=splt_out, ext="csv")
+
+
+def test_multifile_current_event_id_not_leaked_across_files():
+    """current_event_id (and the rest of read_buffer's per-record state) is tracked
+    per input file, not reader-wide. Without that, switching from file A to file B
+    could compare file B's first header against file A's last event id, spuriously
+    re-yielding file A's already-reported event with zero new rows whenever the two
+    files' event ids happen to differ. Verify each file's first read_buffer call
+    starts with current_event_id == 0 (no leakage), and output content is unaffected.
+    """
+    sample_size = 2
+    occ_csr = _make_occ_csr({999: [1], 1000: [1]})
+    period_weights = np.array([(1, 1.0)], dtype=np.dtype([("period_no", np.int32), ("weighting", "f4")]))
+    stream_a = _build_summary_stream(sample_size, [
+        (999, 101, 1000.0, [(1, 10.0), (2, 20.0)]),
+        (999, 102, 2000.0, [(1, 30.0), (2, 40.0)]),
+    ])
+    stream_b = _build_summary_stream(sample_size, [
+        (1000, 201, 3000.0, [(1, 50.0), (2, 60.0)]),
+        (1000, 202, 4000.0, [(1, 70.0), (2, 80.0)]),
+    ])
+
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        file_a = tmp_dir / "a.bin"
+        file_b = tmp_dir / "b.bin"
+        file_a.write_bytes(stream_a)
+        file_b.write_bytes(stream_b)
+        mplt_out = tmp_dir / "mplt.csv"
+
+        calls = []
+        orig_read_buffer = plt_manager.PLTReader.read_buffer
+
+        def spy_read_buffer(self, byte_mv, cursor, valid_buff, event_id, item_id, file_idx):
+            current_event_id_before = int(self.state[file_idx]["current_event_id"])
+            result = orig_read_buffer(self, byte_mv, cursor, valid_buff, event_id, item_id, file_idx)
+            calls.append((file_idx, current_event_id_before, result[3]))
+            return result
+
+        with patch.object(plt_manager.PLTReader, "read_buffer", spy_read_buffer), \
+                patch('oasislmf.pytools.plt.manager.read_occurrence', return_value=(occ_csr, 1, False, 1)), \
+                patch('oasislmf.pytools.plt.manager.read_periods', return_value=period_weights):
+            main(run_dir=tmp_dir, files_in=[file_a, file_b], mplt=mplt_out, ext="csv")
+
+        # Each file's very first read_buffer call must start with current_event_id == 0 -
+        # not just the reader's first-ever call across all files.
+        first_call_per_file = {}
+        for file_idx, current_event_id_before, _ret in calls:
+            first_call_per_file.setdefault(file_idx, current_event_id_before)
+        assert all(v == 0 for v in first_call_per_file.values()), first_call_per_file
+
+        # No spurious extra yield: exactly one read_buffer call per file (each file
+        # is small enough to finish in one call with no event boundary inside it).
+        assert len(calls) == 2, f"expected 1 read_buffer call per file (2 total), got {len(calls)}: {calls}"
+
+        mplt = pd.read_csv(mplt_out)
+        assert len(mplt) == 4, f"expected 4 MPLT rows (4 summaries x 1 period), got {len(mplt)}"
+        assert list(mplt["EventId"]) == [999, 999, 1000, 1000]
+        assert list(mplt["SummaryId"]) == [101, 102, 201, 202]

--- a/tests/pytools/pltpy/test_pltpy.py
+++ b/tests/pytools/pltpy/test_pltpy.py
@@ -271,9 +271,9 @@ def test_mplt_qplt_buffer_full_across_summaries():
         qplt_out = tmp_dir / "qplt.csv"
 
         with patch('oasislmf.pytools.plt.manager.DEFAULT_BUFFER_SIZE', 2), \
-             patch('oasislmf.pytools.plt.manager.read_occurrence', return_value=(occ_csr, 1, False, 1)), \
-             patch('oasislmf.pytools.plt.manager.read_periods', return_value=period_weights), \
-             patch('oasislmf.pytools.plt.manager.read_quantile', return_value=intervals):
+                patch('oasislmf.pytools.plt.manager.read_occurrence', return_value=(occ_csr, 1, False, 1)), \
+                patch('oasislmf.pytools.plt.manager.read_periods', return_value=period_weights), \
+                patch('oasislmf.pytools.plt.manager.read_quantile', return_value=intervals):
             main(run_dir=tmp_dir, files_in=stream_file, mplt=mplt_out, qplt=qplt_out, ext="csv")
 
         mplt = pd.read_csv(mplt_out)
@@ -285,4 +285,101 @@ def test_mplt_qplt_buffer_full_across_summaries():
 
         assert len(qplt) == 3, f"expected 3 QPLT rows (3 summaries x 1 period x 1 interval), got {len(qplt)} - MPLT's overflow must not skip QPLT"
         assert list(qplt["SummaryId"]) == [101, 102, 103]
+        assert (qplt["EventId"] == 999).all()
+
+
+def test_splt_buffer_full_across_summaries():
+    """An SPLT output buffer filling up mid-run must not skip, duplicate, or
+    misattribute rows for any summary. Uses a tiny DEFAULT_BUFFER_SIZE to force
+    this deterministically.
+    """
+    sample_size = 2
+    occ_csr = _make_occ_csr({999: [1]})
+    period_weights = np.array([(1, 1.0)], dtype=np.dtype([("period_no", np.int32), ("weighting", "f4")]))
+    summaries = [
+        (999, 101, 1000.0, [(1, 10.0), (2, 20.0)]),
+        (999, 102, 2000.0, [(1, 40.0), (2, 50.0)]),
+        (999, 103, 3000.0, [(1, 70.0), (2, 80.0)]),
+    ]
+    stream_bytes = _build_summary_stream(sample_size, summaries)
+
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        stream_file = tmp_dir / "summary.bin"
+        stream_file.write_bytes(stream_bytes)
+        splt_out = tmp_dir / "splt.csv"
+
+        with patch('oasislmf.pytools.plt.manager.DEFAULT_BUFFER_SIZE', 4), \
+                patch('oasislmf.pytools.plt.manager.read_occurrence', return_value=(occ_csr, 1, False, 1)), \
+                patch('oasislmf.pytools.plt.manager.read_periods', return_value=period_weights):
+            main(run_dir=tmp_dir, files_in=stream_file, splt=splt_out, ext="csv")
+
+        splt = pd.read_csv(splt_out)
+        assert len(splt) == 6, f"expected 6 SPLT rows (3 summaries x 1 period x 2 samples), got {len(splt)}"
+        assert list(splt["SummaryId"]) == [101, 101, 102, 102, 103, 103]
+        assert (splt["EventId"] == 999).all()
+
+
+def test_mplt_buffer_full_immediately_before_new_event():
+    """An MPLT buffer-full flush that happens to land right before a genuine new event
+    must still detect that event boundary correctly (not merge or lose it).
+    """
+    sample_size = 2
+    occ_csr = _make_occ_csr({1000719084: [1], 1100028063: [1]})
+    period_weights = np.array([(1, 1.0)], dtype=np.dtype([("period_no", np.int32), ("weighting", "f4")]))
+    summaries = [
+        (1000719084, 3820941, 100.0, [(1, 1.0), (2, 2.0)]),
+        (1000719084, 3820948, 200.0, [(1, 3.0), (2, 4.0)]),
+        (1100028063, 111, 300.0, [(1, 5.0), (2, 6.0)]),
+    ]
+    stream_bytes = _build_summary_stream(sample_size, summaries)
+
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        stream_file = tmp_dir / "summary.bin"
+        stream_file.write_bytes(stream_bytes)
+        mplt_out = tmp_dir / "mplt.csv"
+
+        with patch('oasislmf.pytools.plt.manager.DEFAULT_BUFFER_SIZE', 2), \
+                patch('oasislmf.pytools.plt.manager.read_occurrence', return_value=(occ_csr, 1, False, 1)), \
+                patch('oasislmf.pytools.plt.manager.read_periods', return_value=period_weights):
+            main(run_dir=tmp_dir, files_in=stream_file, mplt=mplt_out, ext="csv")
+
+        mplt = pd.read_csv(mplt_out)
+        assert len(mplt) == 3
+        assert list(mplt["EventId"]) == [1000719084, 1000719084, 1100028063]
+        assert list(mplt["SummaryId"]) == [3820941, 3820948, 111]
+
+
+def test_qplt_buffer_full_across_summaries():
+    """A QPLT output buffer filling up mid-run (without MPLT also overflowing) must
+    not skip, duplicate, or misattribute rows for any summary.
+    """
+    sample_size = 3
+    occ_csr = _make_occ_csr({999: [1]})
+    period_weights = np.array([(1, 1.0)], dtype=np.dtype([("period_no", np.int32), ("weighting", "f4")]))
+    intervals = np.array([(0.25, 3, 0.0), (0.75, 3, 0.0)], dtype=np.dtype(
+        [("quantile", "f4"), ("integer_part", "i4"), ("fractional_part", "f4")]))
+    summaries = [
+        (999, 101, 1000.0, [(1, 10.0), (2, 20.0), (3, 30.0)]),
+        (999, 102, 2000.0, [(1, 40.0), (2, 50.0), (3, 60.0)]),
+        (999, 103, 3000.0, [(1, 70.0), (2, 80.0), (3, 90.0)]),
+    ]
+    stream_bytes = _build_summary_stream(sample_size, summaries)
+
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        stream_file = tmp_dir / "summary.bin"
+        stream_file.write_bytes(stream_bytes)
+        qplt_out = tmp_dir / "qplt.csv"
+
+        with patch('oasislmf.pytools.plt.manager.DEFAULT_BUFFER_SIZE', 3), \
+                patch('oasislmf.pytools.plt.manager.read_occurrence', return_value=(occ_csr, 1, False, 1)), \
+                patch('oasislmf.pytools.plt.manager.read_periods', return_value=period_weights), \
+                patch('oasislmf.pytools.plt.manager.read_quantile', return_value=intervals):
+            main(run_dir=tmp_dir, files_in=stream_file, qplt=qplt_out, ext="csv")
+
+        qplt = pd.read_csv(qplt_out)
+        assert len(qplt) == 6, f"expected 6 QPLT rows (3 summaries x 1 period x 2 intervals), got {len(qplt)}"
+        assert list(qplt["SummaryId"]) == [101, 101, 102, 102, 103, 103]
         assert (qplt["EventId"] == 999).all()

--- a/tests/pytools/pltpy/test_pltpy.py
+++ b/tests/pytools/pltpy/test_pltpy.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 import numpy as np
 import shutil
 import pandas as pd
+import pytest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -12,6 +13,7 @@ from oasislmf.pytools.common.event_stream import SUMMARY_STREAM_ID, stream_info_
 from oasislmf.pytools.common.id_index import build as id_index_build
 from oasislmf.pytools.common.input_files import OccurrenceCSR
 from oasislmf.pytools.plt.manager import main
+from oasislmf.utils.exceptions import OasisStreamException
 
 TESTS_ASSETS_DIR = Path(__file__).parent.parent.parent.joinpath("assets").joinpath("test_pltpy")
 
@@ -383,3 +385,29 @@ def test_qplt_buffer_full_across_summaries():
         assert len(qplt) == 6, f"expected 6 QPLT rows (3 summaries x 1 period x 2 intervals), got {len(qplt)}"
         assert list(qplt["SummaryId"]) == [101, 101, 102, 102, 103, 103]
         assert (qplt["EventId"] == 999).all()
+
+
+def test_splt_reservation_impossible_raises_instead_of_hanging():
+    """If a single summary's worst-case SPLT output can never fit in the buffer
+    (e.g. max_records_per_event x sample size too large for DEFAULT_BUFFER_SIZE),
+    read_buffer must raise rather than repeatedly yield a "buffer full" signal with
+    zero progress, which would otherwise hang run() in an infinite loop.
+    """
+    sample_size = 5
+    occ_csr = _make_occ_csr({999: [1]})
+    period_weights = np.array([(1, 1.0)], dtype=np.dtype([("period_no", np.int32), ("weighting", "f4")]))
+    summaries = [(999, 101, 1000.0, [(i, float(i)) for i in range(1, sample_size + 1)])]
+    stream_bytes = _build_summary_stream(sample_size, summaries)
+
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        stream_file = tmp_dir / "summary.bin"
+        stream_file.write_bytes(stream_bytes)
+        splt_out = tmp_dir / "splt.csv"
+
+        # Buffer smaller than a single summary's worst case (1 period x (5 + 1) = 6).
+        with patch('oasislmf.pytools.plt.manager.DEFAULT_BUFFER_SIZE', 3), \
+                patch('oasislmf.pytools.plt.manager.read_occurrence', return_value=(occ_csr, 1, False, 1)), \
+                patch('oasislmf.pytools.plt.manager.read_periods', return_value=period_weights):
+            with pytest.raises(OasisStreamException, match="SPLT reservation"):
+                main(run_dir=tmp_dir, files_in=stream_file, splt=splt_out, ext="csv")

--- a/tests/pytools/pltpy/test_pltpy.py
+++ b/tests/pytools/pltpy/test_pltpy.py
@@ -467,7 +467,10 @@ def test_multifile_current_event_id_not_leaked_across_files():
         # is small enough to finish in one call with no event boundary inside it).
         assert len(calls) == 2, f"expected 1 read_buffer call per file (2 total), got {len(calls)}: {calls}"
 
+        # read_streams interleaves files via a selector, so file processing order isn't
+        # guaranteed - compare content order-independently rather than assuming file A's
+        # rows come first.
         mplt = pd.read_csv(mplt_out)
         assert len(mplt) == 4, f"expected 4 MPLT rows (4 summaries x 1 period), got {len(mplt)}"
-        assert list(mplt["EventId"]) == [999, 999, 1000, 1000]
-        assert list(mplt["SummaryId"]) == [101, 102, 201, 202]
+        expected = sorted([(999, 101), (999, 102), (1000, 201), (1000, 202)])
+        assert sorted(zip(mplt["EventId"], mplt["SummaryId"])) == expected

--- a/tests/pytools/pltpy/test_pltpy.py
+++ b/tests/pytools/pltpy/test_pltpy.py
@@ -1,15 +1,55 @@
 from io import BufferedReader
+import struct
 import sys
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 import numpy as np
 import shutil
 import pandas as pd
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from oasislmf.pytools.common.event_stream import SUMMARY_STREAM_ID, stream_info_to_bytes
+from oasislmf.pytools.common.id_index import build as id_index_build
+from oasislmf.pytools.common.input_files import OccurrenceCSR
 from oasislmf.pytools.plt.manager import main
 
 TESTS_ASSETS_DIR = Path(__file__).parent.parent.parent.joinpath("assets").joinpath("test_pltpy")
+
+
+def _build_summary_stream(sample_size, summaries):
+    """Build a minimal summary-stream binary, same layout as eltpy's test helper.
+
+    summaries: list of (event_id, summary_id, impacted_exposure, [(sidx, loss), ...])
+    """
+    buf = bytearray()
+    buf += struct.pack("<i", np.frombuffer(stream_info_to_bytes(SUMMARY_STREAM_ID, sample_size), dtype=np.int32)[0])
+    buf += struct.pack("<i", sample_size)
+    buf += struct.pack("<i", 1)  # summaryset_id, read once
+    for event_id, summary_id, impacted_exposure, samples in summaries:
+        buf += struct.pack("<i", event_id)
+        buf += struct.pack("<i", summary_id)
+        buf += struct.pack("<f", impacted_exposure)
+        for sidx, loss in samples:
+            buf += struct.pack("<i", sidx)
+            buf += struct.pack("<f", loss)
+        buf += struct.pack("<i", 0)
+        buf += struct.pack("<f", 0.0)
+    return bytes(buf)
+
+
+def _make_occ_csr(event_to_periods):
+    """event_to_periods: dict event_id -> list of period_no (occ_date_id fixed at 1)"""
+    event_ids = sorted(event_to_periods.keys())
+    valtype = np.dtype([("period_no", np.int32), ("occ_date_id", np.int32)])
+    occ_flat = np.empty(sum(len(v) for v in event_to_periods.values()), dtype=valtype)
+    occ_offsets = np.zeros(len(event_ids) + 1, dtype=np.int64)
+    pos = 0
+    for i, eid in enumerate(event_ids):
+        for p in event_to_periods[eid]:
+            occ_flat[pos] = (p, 1)
+            pos += 1
+        occ_offsets[i + 1] = pos
+    return OccurrenceCSR(id_index_build(np.array(event_ids, dtype=np.int64)), occ_offsets, occ_flat)
 
 
 def case_runner(sub_folder, test_name, out_ext="csv"):
@@ -204,3 +244,45 @@ def test_splt_stdin(monkeypatch):
                             Path(error_path, "py_splt.csv"))
             arg_str = ' '.join([f"{k}={v}" for k, v in kwargs.items()])
             raise Exception(f"running 'pltpy {arg_str}' led to diff, see files at {error_path}") from e
+
+
+def test_mplt_qplt_buffer_full_across_summaries():
+    """An MPLT/QPLT output buffer filling up mid-run must not skip, duplicate, or
+    misattribute rows for any summary, including ones that don't trigger the overflow
+    themselves. Uses a tiny DEFAULT_BUFFER_SIZE to force this deterministically.
+    """
+    sample_size = 3
+    occ_csr = _make_occ_csr({999: [1]})
+    period_weights = np.array([(1, 1.0)], dtype=np.dtype([("period_no", np.int32), ("weighting", "f4")]))
+    intervals = np.array([(0.5, 2, 0.0)], dtype=np.dtype(
+        [("quantile", "f4"), ("integer_part", "i4"), ("fractional_part", "f4")]))
+    summaries = [
+        (999, 101, 1000.0, [(1, 10.0), (2, 20.0), (3, 30.0)]),
+        (999, 102, 2000.0, [(1, 40.0), (2, 50.0), (3, 60.0)]),
+        (999, 103, 3000.0, [(1, 70.0), (2, 80.0), (3, 90.0)]),
+    ]
+    stream_bytes = _build_summary_stream(sample_size, summaries)
+
+    with TemporaryDirectory() as tmp_dir_str:
+        tmp_dir = Path(tmp_dir_str)
+        stream_file = tmp_dir / "summary.bin"
+        stream_file.write_bytes(stream_bytes)
+        mplt_out = tmp_dir / "mplt.csv"
+        qplt_out = tmp_dir / "qplt.csv"
+
+        with patch('oasislmf.pytools.plt.manager.DEFAULT_BUFFER_SIZE', 2), \
+             patch('oasislmf.pytools.plt.manager.read_occurrence', return_value=(occ_csr, 1, False, 1)), \
+             patch('oasislmf.pytools.plt.manager.read_periods', return_value=period_weights), \
+             patch('oasislmf.pytools.plt.manager.read_quantile', return_value=intervals):
+            main(run_dir=tmp_dir, files_in=stream_file, mplt=mplt_out, qplt=qplt_out, ext="csv")
+
+        mplt = pd.read_csv(mplt_out)
+        qplt = pd.read_csv(qplt_out)
+
+        assert len(mplt) == 3, f"expected 3 MPLT rows (3 summaries x 1 period sample-mean), got {len(mplt)}"
+        assert list(mplt["SummaryId"]) == [101, 102, 103]
+        assert (mplt["EventId"] == 999).all()
+
+        assert len(qplt) == 3, f"expected 3 QPLT rows (3 summaries x 1 period x 1 interval), got {len(qplt)} - MPLT's overflow must not skip QPLT"
+        assert list(qplt["SummaryId"]) == [101, 102, 103]
+        assert (qplt["EventId"] == 999).all()


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Fix eltpy/pltpy crash on MELT/QELT/MPLT/QPLT output-buffer overflow

`eltpy`/`pltpy` failed to reset `state["reading_losses"]` on the buffer-full early-return taken when the MELT/QELT (or MPLT/QPLT) output buffer fills right at a summary's terminator. This left the reader's state stuck mid-summary, so the next call misread the following summary's header bytes as sample data, crashing with a spurious `IndexError`.

This PR reworks the fix to reserve buffer capacity for a summary's worst-case output *before* reading its header, rather than checking after writing. This removes every capacity check from the terminator write path, so the missing-reset bug can't recur.

It also fixes an independent bug the above depends on: buffer-full and new-event returns now read the persisted `state["current_event_id"]` instead of the `event_id` parameter, since the caller always passes `event_id=0` on a fresh call. Previously this could write `EventId=0` to output after any buffer-full resume.

Adds regression tests covering a buffer overflow spanning multiple summaries, an overflow landing right before a genuine new event, and the SELT reservation margin.

closes https://github.com/OasisLMF/OasisLMF/issues/2147

<!--end_release_notes-->
