### PR TITLE
fix/rerun-stale-fifo-redirect

### DIFF
--- a/oasislmf/execution/runner.py
+++ b/oasislmf/execution/runner.py
@@ -142,9 +142,9 @@ def rerun():
     gul_cmd = [cmd.strip() for cmd in kernel_pipeline if cmd.strip().startswith(('gul'))].pop(0)
     fm_cmds = [cmd.strip() for cmd in kernel_pipeline if cmd.strip().startswith(('fm'))]
 
-    # strip any stale output redirect from the extracted command (e.g. to a fifo whose
+    # strip a trailing output redirect from the extracted command (e.g. to a fifo whose
     # reader has already exited in the main run) before pointing it at our own output file
-    gul_cmd = re.sub(r'>\s*\S+', '', gul_cmd).strip()
+    gul_cmd = re.sub(r'\s*\d*>>?\s*\S+$', '', gul_cmd).strip()
 
     pipe_output = "/tmp/il_P1"
     summary_output = "/tmp/il_S1_summary_P1"
@@ -156,7 +156,7 @@ def rerun():
 
     fm_input = gul_output
     for i in range(len(fm_cmds)):
-        fm_cmd = re.sub(r"-\s*>\s*\S+", f"-o 64_ri{i + 1}.bin", fm_cmds[i])
+        fm_cmd = re.sub(r'\s*\d*>>?\s*\S+$', '', fm_cmds[i]).strip()
         fm_output = f"{event_error}_fm{i + 1}.bin"
         fm_pipe = f"{fm_cmd} -o {fm_output} -i {fm_input}"
         with open("fm_errors.log", "a") as error_log:

--- a/oasislmf/execution/runner.py
+++ b/oasislmf/execution/runner.py
@@ -142,6 +142,10 @@ def rerun():
     gul_cmd = [cmd.strip() for cmd in kernel_pipeline if cmd.strip().startswith(('gul'))].pop(0)
     fm_cmds = [cmd.strip() for cmd in kernel_pipeline if cmd.strip().startswith(('fm'))]
 
+    # strip any stale output redirect from the extracted command (e.g. to a fifo whose
+    # reader has already exited in the main run) before pointing it at our own output file
+    gul_cmd = re.sub(r'>\s*\S+', '', gul_cmd).strip()
+
     pipe_output = "/tmp/il_P1"
     summary_output = "/tmp/il_S1_summary_P1"
     gul_output = f"{event_error}_gul.bin"

--- a/tests/model_execution/test_runner.py
+++ b/tests/model_execution/test_runner.py
@@ -51,3 +51,44 @@ class RerunTestCase(TestCase):
             rerun()
 
         subprocess_run.assert_not_called()
+
+    def test_non_trailing_redirect_is_not_mangled_in_gul_cmd(self):
+        # a non-trailing redirect (e.g. the stderr guard appended around the whole
+        # pipeline) must survive untouched: only the genuinely trailing output
+        # redirect on the gul segment itself should be stripped.
+        with open("run_kernel.sh", "w") as f:
+            f.write(
+                "( ( eve 1 2 | getmodel | gulcalc -S100 -L100 -r -a1 -i - "
+                "2>> log/gul_stderror.err > /tmp/xyz123/fifo/gul_P1 ) | fmcalc -a2 > /tmp/il_P1 ) "
+                "2>> log/stderror.err &\n"
+            )
+
+        with patch("oasislmf.execution.runner.subprocess.run") as subprocess_run:
+            rerun()
+
+        gul_pipe = subprocess_run.call_args_list[0].args[0]
+
+        self.assertNotIn("/tmp/xyz123/fifo/gul_P1", gul_pipe)
+        self.assertIn("2>> log/gul_stderror.err", gul_pipe)
+        self.assertIn("-o 1_gul.bin", gul_pipe)
+
+    def test_stale_redirect_is_stripped_from_fm_cmd(self):
+        # the fm segment carries the same kind of stale output redirect (e.g. to a
+        # fifo consumed by the original run) and must be stripped before rerun()
+        # points it at its own output file, otherwise it hangs the same way the
+        # gul segment used to.
+        with open("run_kernel.sh", "w") as f:
+            f.write(
+                "( ( eve 1 2 | getmodel | gulcalc -S100 -L100 -r -a1 -i - "
+                "> /tmp/xyz123/fifo/gul_P1 ) | fmcalc -a2 > /tmp/il_P1 ) "
+                "2>> log/stderror.err &\n"
+            )
+
+        with patch("oasislmf.execution.runner.subprocess.run") as subprocess_run:
+            rerun()
+
+        fm_pipe = subprocess_run.call_args_list[1].args[0]
+
+        self.assertNotIn("/tmp/il_P1", fm_pipe)
+        self.assertIn("-o 1_fm1.bin", fm_pipe)
+        self.assertTrue(fm_pipe.startswith("fmcalc"))

--- a/tests/model_execution/test_runner.py
+++ b/tests/model_execution/test_runner.py
@@ -1,0 +1,53 @@
+import json
+import os
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from mock import patch
+
+from oasislmf.execution.runner import rerun
+
+
+class RerunTestCase(TestCase):
+    """rerun() replays a single failing event outside numba. It parses the
+    gul command straight out of run_kernel.sh, which still carries that
+    run's own output redirect (e.g. to a fifo whose reader has already
+    exited). That stale redirect must be stripped before rerun() appends
+    its own `-o` output flag, otherwise the replayed command blocks
+    forever trying to write to an orphaned fifo.
+    """
+
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.addCleanup(self.tmp_dir.cleanup)
+        self.cwd = os.getcwd()
+        os.chdir(self.tmp_dir.name)
+        self.addCleanup(os.chdir, self.cwd)
+
+        with open("event_error.json", "w") as f:
+            json.dump({"event_id": "1"}, f)
+
+        with open("run_kernel.sh", "w") as f:
+            f.write(
+                "( ( eve 1 2 | getmodel | gulcalc -S100 -L100 -r -a1 -i - "
+                "> /tmp/xyz123/fifo/gul_P1 ) | fmcalc -a2 -o /tmp/il_P1 ) "
+                "2>> log/stderror.err &\n"
+            )
+
+    def test_stale_fifo_redirect_is_stripped_from_gul_cmd(self):
+        with patch("oasislmf.execution.runner.subprocess.run") as subprocess_run:
+            rerun()
+
+        gul_pipe = subprocess_run.call_args_list[0].args[0]
+
+        self.assertNotIn("/tmp/xyz123/fifo/gul_P1", gul_pipe)
+        self.assertIn("-o 1_gul.bin", gul_pipe)
+        self.assertTrue(gul_pipe.startswith("printf"))
+
+    def test_no_event_error_file_returns_without_running(self):
+        os.remove("event_error.json")
+
+        with patch("oasislmf.execution.runner.subprocess.run") as subprocess_run:
+            rerun()
+
+        subprocess_run.assert_not_called()


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### fix/rerun-stale-fifo-redirect
rerun() reconstructs the gul command from run_kernel.sh to replay a single failing event without numba, but the extracted command still carries the original run's output redirect to a FIFO whose reader has already exited. Writing to that orphaned FIFO blocks forever. Strip any trailing output redirect before pointing the command at rerun()'s own output file instead.

closes https://github.com/OasisLMF/OasisLMF/issues/2146
<!--end_release_notes-->
