### PR TITLE
Make optional arguments not required

### DIFF
--- a/oasislmf/lookup/base.py
+++ b/oasislmf/lookup/base.py
@@ -39,7 +39,7 @@ class AbstractBasicKeyLookup:
         self.output_dir = output_dir
 
         keys_data_path = config.get('keys_data_path')
-        keys_data_path = os.path.join(config_dir, keys_data_path) if keys_data_path else ''
+        keys_data_path = os.path.join(config_dir, keys_data_path) if keys_data_path else self.config_dir
         config['keys_data_path'] = as_path(keys_data_path, 'keys_data_path', preexists=(True if keys_data_path else False))
 
         if config.get("keys_data_storage"):

--- a/oasislmf/lookup/base.py
+++ b/oasislmf/lookup/base.py
@@ -39,8 +39,8 @@ class AbstractBasicKeyLookup:
         self.output_dir = output_dir
 
         keys_data_path = config.get('keys_data_path')
-        keys_data_path = os.path.join(config_dir, keys_data_path) if keys_data_path else self.config_dir
-        config['keys_data_path'] = as_path(keys_data_path, 'keys_data_path', preexists=(True if keys_data_path else False))
+        keys_data_path = os.path.join(self.config_dir, keys_data_path) if keys_data_path else self.config_dir
+        config['keys_data_path'] = as_path(keys_data_path, 'keys_data_path', preexists=True)
 
         if config.get("keys_data_storage"):
             self.storage = get_storage_from_config(config["keys_data_storage"])

--- a/oasislmf/lookup/builtin.py
+++ b/oasislmf/lookup/builtin.py
@@ -378,6 +378,13 @@ class Lookup(AbstractBasicKeyLookup, MultiprocLookupMixin):
         return step_function
 
     def process_locations(self, locations):
+        missing = [key for key in ('step_definition', 'strategy') if key not in self.config]
+        if missing:
+            raise OasisException(
+                f"lookup config is missing the required key(s) {missing}. "
+                "A built-in lookup needs 'step_definition' to define its steps and 'strategy' to order them"
+            )
+
         # drop all unused columns and remove duplicate rows, find and rename useful columns
         lower_case_column_map = {column.lower(): column for column in locations.columns}
         useful_cols = set(['loc_id'] + sum((step_config.get("columns", []) for step_config in self.config['step_definition'].values()), []))

--- a/oasislmf/lookup/factory.py
+++ b/oasislmf/lookup/factory.py
@@ -213,7 +213,7 @@ class KeyServerFactory(object):
         if complex_lookup_config_fp:
             key_server.complex_lookup_config_fp = complex_lookup_config_fp
 
-        return config['model'], key_server
+        return config.get('model'), key_server
 
 
 class BasicKeyServer:
@@ -341,7 +341,7 @@ class BasicKeyServer:
         else:  # built-in lookup
             if self.config.get('builtin_lookup_type') == 'peril_covered_deterministic':
                 lookup_cls = PerilCoveredDeterministicLookup
-            elif self.config.get('builtin_lookup_type') == 'new_lookup':
+            elif self.config.get('builtin_lookup_type', 'new_lookup') == 'new_lookup':
                 lookup_cls = NewLookup
             else:
                 raise OasisException("Unrecognised lookup config file, or config file is from deprecated built in lookup module 'oasislmf<=1.16.0' ")

--- a/oasislmf/lookup/factory.py
+++ b/oasislmf/lookup/factory.py
@@ -339,9 +339,12 @@ class BasicKeyServer:
             lookup_module = get_custom_module(lookup_module_path, 'lookup_module_path')
             lookup_cls = getattr(lookup_module, '{}KeysLookup'.format(self.config['model']['model_id']))
         else:  # built-in lookup
-            if self.config.get('builtin_lookup_type') == 'peril_covered_deterministic':
+            builtin_lookup_type = self.config.get('builtin_lookup_type')
+            if builtin_lookup_type is None and self.config.get('step_definition'):
+                builtin_lookup_type = 'new_lookup'
+            if builtin_lookup_type == 'peril_covered_deterministic':
                 lookup_cls = PerilCoveredDeterministicLookup
-            elif self.config.get('builtin_lookup_type', 'new_lookup') == 'new_lookup':
+            elif builtin_lookup_type == 'new_lookup':
                 lookup_cls = NewLookup
             else:
                 raise OasisException("Unrecognised lookup config file, or config file is from deprecated built in lookup module 'oasislmf<=1.16.0' ")

--- a/tests/model_preparation/test_lookup_optional_config.py
+++ b/tests/model_preparation/test_lookup_optional_config.py
@@ -1,0 +1,232 @@
+"""Tests for the optional keys of the lookup config."""
+
+import filecmp
+import json
+import os
+import pathlib
+import shutil
+from tempfile import TemporaryDirectory
+
+import pandas as pd
+import pytest
+
+from oasislmf.computation.generate.keys import GenerateKeys
+from oasislmf.lookup.builtin import Lookup, PerilCoveredDeterministicLookup
+from oasislmf.lookup.factory import KeyServerFactory
+from oasislmf.utils.exceptions import OasisException
+
+META_DATA_PATH = pathlib.Path(os.path.realpath(__file__)).parent.joinpath('meta_data')
+
+
+def strip_placeholders(obj):
+    if isinstance(obj, dict):
+        return {k: strip_placeholders(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [strip_placeholders(v) for v in obj]
+    if isinstance(obj, str):
+        return obj.replace('%%KEYS_DATA_PATH%%/', '')
+    return obj
+
+
+def without(config, *keys):
+    return {k: v for k, v in config.items() if k not in keys}
+
+
+def shipped_config():
+    with open(META_DATA_PATH.joinpath('lookup_config.json'), encoding='utf-8') as f:
+        return json.load(f)
+
+
+def write_model_dir(target_dir, config, data_subdir=None):
+    data_dir = pathlib.Path(target_dir, data_subdir) if data_subdir else pathlib.Path(target_dir)
+    shutil.copytree(META_DATA_PATH, data_dir, dirs_exist_ok=True)
+    for stale in ('lookup_config.json', 'lookup_config-geo_grid.json'):
+        pathlib.Path(data_dir, stale).unlink(missing_ok=True)
+
+    config_fp = pathlib.Path(target_dir, 'lookup_config.json')
+    with open(config_fp, 'w', encoding='utf-8') as f:
+        json.dump(config, f)
+    return config_fp
+
+
+def run_keys(config, tmp_dir, data_subdir=None):
+    model_dir = pathlib.Path(tmp_dir, 'model')
+    model_dir.mkdir(parents=True, exist_ok=True)
+    config_fp = write_model_dir(model_dir, config, data_subdir=data_subdir)
+
+    out_dir = pathlib.Path(tmp_dir, 'out')
+    out_dir.mkdir(parents=True, exist_ok=True)
+    keys_fp = pathlib.Path(out_dir, 'keys.csv')
+
+    GenerateKeys(
+        oed_location_csv=META_DATA_PATH.joinpath('location.csv'),
+        lookup_config_json=config_fp,
+        keys_data_path=str(keys_fp),
+        keys_format='oasis',
+    ).run()
+    return keys_fp, pathlib.Path(out_dir, 'keys-errors.csv')
+
+
+def assert_matches_golden(keys_fp, keys_errors_fp):
+    assert filecmp.cmp(keys_fp, META_DATA_PATH.joinpath('keys.csv'), shallow=False)
+    assert filecmp.cmp(keys_errors_fp, META_DATA_PATH.joinpath('keys-errors.csv'), shallow=False)
+
+
+CONFIG_VARIANTS = {
+    'as_shipped': lambda c: c,
+    'no_model': lambda c: without(c, 'model'),
+    'no_builtin_lookup_type': lambda c: without(c, 'builtin_lookup_type'),
+    'no_keys_data_path': lambda c: without(c, 'keys_data_path'),
+    'no_placeholders': lambda c: strip_placeholders(c),
+    'no_placeholders_no_keys_data_path': lambda c: without(strip_placeholders(c), 'keys_data_path'),
+    'minimal': lambda c: without(
+        strip_placeholders(c), 'model', 'builtin_lookup_type', 'keys_data_path'),
+}
+
+
+@pytest.mark.parametrize('variant', list(CONFIG_VARIANTS))
+def test_optional_keys_omitted___keys_are_unchanged(variant):
+    config = CONFIG_VARIANTS[variant](shipped_config())
+    with TemporaryDirectory() as d:
+        assert_matches_golden(*run_keys(config, d))
+
+
+def test_keys_data_path_omitted___defaults_to_config_dir_not_cwd():
+    config = without(strip_placeholders(shipped_config()), 'keys_data_path')
+    with TemporaryDirectory() as d:
+        model_dir = pathlib.Path(d, 'model')
+        model_dir.mkdir()
+        config_fp = write_model_dir(model_dir, config)
+
+        _, key_server = KeyServerFactory.create(lookup_config_fp=str(config_fp), output_directory=d)
+        lookup = key_server.lookup_cls(key_server.config, config_dir=key_server.config_dir, output_dir=d)
+
+        assert lookup.config['keys_data_path'] == str(model_dir.resolve())
+        assert lookup.config['keys_data_path'] != os.getcwd()
+
+
+def test_keys_data_path_is_relative___resolved_against_config_dir():
+    config = dict(shipped_config(), keys_data_path='keys_data')
+    with TemporaryDirectory() as d:
+        keys_fp, keys_errors_fp = run_keys(config, d, data_subdir='keys_data')
+        assert_matches_golden(keys_fp, keys_errors_fp)
+
+
+def test_keys_data_path_does_not_exist___error_is_raised():
+    config = dict(shipped_config(), keys_data_path='no_such_dir')
+    with TemporaryDirectory() as d:
+        with pytest.raises(OasisException, match='keys_data_path'):
+            run_keys(config, d)
+
+
+def test_placeholder_with_keys_data_path_omitted___resolves_to_config_dir():
+    config = without(shipped_config(), 'keys_data_path')
+    with TemporaryDirectory() as d:
+        assert_matches_golden(*run_keys(config, d))
+
+
+def test_keys_data_storage___is_used_instead_of_the_default_keys_data_path():
+    config = without(strip_placeholders(shipped_config()), 'keys_data_path')
+    config['keys_data_storage'] = {
+        'storage_class': 'oasis_data_manager.filestore.backends.local.LocalStorage',
+        'options': {'root_dir': str(META_DATA_PATH)},
+    }
+    with TemporaryDirectory() as d:
+        model_dir = pathlib.Path(d, 'empty_model')
+        model_dir.mkdir()
+        config_fp = pathlib.Path(model_dir, 'lookup_config.json')
+        with open(config_fp, 'w', encoding='utf-8') as f:
+            json.dump(config, f)
+
+        _, key_server = KeyServerFactory.create(lookup_config_fp=str(config_fp), output_directory=d)
+        lookup = key_server.lookup_cls(key_server.config, config_dir=key_server.config_dir, output_dir=d)
+
+        assert lookup.storage.root_dir == str(META_DATA_PATH)
+        keys_df = lookup.process_locations(
+            pd.read_csv(META_DATA_PATH.joinpath('location.csv')).assign(loc_id=lambda df: range(1, len(df) + 1)))
+        assert not keys_df.empty
+
+
+def test_model_omitted___create_returns_no_model_info():
+    config = without(shipped_config(), 'model')
+    with TemporaryDirectory() as d:
+        config_fp = write_model_dir(pathlib.Path(d), config)
+        model_info, key_server = KeyServerFactory.create(
+            lookup_config_fp=str(config_fp), output_directory=d)
+
+        assert model_info is None
+        assert key_server.lookup_cls is Lookup
+
+
+def test_model_omitted_with_custom_lookup_module___error_is_raised():
+    with TemporaryDirectory() as d:
+        module_fp = pathlib.Path(d, 'custom_lookup.py')
+        with open(module_fp, 'w', encoding='utf-8') as f:
+            f.write('from oasislmf.lookup.builtin import Lookup\n'
+                    'class MyModelKeysLookup(Lookup):\n'
+                    '    pass\n')
+
+        config = without(shipped_config(), 'model')
+        config['lookup_module_path'] = str(module_fp)
+        config_fp = write_model_dir(pathlib.Path(d), config)
+
+        with pytest.raises(KeyError):
+            KeyServerFactory.create(lookup_config_fp=str(config_fp), output_directory=d)
+
+
+def test_builtin_lookup_type_omitted___step_definition_selects_new_lookup():
+    config = without(shipped_config(), 'builtin_lookup_type')
+    with TemporaryDirectory() as d:
+        config_fp = write_model_dir(pathlib.Path(d), config)
+        _, key_server = KeyServerFactory.create(lookup_config_fp=str(config_fp), output_directory=d)
+        assert key_server.lookup_cls is Lookup
+
+
+def test_deprecated_pre_1_17_config___error_still_names_the_old_module():
+    config = {
+        'model': {'supplier_id': 'OasisLMF', 'model_id': 'PiWind', 'model_version': '1'},
+        'keys_data_path': './',
+        'peril': {'peril_ids': ['WTC']},
+        'coverage': {'coverage_types': [1]},
+        'vulnerability': {},
+    }
+    with TemporaryDirectory() as d:
+        config_fp = write_model_dir(pathlib.Path(d), config)
+        with pytest.raises(OasisException, match='oasislmf<=1.16.0'):
+            KeyServerFactory.create(lookup_config_fp=str(config_fp), output_directory=d)
+
+
+def test_builtin_lookup_type_unrecognised___error_is_raised():
+    config = dict(shipped_config(), builtin_lookup_type='not_a_lookup_type')
+    with TemporaryDirectory() as d:
+        config_fp = write_model_dir(pathlib.Path(d), config)
+        with pytest.raises(OasisException, match='Unrecognised lookup config'):
+            KeyServerFactory.create(lookup_config_fp=str(config_fp), output_directory=d)
+
+
+def test_peril_covered_deterministic___is_still_selected():
+    config = {
+        'builtin_lookup_type': 'peril_covered_deterministic',
+        'supported_oed_coverage_types': [1],
+        'model_perils_covered': ['AA1'],
+    }
+    with TemporaryDirectory() as d:
+        _, key_server = KeyServerFactory.create(lookup_config=config, output_directory=d)
+        assert key_server.lookup_cls is PerilCoveredDeterministicLookup
+
+
+@pytest.mark.parametrize('missing_key', ['step_definition', 'strategy'])
+def test_step_definition_or_strategy_missing___error_names_the_key(missing_key):
+    config = without(shipped_config(), missing_key)
+    locations = pd.DataFrame({'loc_id': [1], 'occupancycode': [1050]})
+    with TemporaryDirectory() as d:
+        config_fp = write_model_dir(pathlib.Path(d), config)
+        _, key_server = KeyServerFactory.create(lookup_config_fp=str(config_fp), output_directory=d)
+        lookup = key_server.lookup_cls(key_server.config, config_dir=key_server.config_dir, output_dir=d)
+
+        with pytest.raises(OasisException, match=missing_key):
+            lookup.process_locations(locations)
+
+
+def test_bare_lookup_is_constructible_for_builders():
+    assert Lookup(config={}).build_split_loc_perils_covered(model_perils_covered=['WTC']) is not None


### PR DESCRIPTION
<!--start_release_notes-->
### Lookup config: `model`, `builtin_lookup_type` and `keys_data_path` are now optional

`lookup_config.json` no longer requires boilerplate that the built-in lookup does not read. `model` and `builtin_lookup_type` may be omitted, and `keys_data_path` now defaults to the directory holding the lookup config rather than the process working directory — so a model's data files can be referenced by plain relative path, with no `%%KEYS_DATA_PATH%%` placeholder.

Configs that set `keys_data_path` are unaffected. A config that *omits* it does change behaviour: relative paths in `step_definition`, and `%%KEYS_DATA_PATH%%` itself, now resolve against the directory holding the lookup config instead of the working directory the run happened to start in.
<!--end_release_notes-->

Fixes #2149.

Prompted by a support thread on what a new model actually has to put in its config. Three keys turned out to be mandatory without being used, and a fourth had a default that could not work.

## What's in

**`model` is optional.** `KeyServerFactory.create` ended with `return config['model'], key_server`, so the section had to exist even when empty. It is now `config.get('model')` and the returned `model_info` is `None` when absent. Nothing on the built-in path reads it.

**`builtin_lookup_type` is optional.** `new_lookup` is the only modern built-in (it is an alias for `Lookup`), and 14 of the 16 in-house configs spell it out identically. It now defaults to `new_lookup` **when the config carries a `step_definition`**. That condition matters: a config with neither key predates oasislmf 1.17, and an unconditional default would silently route it to `Lookup` and fail later with `KeyError: 'step_definition'` instead of the existing error naming the deprecated module. `OasisPiWind/keys_data/PiWind/lookup_config_old.json` is exactly that shape and still gets the good error.

**`keys_data_path` defaults to the config's own directory.** It was already omittable in principle, but `as_path('')` resolves through `os.path.abspath('')`, which is the *working directory* — so omitting it made every relative path in `step_definition` resolve against wherever the process happened to start. It now defaults to `config_dir`, which is what `"keys_data_path": "./"` means in every shipped config anyway.

The knock-on effect is that `%%KEYS_DATA_PATH%%` is no longer needed. Relative paths in `step_definition` already resolve against `keys_data_path` via `LocalStorage(root_dir=...)`; the placeholder only ever short-circuited that. `PiWindS3` and `PiWindAzure` have used the placeholder-free form for a while, since it is the only form that works with a `keys_data_storage` backend.

Two smaller things in `base.py`: `keys_data_path` is now joined against `self.config_dir` rather than the raw `config_dir` argument (so `config_dir=None` with an explicit path no longer raises `TypeError`), and the `preexists=(True if keys_data_path else False)` ternary is simplified to `preexists=True` — once the fallback is `self.config_dir` the local is always truthy, so the ternary was dead.

**Clearer errors for what stays required.** A missing `step_definition` or `strategy` raised a bare `KeyError` from deep inside `process_locations`. Both now raise a named `OasisException`. This matters more now, because the `builtin_lookup_type` default routes more configs into `Lookup`.

The routing default and that guard read the config the same way, on presence rather than truthiness, so an incomplete new-style config gets the error that names the key. `"step_definition": {}` would otherwise have fallen past the default and hit the `oasislmf<=1.16.0` error, which is the wrong diagnosis for a config that is simply unfinished. `process_locations` rejects empty as well as missing, so an empty `strategy` raises instead of running a no-op pipeline that returns every location as a success. `lookup_config_old.json` has no `step_definition` key at all, so the pre-1.17 error is unaffected either way.

## What's not in

**`step_definition` and `strategy` stay required.** Defaulting `strategy` to `step_definition`'s declaration order is the obvious move and it is wrong: PiWind's own config declares `peril, split_loc_perils_covered, create_coverage_type, vulnerability, amplification` but runs `split_loc_perils_covered, peril, create_coverage_type, vulnerability` — different order, and `amplification` is defined but deliberately unused. A positional default would silently run the wrong pipeline. `strategy` carries real information, so it keeps carrying it.

**`model` is still required on the custom paths.** It is optional only for the built-in lookup. Both custom hooks derive a class name from `model_id` — `lookup_module_path` looks up `{model_id}KeysLookup` and `key_server_module_path` looks up `{model_id}KeysServer` — so `model` is load-bearing on either, and the deprecated `interface_version = 0` lookups also need `supplier_id` and `model_version`. Both are plain subscripts and both raise a bare `KeyError` without `model`; that is unchanged here and consistent between them, and there is a test asserting the lookup path still fails. This is by design, not an oversight — `lookup_class` (a full dotted path) is the way to avoid the name coupling.

**No rename of `keys_data_path` to `lookup_data_dir`.** These are the same concept — the 1.4.1 compatibility profile shows oasislmf.json's `keys_data_path` being renamed to `lookup_data_dir` while the lookup config kept the old name — but a rename has no migration path here. `lookup_config.json` has no schema and no compatibility profile, and the `%%KEYS_DATA_PATH%%` placeholder is derived from the key name (`config[placeholder_key.lower()]`), so renaming would break the placeholder in 33 in-house config files plus every customer model. Reviving `lookup_data_dir` — currently the *ignored* key in oasislmf.json — would also make the same name essential in one file and dead in another. Making the key optional gets most of the benefit at none of that cost.

**`lookup_data_dir` in oasislmf.json is untouched.** It does nothing whenever a non-empty lookup config exists (it is only passed as the deprecated `model_keys_data_path`, and `update_deprecated_args` runs only under `if not config:`), and it is still `pre_exist: True`, so a stale value fails a run it never influences. Worth removing, but that is a deprecation with its own blast radius — separate PR.

**`PerilCoveredDeterministicLookup`'s `model_perils_covered` and `supported_oed_coverage_types` are untouched.** Both are bracket-accessed, but `GenerateKeysDeterministic` always supplies them, and the latter is derived from the OED schema — hardcoding a `[1, 2, 3, 4]` fallback in the lookup class would silently diverge from that.

**No schema changes.** `model_supplier_id` / `model_name_id` in analysis_settings and the `model_settings` / `lookup_settings` requirements live in ODS_Tools.

## Testing

New module `tests/model_preparation/test_lookup_optional_config.py`, 24 tests. The core ones reuse the existing `meta_data/lookup_config.json` and its golden `keys.csv` / `keys-errors.csv`, dropping the now-optional keys and asserting byte-identical output — including a `minimal` variant with `model`, `builtin_lookup_type` and `keys_data_path` all removed and every placeholder stripped.

| Code under test | Result |
| --- | --- |
| this branch | 24 passed |
| `factory.py` and `builtin.py` reverted to `main`, `base.py` kept | 11 failed |
| `oasislmf/lookup/` reverted to `main` | 15 failed |

Also covered: `keys_data_path` resolving to the config directory and explicitly not `os.getcwd()`; a relative `keys_data_path` resolved against the config directory; a non-existent one still raising; `%%KEYS_DATA_PATH%%` still working with `keys_data_path` omitted; `keys_data_storage` still taking precedence over the new default (via a `LocalStorage` backend, so no cloud credentials needed); `peril_covered_deterministic` still selected; `step_definition` or `strategy` present but empty raising the error that names the key, and an empty `step_definition` with no `builtin_lookup_type` still routing to `Lookup`; and `Lookup(config={})` still constructible, which is how `tests/lookup/test_builtin.py` reaches the `build_*` factories in 7 places. That last one is why the `step_definition` / `strategy` check sits in `process_locations` rather than `__init__`.

Wider suites: `tests/lookup` + `tests/model_preparation` → 126 passed. `tests/computation` → 230 passed, 2 failed in `test_generate_losses.py` (`test_losses__bash_error__exception_raised__outputs`, `test_losses__chucked_workflow`) — both reproduce on unmodified `main`, so pre-existing and unrelated. `autopep8 --diff --exit-code --max-line-length 150 --ignore E402` and `ruff check` are clean.

No model config needs changing for this PR to land.



