### PR TITLE
fix(cli): print help when oasislmf api get is called without options set

### DIFF
--- a/oasislmf/cli/api.py
+++ b/oasislmf/cli/api.py
@@ -1,5 +1,6 @@
 from argparse import RawDescriptionHelpFormatter
 from .command import OasisBaseCommand, OasisComputationCommand
+from ..utils.exceptions import OasisNoDownloadSelectedException
 
 
 class ServerInfoApiCmd(OasisComputationCommand):
@@ -42,6 +43,13 @@ class GetApiCmd(OasisComputationCommand):
     """Download files from the Oasis Platform API"""
     formatter_class = RawDescriptionHelpFormatter
     computation_name = 'PlatformGet'
+
+    def action(self, args):
+        try:
+            return super().action(args)
+        except OasisNoDownloadSelectedException:
+            self.arg_parser.print_help()
+            return 1
 
 
 class PostApiCmd(OasisComputationCommand):

--- a/oasislmf/computation/run/platform.py
+++ b/oasislmf/computation/run/platform.py
@@ -30,7 +30,7 @@ from mimetypes import guess_extension
 from requests.exceptions import HTTPError
 
 from ...platform_api.client import APIClient
-from ...utils.exceptions import OasisException
+from ...utils.exceptions import OasisException, OasisNoDownloadSelectedException
 from ...utils.defaults import API_EXAMPLE_AUTH
 from ...utils.inputs import str2bool
 
@@ -600,7 +600,8 @@ class PlatformGet(PlatformBase):
 
         # Check that at least one option is given
         if not any([model_files, portfolio_files, analyses_files, subtask_files]):
-            raise OasisException('Select file for download e.g. "--analyses_output <id_1> .. <id_n>"')
+            raise OasisNoDownloadSelectedException(
+                'Select file for download e.g. "--analyses-output-file <id_1> .. <id_n>"')
 
         if model_files:
             self.download('models', model_files)

--- a/oasislmf/execution/bash.py
+++ b/oasislmf/execution/bash.py
@@ -259,7 +259,6 @@ check_complete(){
         elif [ "$started" -gt 0 ]; then
             echo "[OK] $p"
         fi
-        echo "Inject Error" && false
     done
 """
     # Add in check for custom gulcalc if settings are provided

--- a/oasislmf/execution/bash.py
+++ b/oasislmf/execution/bash.py
@@ -259,6 +259,7 @@ check_complete(){
         elif [ "$started" -gt 0 ]; then
             echo "[OK] $p"
         fi
+        echo "Inject Error" && false
     done
 """
     # Add in check for custom gulcalc if settings are provided

--- a/oasislmf/utils/exceptions.py
+++ b/oasislmf/utils/exceptions.py
@@ -3,6 +3,7 @@ from oasis_data_manager.errors import OasisException
 __all__ = [
     'OasisException',
     'OasisExceptionNoKeys',
+    'OasisNoDownloadSelectedException',
 ]
 
 
@@ -12,5 +13,12 @@ class OasisStreamException(OasisException):
 
 
 class OasisExceptionNoKeys(OasisException):
+    def __init__(self, msg, original_exception=None):
+        super().__init__(msg, original_exception)
+
+
+class OasisNoDownloadSelectedException(OasisException):
+    """Raised when 'oasislmf api get' is called without selecting any file to download."""
+
     def __init__(self, msg, original_exception=None):
         super().__init__(msg, original_exception)


### PR DESCRIPTION
<!--start_release_notes-->
### fix(cli): print help when oasislmf api get is called without options set
Minor fix for platform CLI, print help when missing required option. 
<!--end_release_notes-->
